### PR TITLE
Fix warning in the "HtmlEditor > Mentions" demo (T944741)

### DIFF
--- a/JSDemos/Demos/HtmlEditor/Mentions/Angular/app/app.component.html
+++ b/JSDemos/Demos/HtmlEditor/Mentions/Angular/app/app.component.html
@@ -52,6 +52,6 @@
         [dataSource]="employees"
     ></dxi-mention>
     <p>
-        <span class="dx-mention" spellcheck="false" data-marker="@" data-mention-value="Kevin Carter"><span contenteditable="false"><span>@</span>Kevin Carter</span></span> I think John's expertise can be very valuable in our startup.
+        <span class="dx-mention" spellcheck="false" data-marker="@" data-mention-value="Kevin Carter"><span><span>@</span>Kevin Carter</span></span> I think John's expertise can be very valuable in our startup.
     </p>
 </dx-html-editor>

--- a/JSDemos/Demos/HtmlEditor/Mentions/AngularJS/index.html
+++ b/JSDemos/Demos/HtmlEditor/Mentions/AngularJS/index.html
@@ -65,7 +65,7 @@
         </div>
         <div dx-html-editor="htmlEditorOptions">
             <p>
-                <span class="dx-mention" spellcheck="false" data-marker="@" data-mention-value="Kevin Carter"><span contenteditable="false"><span>@</span>Kevin Carter</span></span> I think John's expertise can be very valuable in our startup.
+                <span class="dx-mention" spellcheck="false" data-marker="@" data-mention-value="Kevin Carter"><span><span>@</span>Kevin Carter</span></span> I think John's expertise can be very valuable in our startup.
             </p>
         </div>
     </div>

--- a/JSDemos/Demos/HtmlEditor/Mentions/React/App.js
+++ b/JSDemos/Demos/HtmlEditor/Mentions/React/App.js
@@ -62,7 +62,7 @@ class App extends React.Component {
         <HtmlEditor
           mentions={mentionsConfig}>
           <p>
-            <span className="dx-mention" spellCheck="false" data-marker="@" data-mention-value="Kevin Carter"><span contentEditable="false"><span>@</span>Kevin Carter</span></span>
+            <span className="dx-mention" spellCheck="false" data-marker="@" data-mention-value="Kevin Carter"><span><span>@</span>Kevin Carter</span></span>
             {" I think John's expertise can be very valuable in our startup."}
           </p>
         </HtmlEditor>

--- a/JSDemos/Demos/HtmlEditor/Mentions/Vue/App.vue
+++ b/JSDemos/Demos/HtmlEditor/Mentions/Vue/App.vue
@@ -61,7 +61,7 @@
           spellcheck="false"
           data-marker="@"
           data-mention-value="Kevin Carter"
-        ><span contenteditable="false"><span>@</span>Kevin Carter</span></span> I think John's expertise can be very valuable in our startup.
+        ><span><span>@</span>Kevin Carter</span></span> I think John's expertise can be very valuable in our startup.
       </p>
     </DxHtmlEditor>
   </div>

--- a/JSDemos/Demos/HtmlEditor/Mentions/jQuery/index.html
+++ b/JSDemos/Demos/HtmlEditor/Mentions/jQuery/index.html
@@ -64,7 +64,7 @@
         </div>
         <div id="html-editor">
             <p>
-                <span class="dx-mention" spellcheck="false" data-marker="@" data-mention-value="Kevin Carter"><span contenteditable="false"><span>@</span>Kevin Carter</span></span> I think John's expertise can be very valuable in our startup.
+                <span class="dx-mention" spellcheck="false" data-marker="@" data-mention-value="Kevin Carter"><span><span>@</span>Kevin Carter</span></span> I think John's expertise can be very valuable in our startup.
             </p>
         </div>
     </div>

--- a/MVCDemos/Views/HtmlEditor/Mentions.cshtml
+++ b/MVCDemos/Views/HtmlEditor/Mentions.cshtml
@@ -57,7 +57,7 @@
     })
     .Content(@<text>
         <p>
-            <span class="dx-mention" spellcheck="false" data-marker="@@" data-mention-value="Kevin Carter"><span contenteditable = "false"><span>@@</span>Kevin Carter</span></span> I think John's expertise can be very valuable in our startup.
+            <span class="dx-mention" spellcheck="false" data-marker="@@" data-mention-value="Kevin Carter"><span><span>@@</span>Kevin Carter</span></span> I think John's expertise can be very valuable in our startup.
         </p>
     </text>)
 )

--- a/NetCoreDemos/Views/HtmlEditor/Mentions.cshtml
+++ b/NetCoreDemos/Views/HtmlEditor/Mentions.cshtml
@@ -57,7 +57,7 @@
     })
     .Content(@<text>
         <p>
-            <span class="dx-mention" spellcheck="false" data-marker="@@" data-mention-value="Kevin Carter"><span contenteditable = "false"><span>@@</span>Kevin Carter</span></span> I think John's expertise can be very valuable in our startup.
+            <span class="dx-mention" spellcheck="false" data-marker="@@" data-mention-value="Kevin Carter"><span><span>@@</span>Kevin Carter</span></span> I think John's expertise can be very valuable in our startup.
         </p>
     </text>)
 )


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1420883/97782506-e70d6a00-1ba2-11eb-88de-d3cc66d46563.png)

The `contenteditable` attribute is not necessary here.