### PR TITLE
ExcelJS demos - remove obsolete(redundant) comments

### DIFF
--- a/JSDemos/Demos/DataGrid/ExcelJS/Angular/app/app.component.ts
+++ b/JSDemos/Demos/DataGrid/ExcelJS/Angular/app/app.component.ts
@@ -118,8 +118,8 @@ export class AppComponent {
             }
         }).then(function(cellRange) {
             // header
-            worksheet.getRow(2).height = 20; // https://github.com/exceljs/exceljs#rows
-            worksheet.mergeCells(2, 1, 2, 4); // https://github.com/exceljs/exceljs#merged-cells
+            worksheet.getRow(2).height = 20;
+            worksheet.mergeCells(2, 1, 2, 4);
             Object.assign(worksheet.getRow(2).getCell(1), {
                 value: "Sales amounts report",
                 font: { bold: true, size: 16 },
@@ -134,7 +134,7 @@ export class AppComponent {
                 alignment: { horizontal: 'right' }
             });
         }).then(function() {
-            workbook.xlsx.writeBuffer().then(function(buffer) { // https://github.com/exceljs/exceljs#writing-xlsx
+            workbook.xlsx.writeBuffer().then(function(buffer) {
                 saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'DataGrid.xlsx');
             });
         });

--- a/JSDemos/Demos/DataGrid/ExcelJS/AngularJS/index.js
+++ b/JSDemos/Demos/DataGrid/ExcelJS/AngularJS/index.js
@@ -144,8 +144,8 @@ DemoApp.controller('DemoController', function DemoController($scope) {
         }
       }).then(function(cellRange) {
         // header
-        worksheet.getRow(2).height = 20; // https://github.com/exceljs/exceljs#rows
-        worksheet.mergeCells(2, 1, 2, 4); // https://github.com/exceljs/exceljs#merged-cells
+        worksheet.getRow(2).height = 20;
+        worksheet.mergeCells(2, 1, 2, 4);
         Object.assign(worksheet.getRow(2).getCell(1), {
           value: "Sales amounts report",
           font: { bold: true, size: 16 },
@@ -160,7 +160,7 @@ DemoApp.controller('DemoController', function DemoController($scope) {
           alignment: { horizontal: 'right' }
         });
       }).then(function() {
-        workbook.xlsx.writeBuffer().then(function(buffer) { // https://github.com/exceljs/exceljs#writing-xlsx
+        workbook.xlsx.writeBuffer().then(function(buffer) {
           saveAs(new Blob([buffer], { type: "application/octet-stream" }), "DataGrid.xlsx");
         });
       });

--- a/JSDemos/Demos/DataGrid/ExcelJS/Knockout/index.js
+++ b/JSDemos/Demos/DataGrid/ExcelJS/Knockout/index.js
@@ -141,8 +141,8 @@ window.onload = function() {
               }
             }).then(function(cellRange) {  
               // header
-              worksheet.getRow(2).height = 20; // https://github.com/exceljs/exceljs#rows
-              worksheet.mergeCells(2, 1, 2, 4); // https://github.com/exceljs/exceljs#merged-cells
+              worksheet.getRow(2).height = 20;
+              worksheet.mergeCells(2, 1, 2, 4);
               Object.assign(worksheet.getRow(2).getCell(1), {
                 value: "Sales amounts report",
                 font: { bold: true, size: 16 },
@@ -157,7 +157,7 @@ window.onload = function() {
                 alignment: { horizontal: 'right' }
               });
             }).then(function() {
-              workbook.xlsx.writeBuffer().then(function(buffer) { // https://github.com/exceljs/exceljs#writing-xlsx
+              workbook.xlsx.writeBuffer().then(function(buffer) {
                 saveAs(new Blob([buffer], { type: "application/octet-stream" }), "DataGrid.xlsx");
               });
             });

--- a/JSDemos/Demos/DataGrid/ExcelJS/React/App.js
+++ b/JSDemos/Demos/DataGrid/ExcelJS/React/App.js
@@ -138,8 +138,8 @@ class App extends React.Component {
       }
     }).then(function(cellRange) {
       // header
-      worksheet.getRow(2).height = 20; // https://github.com/exceljs/exceljs#rows
-      worksheet.mergeCells(2, 1, 2, 4); // https://github.com/exceljs/exceljs#merged-cells
+      worksheet.getRow(2).height = 20;
+      worksheet.mergeCells(2, 1, 2, 4);
       Object.assign(worksheet.getRow(2).getCell(1), {
         value: 'Sales amounts report',
         font: { bold: true, size: 16 },
@@ -154,7 +154,7 @@ class App extends React.Component {
         alignment: { horizontal: 'right' }
       });
     }).then(function() {
-      workbook.xlsx.writeBuffer().then(function(buffer) { // https://github.com/exceljs/exceljs#writing-xlsx
+      workbook.xlsx.writeBuffer().then(function(buffer) {
         saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'DataGrid.xlsx');
       });
     });

--- a/JSDemos/Demos/DataGrid/ExcelJS/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/ExcelJS/Vue/App.vue
@@ -172,8 +172,8 @@ export default {
         }
       }).then(function(cellRange) {
         // header
-        worksheet.getRow(2).height = 20; // https://github.com/exceljs/exceljs#rows
-        worksheet.mergeCells(2, 1, 2, 4); // https://github.com/exceljs/exceljs#merged-cells
+        worksheet.getRow(2).height = 20;
+        worksheet.mergeCells(2, 1, 2, 4);
         Object.assign(worksheet.getRow(2).getCell(1), {
           value: 'Sales amounts report',
           font: { bold: true, size: 16 },
@@ -188,7 +188,7 @@ export default {
           alignment: { horizontal: 'right' }
         });
       }).then(function() {
-        workbook.xlsx.writeBuffer().then(function(buffer) { // https://github.com/exceljs/exceljs#writing-xlsx
+        workbook.xlsx.writeBuffer().then(function(buffer) {
           saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'DataGrid.xlsx');
         });
       });

--- a/JSDemos/Demos/DataGrid/ExcelJS/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/ExcelJS/jQuery/index.js
@@ -141,8 +141,8 @@ $(function(){
         }
       }).then(function(cellRange) {
         // header
-        worksheet.getRow(2).height = 20; // https://github.com/exceljs/exceljs#rows
-        worksheet.mergeCells(2, 1, 2, 4); // https://github.com/exceljs/exceljs#merged-cells
+        worksheet.getRow(2).height = 20;
+        worksheet.mergeCells(2, 1, 2, 4);
         Object.assign(worksheet.getRow(2).getCell(1), { 
           value: 'Sales amounts report',
           font: { bold: true, size: 16 },
@@ -157,7 +157,7 @@ $(function(){
           alignment: { horizontal: 'right' }
         });
       }).then(function() {
-        workbook.xlsx.writeBuffer().then(function(buffer) { // https://github.com/exceljs/exceljs#writing-xlsx
+        workbook.xlsx.writeBuffer().then(function(buffer) {
           saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'SaleAmounts.xlsx');
         });
       });

--- a/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/Angular/app/app.component.ts
+++ b/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/Angular/app/app.component.ts
@@ -34,7 +34,6 @@ export class AppComponent {
     const workbook = new ExcelJS.Workbook();
     const worksheet = workbook.addWorksheet('Companies');
 
-    // https://github.com/exceljs/exceljs#columns
     worksheet.columns = [
       { width: 5 }, { width: 30 }, { width: 25 }, { width: 15 }, { width: 25 }, { width: 40 }
     ];
@@ -48,20 +47,15 @@ export class AppComponent {
         if(gridCell.rowType === "data") {
           if(gridCell.column.dataField === 'Phone') {
             excelCell.value = parseInt(gridCell.value);
-            // https://github.com/exceljs/exceljs#number-formats
             excelCell.numFmt = '[<=9999999]###-####;(###) ###-####';
           }
           if(gridCell.column.dataField === 'Website') {
-            // https://github.com/exceljs/exceljs#hyperlink-value
             excelCell.value = { text: gridCell.value, hyperlink: gridCell.value };
-            // https://github.com/exceljs/exceljs#fonts
             excelCell.font = { color: { argb: 'FF0000FF' }, underline: true };
-            // https://github.com/exceljs/exceljs#alignment
             excelCell.alignment = { horizontal: 'left' };
           }
         }
         if(gridCell.rowType === "group") {
-          // https://github.com/exceljs/exceljs#fills
           excelCell.fill = { type: 'pattern', pattern:'solid', fgColor: { argb: "BEDFE6" } };
         }
         if(gridCell.rowType === "totalFooter" && excelCell.value) {

--- a/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/AngularJS/index.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/AngularJS/index.js
@@ -52,12 +52,11 @@ DemoApp.controller('DemoController', function DemoController($scope) {
     onExporting: function(e) {
       var workbook = new ExcelJS.Workbook();
       var worksheet = workbook.addWorksheet('Companies');
-      
-      // https://github.com/exceljs/exceljs#columns
+
       worksheet.columns = [
         { width: 5 }, { width: 30 }, { width: 25 }, { width: 15 }, { width: 25 }, { width: 40 }
       ];
-      
+
       DevExpress.excelExporter.exportDataGrid({
         component: e.component,
         worksheet: worksheet,
@@ -66,24 +65,19 @@ DemoApp.controller('DemoController', function DemoController($scope) {
         customizeCell: function(options) {
           var gridCell = options.gridCell;
           var excelCell = options.excelCell;
-          
+
           if(gridCell.rowType === "data") {
             if(gridCell.column.dataField === 'Phone') {
               excelCell.value = parseInt(gridCell.value);
-              // https://github.com/exceljs/exceljs#number-formats
               excelCell.numFmt = '[<=9999999]###-####;(###) ###-####';
             }
             if(gridCell.column.dataField === 'Website') {
-              // https://github.com/exceljs/exceljs#hyperlink-value
               excelCell.value = { text: gridCell.value, hyperlink: gridCell.value };
-              // https://github.com/exceljs/exceljs#fonts
               excelCell.font = { color: { argb: 'FF0000FF' }, underline: true };
-              // https://github.com/exceljs/exceljs#alignment
               excelCell.alignment = { horizontal: 'left' };
             }
           }
           if(gridCell.rowType === "group") {
-            // https://github.com/exceljs/exceljs#fills
             excelCell.fill = { type: 'pattern', pattern:'solid', fgColor: { argb: "BEDFE6" } };
           }
           if(gridCell.rowType === "totalFooter" && excelCell.value) {

--- a/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/Knockout/index.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/Knockout/index.js
@@ -51,12 +51,11 @@ window.onload = function() {
       onExporting: function(e) {
         var workbook = new ExcelJS.Workbook();
         var worksheet = workbook.addWorksheet('Companies');
-        
-        // https://github.com/exceljs/exceljs#columns
+
         worksheet.columns = [
           { width: 5 }, { width: 30 }, { width: 25 }, { width: 15 }, { width: 25 }, { width: 40 }
         ];
-        
+
         DevExpress.excelExporter.exportDataGrid({
           component: e.component,
           worksheet: worksheet,
@@ -69,20 +68,15 @@ window.onload = function() {
             if(gridCell.rowType === "data") {
               if(gridCell.column.dataField === 'Phone') {
                 excelCell.value = parseInt(gridCell.value);
-                // https://github.com/exceljs/exceljs#number-formats
                 excelCell.numFmt = '[<=9999999]###-####;(###) ###-####';
               }
               if(gridCell.column.dataField === 'Website') {
-                // https://github.com/exceljs/exceljs#hyperlink-value
                 excelCell.value = { text: gridCell.value, hyperlink: gridCell.value };
-                // https://github.com/exceljs/exceljs#fonts
                 excelCell.font = { color: { argb: 'FF0000FF' }, underline: true };
-                // https://github.com/exceljs/exceljs#alignment
                 excelCell.alignment = { horizontal: 'left' };
               }
             }
             if(gridCell.rowType === "group") {
-              // https://github.com/exceljs/exceljs#fills
               excelCell.fill = { type: 'pattern', pattern:'solid', fgColor: { argb: "BEDFE6" } };
             }
             if(gridCell.rowType === "totalFooter" && excelCell.value) {

--- a/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/React/App.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/React/App.js
@@ -65,7 +65,6 @@ class App extends React.Component {
     const workbook = new ExcelJS.Workbook();
     const worksheet = workbook.addWorksheet('Companies');
 
-    // https://github.com/exceljs/exceljs#columns
     worksheet.columns = [
       { width: 5 }, { width: 30 }, { width: 25 }, { width: 15 }, { width: 25 }, { width: 40 }
     ];
@@ -79,20 +78,15 @@ class App extends React.Component {
         if(gridCell.rowType === 'data') {
           if(gridCell.column.dataField === 'Phone') {
             excelCell.value = parseInt(gridCell.value);
-            // https://github.com/exceljs/exceljs#number-formats
             excelCell.numFmt = '[<=9999999]###-####;(###) ###-####';
           }
           if(gridCell.column.dataField === 'Website') {
-            // https://github.com/exceljs/exceljs#hyperlink-value
             excelCell.value = { text: gridCell.value, hyperlink: gridCell.value };
-            // https://github.com/exceljs/exceljs#fonts
             excelCell.font = { color: { argb: 'FF0000FF' }, underline: true };
-            // https://github.com/exceljs/exceljs#alignment
             excelCell.alignment = { horizontal: 'left' };
           }
         }
         if(gridCell.rowType === 'group') {
-          // https://github.com/exceljs/exceljs#fills
           excelCell.fill = { type: 'pattern', pattern:'solid', fgColor: { argb: 'BEDFE6' } };
         }
         if(gridCell.rowType === 'totalFooter' && excelCell.value) {

--- a/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/Vue/App.vue
@@ -82,7 +82,6 @@ export default {
       const workbook = new ExcelJS.Workbook();
       const worksheet = workbook.addWorksheet('Companies');
 
-      // https://github.com/exceljs/exceljs#columns
       worksheet.columns = [
         { width: 5 }, { width: 30 }, { width: 25 }, { width: 15 }, { width: 25 }, { width: 40 }
       ];
@@ -96,20 +95,15 @@ export default {
           if(gridCell.rowType === 'data') {
             if(gridCell.column.dataField === 'Phone') {
               excelCell.value = parseInt(gridCell.value);
-              // https://github.com/exceljs/exceljs#number-formats
               excelCell.numFmt = '[<=9999999]###-####;(###) ###-####';
             }
             if(gridCell.column.dataField === 'Website') {
-              // https://github.com/exceljs/exceljs#hyperlink-value
               excelCell.value = { text: gridCell.value, hyperlink: gridCell.value };
-              // https://github.com/exceljs/exceljs#fonts
               excelCell.font = { color: { argb: 'FF0000FF' }, underline: true };
-              // https://github.com/exceljs/exceljs#alignment
               excelCell.alignment = { horizontal: 'left' };
             }
           }
           if(gridCell.rowType === 'group') {
-            // https://github.com/exceljs/exceljs#fills
             excelCell.fill = { type: 'pattern', pattern:'solid', fgColor: { argb: 'BEDFE6' } };
           }
           if(gridCell.rowType === 'totalFooter' && excelCell.value) {

--- a/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/jQuery/index.js
@@ -50,12 +50,11 @@ $(function(){
     onExporting: function(e) {
       var workbook = new ExcelJS.Workbook();
       var worksheet = workbook.addWorksheet('Companies');
-      
-      // https://github.com/exceljs/exceljs#columns
+
       worksheet.columns = [
         { width: 5 }, { width: 30 }, { width: 25 }, { width: 15 }, { width: 25 }, { width: 40 }
       ];
-      
+
       DevExpress.excelExporter.exportDataGrid({
         component: e.component,
         worksheet: worksheet,
@@ -68,20 +67,15 @@ $(function(){
           if(gridCell.rowType === "data") {
             if(gridCell.column.dataField === 'Phone') {
               excelCell.value = parseInt(gridCell.value);
-              // https://github.com/exceljs/exceljs#number-formats
               excelCell.numFmt = '[<=9999999]###-####;(###) ###-####';
             }
             if(gridCell.column.dataField === 'Website') {
-              // https://github.com/exceljs/exceljs#hyperlink-value
               excelCell.value = { text: gridCell.value, hyperlink: gridCell.value };
-              // https://github.com/exceljs/exceljs#fonts
               excelCell.font = { color: { argb: 'FF0000FF' }, underline: true };
-              // https://github.com/exceljs/exceljs#alignment
               excelCell.alignment = { horizontal: 'left' };
             }
           }
           if(gridCell.rowType === "group") {
-            // https://github.com/exceljs/exceljs#fills
             excelCell.fill = { type: 'pattern', pattern:'solid', fgColor: { argb: "BEDFE6" } };
           }
           if(gridCell.rowType === "totalFooter" && excelCell.value) {

--- a/JSDemos/Demos/DataGrid/ExcelJSExportImages/Angular/app/app.component.ts
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportImages/Angular/app/app.component.ts
@@ -44,7 +44,7 @@ export class AppComponent {
           if(gridCell.column.dataField === "Picture") {
             excelCell.value = undefined;
             
-            const image = workbook.addImage({ // https://github.com/exceljs/exceljs#images
+            const image = workbook.addImage({
               base64: gridCell.value,
               extension: 'png',
             });

--- a/JSDemos/Demos/DataGrid/ExcelJSExportImages/AngularJS/index.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportImages/AngularJS/index.js
@@ -47,7 +47,7 @@ DemoApp.controller('DemoController', function DemoController($scope) {
             if(gridCell.column.dataField === "Picture") {
               excelCell.value = undefined;
 
-              const image = workbook.addImage({ // https://github.com/exceljs/exceljs#images
+              const image = workbook.addImage({
                 base64: gridCell.value,
                 extension: 'png',
               });

--- a/JSDemos/Demos/DataGrid/ExcelJSExportImages/Knockout/index.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportImages/Knockout/index.js
@@ -46,7 +46,7 @@ window.onload = function() {
               if(gridCell.column.dataField === "Picture") {
                 excelCell.value = undefined;
 
-                const image = workbook.addImage({ // https://github.com/exceljs/exceljs#images
+                const image = workbook.addImage({
                   base64: gridCell.value,
                   extension: 'png',
                 });

--- a/JSDemos/Demos/DataGrid/ExcelJSExportImages/React/App.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportImages/React/App.js
@@ -55,7 +55,7 @@ class App extends React.Component {
           if(gridCell.column.dataField === 'Picture') {
             excelCell.value = undefined;
 
-            const image = workbook.addImage({ // https://github.com/exceljs/exceljs#images
+            const image = workbook.addImage({
               base64: gridCell.value,
               extension: 'png',
             });

--- a/JSDemos/Demos/DataGrid/ExcelJSExportImages/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportImages/Vue/App.vue
@@ -72,7 +72,7 @@ export default {
             if(gridCell.column.dataField === 'Picture') {
               excelCell.value = undefined;
 
-              const image = workbook.addImage({ // https://github.com/exceljs/exceljs#images
+              const image = workbook.addImage({
                 base64: gridCell.value,
                 extension: 'png',
               });

--- a/JSDemos/Demos/DataGrid/ExcelJSExportImages/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportImages/jQuery/index.js
@@ -45,7 +45,7 @@ $(function(){
             if(gridCell.column.dataField === "Picture") {
               excelCell.value = undefined;
 
-              const image = workbook.addImage({ // https://github.com/exceljs/exceljs#images
+              const image = workbook.addImage({
                 base64: gridCell.value,
                 extension: 'png',
               });

--- a/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/Angular/app/app.component.ts
+++ b/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/Angular/app/app.component.ts
@@ -41,17 +41,12 @@ export class AppComponent {
       topLeftCell: { row: 4, column: 1 }
     }).then((cellRange) => {
       // header
-      // https://github.com/exceljs/exceljs#rows
       const headerRow = worksheet.getRow(2);
-      headerRow.height = 30; 
-      // https://github.com/exceljs/exceljs#merged-cells
+      headerRow.height = 30;
       worksheet.mergeCells(2, 1, 2, 8);
       
-      // https://github.com/exceljs/exceljs#value-types
       headerRow.getCell(1).value = 'Country Area, Population, and GDP Structure';
-      // https://github.com/exceljs/exceljs#fonts
       headerRow.getCell(1).font = { name: 'Segoe UI Light', size: 22 };
-      // https://github.com/exceljs/exceljs#alignment
       headerRow.getCell(1).alignment = { horizontal: 'center' };
       
       // footer
@@ -63,7 +58,6 @@ export class AppComponent {
       footerRow.getCell(1).font = { color: { argb: 'BFBFBF' }, italic: true };
       footerRow.getCell(1).alignment = { horizontal: 'right' };
     }).then(() => {
-      // https://github.com/exceljs/exceljs#writing-xlsx
       workbook.xlsx.writeBuffer().then((buffer) => {
         saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'CountriesPopulation.xlsx');
       });

--- a/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/AngularJS/index.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/AngularJS/index.js
@@ -17,17 +17,12 @@ DemoApp.controller('DemoController', function DemoController($scope) {
         topLeftCell: { row: 4, column: 1 }
       }).then(function(cellRange) {
         // header
-        // https://github.com/exceljs/exceljs#rows
         var headerRow = worksheet.getRow(2);
-        headerRow.height = 30; 
-        // https://github.com/exceljs/exceljs#merged-cells
+        headerRow.height = 30;
         worksheet.mergeCells(2, 1, 2, 8);
-        
-        // https://github.com/exceljs/exceljs#value-types
+
         headerRow.getCell(1).value = 'Country Area, Population, and GDP Structure';
-        // https://github.com/exceljs/exceljs#fonts
         headerRow.getCell(1).font = { name: 'Segoe UI Light', size: 22 };
-        // https://github.com/exceljs/exceljs#alignment
         headerRow.getCell(1).alignment = { horizontal: 'center' };
         
         // footer
@@ -39,7 +34,6 @@ DemoApp.controller('DemoController', function DemoController($scope) {
         footerRow.getCell(1).font = { color: { argb: 'BFBFBF' }, italic: true };
         footerRow.getCell(1).alignment = { horizontal: 'right' };
       }).then(function() {
-        // https://github.com/exceljs/exceljs#writing-xlsx
         workbook.xlsx.writeBuffer().then(function(buffer) {
           saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'CountriesPopulation.xlsx');
         });

--- a/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/Knockout/index.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/Knockout/index.js
@@ -16,17 +16,12 @@ window.onload = function() {
           topLeftCell: { row: 4, column: 1 }
         }).then(function(cellRange) {
           // header
-          // https://github.com/exceljs/exceljs#rows
           var headerRow = worksheet.getRow(2);
           headerRow.height = 30; 
-          // https://github.com/exceljs/exceljs#merged-cells
           worksheet.mergeCells(2, 1, 2, 8);
-          
-          // https://github.com/exceljs/exceljs#value-types
+
           headerRow.getCell(1).value = 'Country Area, Population, and GDP Structure';
-          // https://github.com/exceljs/exceljs#fonts
           headerRow.getCell(1).font = { name: 'Segoe UI Light', size: 22 };
-          // https://github.com/exceljs/exceljs#alignment
           headerRow.getCell(1).alignment = { horizontal: 'center' };
           
           // footer
@@ -38,7 +33,6 @@ window.onload = function() {
           footerRow.getCell(1).font = { color: { argb: 'BFBFBF' }, italic: true };
           footerRow.getCell(1).alignment = { horizontal: 'right' };
         }).then(function() {
-          // https://github.com/exceljs/exceljs#writing-xlsx
           workbook.xlsx.writeBuffer().then(function(buffer) {
             saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'CountriesPopulation.xlsx');
           });

--- a/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/React/App.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/React/App.js
@@ -87,17 +87,12 @@ class App extends React.Component {
       topLeftCell: { row: 4, column: 1 }
     }).then((cellRange) => {
       // header
-      // https://github.com/exceljs/exceljs#rows
       const headerRow = worksheet.getRow(2);
       headerRow.height = 30;
-      // https://github.com/exceljs/exceljs#merged-cells
       worksheet.mergeCells(2, 1, 2, 8);
 
-      // https://github.com/exceljs/exceljs#value-types
       headerRow.getCell(1).value = 'Country Area, Population, and GDP Structure';
-      // https://github.com/exceljs/exceljs#fonts
       headerRow.getCell(1).font = { name: 'Segoe UI Light', size: 22 };
-      // https://github.com/exceljs/exceljs#alignment
       headerRow.getCell(1).alignment = { horizontal: 'center' };
 
       // footer
@@ -109,7 +104,6 @@ class App extends React.Component {
       footerRow.getCell(1).font = { color: { argb: 'BFBFBF' }, italic: true };
       footerRow.getCell(1).alignment = { horizontal: 'right' };
     }).then(() => {
-      // https://github.com/exceljs/exceljs#writing-xlsx
       workbook.xlsx.writeBuffer().then((buffer) => {
         saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'CountriesPopulation.xlsx');
       });

--- a/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/Vue/App.vue
@@ -89,17 +89,12 @@ export default {
         topLeftCell: { row: 4, column: 1 }
       }).then((cellRange) => {
         // header
-        // https://github.com/exceljs/exceljs#rows
         const headerRow = worksheet.getRow(2);
         headerRow.height = 30;
-        // https://github.com/exceljs/exceljs#merged-cells
         worksheet.mergeCells(2, 1, 2, 8);
 
-        // https://github.com/exceljs/exceljs#value-types
         headerRow.getCell(1).value = 'Country Area, Population, and GDP Structure';
-        // https://github.com/exceljs/exceljs#fonts
         headerRow.getCell(1).font = { name: 'Segoe UI Light', size: 22 };
-        // https://github.com/exceljs/exceljs#alignment
         headerRow.getCell(1).alignment = { horizontal: 'center' };
 
         // footer
@@ -111,7 +106,6 @@ export default {
         footerRow.getCell(1).font = { color: { argb: 'BFBFBF' }, italic: true };
         footerRow.getCell(1).alignment = { horizontal: 'right' };
       }).then(() => {
-        // https://github.com/exceljs/exceljs#writing-xlsx
         workbook.xlsx.writeBuffer().then((buffer) => {
           saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'CountriesPopulation.xlsx');
         });

--- a/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/jQuery/index.js
@@ -15,17 +15,12 @@ $(function(){
         topLeftCell: { row: 4, column: 1 }
       }).then(function(cellRange) {
         // header
-        // https://github.com/exceljs/exceljs#rows
         var headerRow = worksheet.getRow(2);
-        headerRow.height = 30; 
-        // https://github.com/exceljs/exceljs#merged-cells
+        headerRow.height = 30;
         worksheet.mergeCells(2, 1, 2, 8);
-        
-        // https://github.com/exceljs/exceljs#value-types
+
         headerRow.getCell(1).value = 'Country Area, Population, and GDP Structure';
-        // https://github.com/exceljs/exceljs#fonts
         headerRow.getCell(1).font = { name: 'Segoe UI Light', size: 22 };
-        // https://github.com/exceljs/exceljs#alignment
         headerRow.getCell(1).alignment = { horizontal: 'center' };
         
         // footer
@@ -37,7 +32,6 @@ $(function(){
         footerRow.getCell(1).font = { color: { argb: 'BFBFBF' }, italic: true };
         footerRow.getCell(1).alignment = { horizontal: 'right' };
       }).then(function() {
-        // https://github.com/exceljs/exceljs#writing-xlsx
         workbook.xlsx.writeBuffer().then(function(buffer) {
           saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'CountriesPopulation.xlsx');
         });

--- a/JSDemos/Demos/DataGrid/ExcelJSOverview/Angular/app/app.component.ts
+++ b/JSDemos/Demos/DataGrid/ExcelJSOverview/Angular/app/app.component.ts
@@ -39,7 +39,6 @@ export class AppComponent {
       worksheet: worksheet,
       autoFilterEnabled: true
     }).then(() => {
-      // https://github.com/exceljs/exceljs#writing-xlsx
       workbook.xlsx.writeBuffer().then((buffer) => {
         saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'DataGrid.xlsx');
       });

--- a/JSDemos/Demos/DataGrid/ExcelJSOverview/AngularJS/index.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSOverview/AngularJS/index.js
@@ -23,7 +23,6 @@ DemoApp.controller('DemoController', function DemoController($scope) {
           worksheet: worksheet,
           autoFilterEnabled: true
         }).then(function() {
-          // https://github.com/exceljs/exceljs#writing-xlsx
           workbook.xlsx.writeBuffer().then(function(buffer) {
             saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'Employees.xlsx');
           });

--- a/JSDemos/Demos/DataGrid/ExcelJSOverview/Knockout/index.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSOverview/Knockout/index.js
@@ -22,7 +22,6 @@ window.onload = function() {
           worksheet: worksheet,
           autoFilterEnabled: true
         }).then(function() {
-          // https://github.com/exceljs/exceljs#writing-xlsx
           workbook.xlsx.writeBuffer().then(function(buffer) {
             saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'Employees.xlsx');
           });

--- a/JSDemos/Demos/DataGrid/ExcelJSOverview/React/App.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSOverview/React/App.js
@@ -51,7 +51,6 @@ class App extends React.Component {
       worksheet: worksheet,
       autoFilterEnabled: true
     }).then(() => {
-      // https://github.com/exceljs/exceljs#writing-xlsx
       workbook.xlsx.writeBuffer().then((buffer) => {
         saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'DataGrid.xlsx');
       });

--- a/JSDemos/Demos/DataGrid/ExcelJSOverview/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/ExcelJSOverview/Vue/App.vue
@@ -67,7 +67,6 @@ export default {
         worksheet: worksheet,
         autoFilterEnabled: true
       }).then(() => {
-        // https://github.com/exceljs/exceljs#writing-xlsx
         workbook.xlsx.writeBuffer().then((buffer) => {
           saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'DataGrid.xlsx');
         });

--- a/JSDemos/Demos/DataGrid/ExcelJSOverview/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSOverview/jQuery/index.js
@@ -21,7 +21,6 @@ $(function(){
         worksheet: worksheet,
         autoFilterEnabled: true
       }).then(function() {
-        // https://github.com/exceljs/exceljs#writing-xlsx
         workbook.xlsx.writeBuffer().then(function(buffer) {
           saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'Employees.xlsx');
         });

--- a/JSDemos/Demos/PivotGrid/StandaloneFieldChooser/React/App.js
+++ b/JSDemos/Demos/PivotGrid/StandaloneFieldChooser/React/App.js
@@ -68,7 +68,6 @@ class App extends React.Component {
             height={400}
             layout={this.state.layout}
             applyChangesMode={this.state.applyChangesMode}
-            state={this.state.state}
           >
             <Texts
               allFields="All"

--- a/MVCDemos/Views/DataGrid/ExcelJS.cshtml
+++ b/MVCDemos/Views/DataGrid/ExcelJS.cshtml
@@ -142,8 +142,8 @@
             }
         }).then(function (dataGridRange) {
             // header
-            worksheet.getRow(2).height = 20; // https://github.com/exceljs/exceljs#rows
-            worksheet.mergeCells(2, 1, 2, 4); // https://github.com/exceljs/exceljs#merged-cells
+            worksheet.getRow(2).height = 20;
+            worksheet.mergeCells(2, 1, 2, 4);
             Object.assign(worksheet.getRow(2).getCell(1), {
                 value: 'Sales amounts report',
                 font: { bold: true, size: 16 },
@@ -158,7 +158,7 @@
                 alignment: { horizontal: 'right' }
             });
         }).then(function () {
-            workbook.xlsx.writeBuffer().then(function (buffer) { // https://github.com/exceljs/exceljs#writing-xlsx
+            workbook.xlsx.writeBuffer().then(function (buffer) {
                 saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'DataGrid.xlsx');
             });
         });

--- a/MVCDemos/Views/DataGrid/ExcelJSCellCustomization.cshtml
+++ b/MVCDemos/Views/DataGrid/ExcelJSCellCustomization.cshtml
@@ -49,7 +49,6 @@
         var workbook = new ExcelJS.Workbook();
         var worksheet = workbook.addWorksheet('Companies');
 
-        // https://github.com/exceljs/exceljs#columns
         worksheet.columns = [
             { width: 5 }, { width: 30 }, { width: 25 }, { width: 15 }, { width: 25 }, { width: 40 }
         ];
@@ -66,20 +65,15 @@
                 if (gridCell.rowType === "data") {
                     if (gridCell.column.dataField === 'Phone') {
                         excelCell.value = parseInt(gridCell.value);
-                        // https://github.com/exceljs/exceljs#number-formats
                         excelCell.numFmt = '[<=9999999]###-####;(###) ###-####';
                     }
                     if (gridCell.column.dataField === 'Website') {
-                        // https://github.com/exceljs/exceljs#hyperlink-value
                         excelCell.value = { text: gridCell.value, hyperlink: gridCell.value };
-                        // https://github.com/exceljs/exceljs#fonts
                         excelCell.font = { color: { argb: 'FF0000FF' }, underline: true }
-                        // https://github.com/exceljs/exceljs#alignment
                         excelCell.alignment = { horizontal: 'left' };
                     }
                 }
                 if (gridCell.rowType === "group") {
-                    // https://github.com/exceljs/exceljs#fills
                     excelCell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: "BEDFE6" } };
                 }
                 if (gridCell.rowType === "totalFooter" && excelCell.value) {

--- a/MVCDemos/Views/DataGrid/ExcelJSExportImages.cshtml
+++ b/MVCDemos/Views/DataGrid/ExcelJSExportImages.cshtml
@@ -48,7 +48,7 @@
                     if (gridCell.column.dataField === "Picture") {
                         excelCell.value = undefined;
 
-                        const image = workbook.addImage({ // https://github.com/exceljs/exceljs#images
+                        const image = workbook.addImage({
                             base64: gridCell.value,
                             extension: 'png',
                         });

--- a/MVCDemos/Views/DataGrid/ExcelJSHeaderAndFooter.cshtml
+++ b/MVCDemos/Views/DataGrid/ExcelJSHeaderAndFooter.cshtml
@@ -69,17 +69,12 @@
             topLeftCell: { row: 4, column: 1 }
         }).then(function (dataGridRange) {
             // header
-            // https://github.com/exceljs/exceljs#rows
             var headerRow = worksheet.getRow(2);
             headerRow.height = 30;
-            // https://github.com/exceljs/exceljs#merged-cells
             worksheet.mergeCells(2, 1, 2, 8);
 
-            // https://github.com/exceljs/exceljs#value-types
             headerRow.getCell(1).value = 'Country Area, Population, and GDP Structure';
-            // https://github.com/exceljs/exceljs#fonts
             headerRow.getCell(1).font = { name: 'Segoe UI Light', size: 22 };
-            // https://github.com/exceljs/exceljs#alignment
             headerRow.getCell(1).alignment = { horizontal: 'center' };
 
             // footer
@@ -91,7 +86,6 @@
             footerRow.getCell(1).font = { color: { argb: 'BFBFBF' }, italic: true };
             footerRow.getCell(1).alignment = { horizontal: 'right' };
         }).then(function () {
-            // https://github.com/exceljs/exceljs#writing-xlsx
             workbook.xlsx.writeBuffer().then(function (buffer) {
                 saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'CountriesPopulation.xlsx');
             });

--- a/MVCDemos/Views/DataGrid/ExcelJSOverview.cshtml
+++ b/MVCDemos/Views/DataGrid/ExcelJSOverview.cshtml
@@ -46,7 +46,6 @@
             worksheet: worksheet,
             autoFilterEnabled: true
         }).then(function () {
-            // https://github.com/exceljs/exceljs#writing-xlsx
             workbook.xlsx.writeBuffer().then(function (buffer) {
                 saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'Employees.xlsx');
             });

--- a/NetCoreDemos/Views/DataGrid/ExcelJS.cshtml
+++ b/NetCoreDemos/Views/DataGrid/ExcelJS.cshtml
@@ -141,8 +141,8 @@
             }
         }).then(function (dataGridRange) {
             // header
-            worksheet.getRow(2).height = 20; // https://github.com/exceljs/exceljs#rows
-            worksheet.mergeCells(2, 1, 2, 4); // https://github.com/exceljs/exceljs#merged-cells
+            worksheet.getRow(2).height = 20;
+            worksheet.mergeCells(2, 1, 2, 4);
             Object.assign(worksheet.getRow(2).getCell(1), {
                 value: 'Sales amounts report',
                 font: { bold: true, size: 16 },
@@ -157,7 +157,7 @@
                 alignment: { horizontal: 'right' }
             });
         }).then(function () {
-            workbook.xlsx.writeBuffer().then(function (buffer) { // https://github.com/exceljs/exceljs#writing-xlsx
+            workbook.xlsx.writeBuffer().then(function (buffer) {
                 saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'DataGrid.xlsx');
             });
         });

--- a/NetCoreDemos/Views/DataGrid/ExcelJSCellCustomization.cshtml
+++ b/NetCoreDemos/Views/DataGrid/ExcelJSCellCustomization.cshtml
@@ -48,7 +48,6 @@
         var workbook = new ExcelJS.Workbook();
         var worksheet = workbook.addWorksheet('Companies');
 
-        // https://github.com/exceljs/exceljs#columns
         worksheet.columns = [
             { width: 5 }, { width: 30 }, { width: 25 }, { width: 15 }, { width: 25 }, { width: 40 }
         ];
@@ -65,20 +64,15 @@
                 if (gridCell.rowType === "data") {
                     if (gridCell.column.dataField === 'Phone') {
                         excelCell.value = parseInt(gridCell.value);
-                        // https://github.com/exceljs/exceljs#number-formats
                         excelCell.numFmt = '[<=9999999]###-####;(###) ###-####';
                     }
                     if (gridCell.column.dataField === 'Website') {
-                        // https://github.com/exceljs/exceljs#hyperlink-value
                         excelCell.value = { text: gridCell.value, hyperlink: gridCell.value };
-                        // https://github.com/exceljs/exceljs#fonts
                         excelCell.font = { color: { argb: 'FF0000FF' }, underline: true }
-                        // https://github.com/exceljs/exceljs#alignment
                         excelCell.alignment = { horizontal: 'left' };
                     }
                 }
                 if (gridCell.rowType === "group") {
-                    // https://github.com/exceljs/exceljs#fills
                     excelCell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: "BEDFE6" } };
                 }
                 if (gridCell.rowType === "totalFooter" && excelCell.value) {

--- a/NetCoreDemos/Views/DataGrid/ExcelJSExportImages.cshtml
+++ b/NetCoreDemos/Views/DataGrid/ExcelJSExportImages.cshtml
@@ -48,7 +48,7 @@
                     if (gridCell.column.dataField === "Picture") {
                         excelCell.value = undefined;
 
-                        const image = workbook.addImage({ // https://github.com/exceljs/exceljs#images
+                        const image = workbook.addImage({
                             base64: gridCell.value,
                             extension: 'png',
                         });

--- a/NetCoreDemos/Views/DataGrid/ExcelJSHeaderAndFooter.cshtml
+++ b/NetCoreDemos/Views/DataGrid/ExcelJSHeaderAndFooter.cshtml
@@ -69,17 +69,12 @@
             topLeftCell: { row: 4, column: 1 }
         }).then(function (dataGridRange) {
             // header
-            // https://github.com/exceljs/exceljs#rows
             var headerRow = worksheet.getRow(2);
             headerRow.height = 30;
-            // https://github.com/exceljs/exceljs#merged-cells
             worksheet.mergeCells(2, 1, 2, 8);
 
-            // https://github.com/exceljs/exceljs#value-types
             headerRow.getCell(1).value = 'Country Area, Population, and GDP Structure';
-            // https://github.com/exceljs/exceljs#fonts
             headerRow.getCell(1).font = { name: 'Segoe UI Light', size: 22 };
-            // https://github.com/exceljs/exceljs#alignment
             headerRow.getCell(1).alignment = { horizontal: 'center' };
 
             // footer
@@ -91,7 +86,6 @@
             footerRow.getCell(1).font = { color: { argb: 'BFBFBF' }, italic: true };
             footerRow.getCell(1).alignment = { horizontal: 'right' };
         }).then(function () {
-            // https://github.com/exceljs/exceljs#writing-xlsx
             workbook.xlsx.writeBuffer().then(function (buffer) {
                 saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'CountriesPopulation.xlsx');
             });

--- a/NetCoreDemos/Views/DataGrid/ExcelJSOverview.cshtml
+++ b/NetCoreDemos/Views/DataGrid/ExcelJSOverview.cshtml
@@ -46,7 +46,6 @@
             worksheet: worksheet,
             autoFilterEnabled: true
         }).then(function () {
-            // https://github.com/exceljs/exceljs#writing-xlsx
             workbook.xlsx.writeBuffer().then(function (buffer) {
                 saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'Employees.xlsx');
             });


### PR DESCRIPTION
We promise our techwriters that we remove these comments when documentation and description for all demos will released. Also we have a troubles with our comments in jQuery approach. The algorithm patheses them and inside the link occurs the incorrect path exceljs@1.7.0 instead of ../exceljs/exceljs... As the result the links was corrupted.

![image](https://user-images.githubusercontent.com/15689080/98264893-75b22a80-1f99-11eb-8acd-b570fe18262a.png)
