### PR TITLE
DataGrid Export to PDF - FIX: Uncaught TypeError: Cannot read property 'jsPDF' of undefined

### DIFF
--- a/JSDemos/Demos/DataGrid/ExportToPDF/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/ExportToPDF/jQuery/index.html
@@ -11,9 +11,9 @@
     <script src="../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
-    <script src="index.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.0.0/jspdf.umd.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.9/jspdf.plugin.autotable.min.js"></script>
+    <script src="index.js"></script>
 </head>
 <body class="dx-viewport">
     <div class="demo-container">


### PR DESCRIPTION
(cherry picked from commit bded003eb1c9afb84df85c5b19373006784174ad)