### PR TITLE
Replace the link to the Form - Overview guide (#735)

### DIFF
--- a/JSDemos/menuMeta.json
+++ b/JSDemos/menuMeta.json
@@ -4472,7 +4472,6 @@
           {
             "Title": "Overview",
             "Name": "Overview",
-            "DocUrl": "Guide/UI_Components/Form/Overview/",
             "Widget": "Form",
             "MvcAdditionalFiles": [
               "/Models/Company.cs",


### PR DESCRIPTION
* Replace the link to the Form - Overview guide

* Remove the doc button

Co-authored-by: Alexander Yakovlev <alexander.yakovlev@devexpress.com>
(cherry picked from commit 2f4790e71a24df8dbb6ccb9b9fdd1c6c8ebe89a4)