### PR TITLE
DataGrid & TreeList State Storing Demo - Add a button to reset state

### DIFF
--- a/JSDemos/Demos/DataGrid/StatePersistence/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/StatePersistence/Angular/app/app.component.html
@@ -1,4 +1,4 @@
-<div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped.</div>
+<div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a (click)="onStateResetClick()">reset</a> the grid to its initial state.</div>
 <dx-data-grid id="gridContainer"
     [dataSource]="orders"
     [allowColumnResizing]="true"

--- a/JSDemos/Demos/DataGrid/StatePersistence/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/StatePersistence/Angular/app/app.component.html
@@ -1,5 +1,5 @@
-<div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a (click)="onStateResetClick()">reset</a> the grid to its initial state.</div>
-<dx-data-grid id="gridContainer"
+<div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a (click)="onRefreshClick()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a (click)="onStateResetClick()">reset</a> the grid to its initial state.</div>
+<dx-data-grid id="gridContainer" #dataGrid
     [dataSource]="orders"
     [allowColumnResizing]="true"
     [allowColumnReordering]="true"

--- a/JSDemos/Demos/DataGrid/StatePersistence/Angular/app/app.component.ts
+++ b/JSDemos/Demos/DataGrid/StatePersistence/Angular/app/app.component.ts
@@ -1,7 +1,7 @@
-import { NgModule, Component, enableProdMode } from '@angular/core';
+import { NgModule, Component, enableProdMode, ViewChild } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { DxDataGridModule } from 'devextreme-angular';
+import { DxDataGridModule, DxDataGridComponent } from 'devextreme-angular';
 import { Order, Service } from './app.service';
 
 if(!/localhost/.test(document.location.host)) {
@@ -15,10 +15,16 @@ if(!/localhost/.test(document.location.host)) {
     providers: [Service]
 })
 export class AppComponent {
+    @ViewChild(DxDataGridComponent, { static: false }) dataGrid: DxDataGridComponent
+
     orders: Order[];
 
     constructor(private service: Service) {
         this.orders = service.getOrders()
+    }
+
+    onStateResetClick() {
+        this.dataGrid.instance.state(null)
     }
 }
 

--- a/JSDemos/Demos/DataGrid/StatePersistence/Angular/app/app.component.ts
+++ b/JSDemos/Demos/DataGrid/StatePersistence/Angular/app/app.component.ts
@@ -24,7 +24,11 @@ export class AppComponent {
     }
 
     onStateResetClick() {
-        this.dataGrid.instance.state(null)
+        this.dataGrid.instance.state(null);
+    }
+
+    onRefreshClick() {
+        window.location.reload();
     }
 }
 

--- a/JSDemos/Demos/DataGrid/StatePersistence/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/StatePersistence/AngularJS/index.html
@@ -16,7 +16,7 @@
 </head>
 <body class="dx-viewport">
     <div class="demo-container" ng-app="DemoApp" ng-controller="DemoController">
-        <div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a ng-click="onStateResetClick()">reset</a> the grid to its initial state.</div>
+        <div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a ng-click="onRefreshClick()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a ng-click="onStateResetClick()">reset</a> the grid to its initial state.</div>
         <div id="gridContainer" dx-data-grid="gridOptions"> </div>
     </div>
 </body>

--- a/JSDemos/Demos/DataGrid/StatePersistence/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/StatePersistence/AngularJS/index.html
@@ -16,7 +16,7 @@
 </head>
 <body class="dx-viewport">
     <div class="demo-container" ng-app="DemoApp" ng-controller="DemoController">
-        <div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped.</div>
+        <div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a ng-click="onStateResetClick()">reset</a> the grid to its initial state.</div>
         <div id="gridContainer" dx-data-grid="gridOptions"> </div>
     </div>
 </body>

--- a/JSDemos/Demos/DataGrid/StatePersistence/AngularJS/index.js
+++ b/JSDemos/Demos/DataGrid/StatePersistence/AngularJS/index.js
@@ -54,5 +54,9 @@ DemoApp.controller('DemoController', function DemoController($scope) {
     $scope.onStateResetClick = function() {
         $scope.dataGrid.state(null);
     };
+
+    $scope.onRefreshClick = function() {
+        window.location.reload();
+    };
     
 });

--- a/JSDemos/Demos/DataGrid/StatePersistence/AngularJS/index.js
+++ b/JSDemos/Demos/DataGrid/StatePersistence/AngularJS/index.js
@@ -4,6 +4,9 @@ DemoApp.controller('DemoController', function DemoController($scope) {
     $scope.gridOptions = {
         dataSource: orders,
         keyExpr: "ID",
+        onInitialized: function (e) {
+            $scope.dataGrid = e.component;    
+        },
         allowColumnReordering: true,
         allowColumnResizing: true,
         showBorders: true,
@@ -46,6 +49,10 @@ DemoApp.controller('DemoController', function DemoController($scope) {
             dataField: "CustomerStoreState",
             groupIndex: 0
         }]
+    };
+
+    $scope.onStateResetClick = function() {
+        $scope.dataGrid.state(null);
     };
     
 });

--- a/JSDemos/Demos/DataGrid/StatePersistence/React/App.js
+++ b/JSDemos/Demos/DataGrid/StatePersistence/React/App.js
@@ -7,21 +7,27 @@ class App extends React.Component {
   constructor(props) {
     super(props);
     this.orders = service.getOrders();
+    this.dataGrid = React.createRef();
+    this.onStateResetClick = this.onStateResetClick.bind(this);
   }
   onRefreshClick() {
     window.location.reload();
   }
+  onStateResetClick() {
+    this.dataGrid.current.instance.state(null);
+  }
   render() {
     return (
       <React.Fragment>
-        <div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a onClick={this.onRefreshClick}>refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped.</div>
+        <div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a onClick={this.onRefreshClick}>refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a onClick={this.onStateResetClick}>reset</a> the grid to its initial state.</div>
         <DataGrid
           id="gridContainer"
           dataSource={this.orders}
           allowColumnResizing={true}
           allowColumnReordering={true}
           showBorders={true}
-          keyExpr="ID">
+          keyExpr="ID"
+          ref={this.dataGrid}>
           <Selection mode="single" />
           <FilterRow visible={true} />
           <GroupPanel visible={true} />

--- a/JSDemos/Demos/DataGrid/StatePersistence/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/StatePersistence/Vue/App.vue
@@ -1,8 +1,9 @@
 <template>
   <div>
-    <div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a @click="onRefreshClick">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped.</div>
+    <div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a @click="onRefreshClick">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a @click="onStateResetClick">reset</a> the grid to its initial state.</div>
     <DxDataGrid
       id="gridContainer"
+      ref="dataGrid"
       :data-source="orders"
       :allow-column-resizing="true"
       :allow-column-reordering="true"
@@ -65,6 +66,9 @@ export default {
   methods: {
     onRefreshClick() {
       window.location.reload();
+    },
+    onStateResetClick() {
+      this.$refs['dataGrid'].instance.state(null);
     }
   }
 };

--- a/JSDemos/Demos/DataGrid/StatePersistence/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/StatePersistence/jQuery/index.html
@@ -15,7 +15,7 @@
 </head>
 <body class="dx-viewport">
     <div class="demo-container">
-        <div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a onclick="onStateResetClick()">reset</a> the grid to its initial state.</div>
+        <div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a id="state-reset-link">reset</a> the grid to its initial state.</div>
         <div id="gridContainer"></div>
         
     </div>

--- a/JSDemos/Demos/DataGrid/StatePersistence/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/StatePersistence/jQuery/index.html
@@ -15,7 +15,7 @@
 </head>
 <body class="dx-viewport">
     <div class="demo-container">
-        <div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped.</div>
+        <div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a onclick="onStateResetClick()">reset</a> the grid to its initial state.</div>
         <div id="gridContainer"></div>
         
     </div>

--- a/JSDemos/Demos/DataGrid/StatePersistence/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/StatePersistence/jQuery/index.js
@@ -1,5 +1,5 @@
 $(function(){
-    $("#gridContainer").dxDataGrid({
+    const dataGrid = $("#gridContainer").dxDataGrid({
         dataSource: orders,
         keyExpr: "ID",
         allowColumnReordering: true,
@@ -44,5 +44,9 @@ $(function(){
             dataField: "CustomerStoreState",
             groupIndex: 0
         }]
-    });
+    }).dxDataGrid("instance");
+
+    window.onStateResetClick = function() {
+        dataGrid.state(null);
+    };
 });

--- a/JSDemos/Demos/DataGrid/StatePersistence/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/StatePersistence/jQuery/index.js
@@ -46,7 +46,7 @@ $(function(){
         }]
     }).dxDataGrid("instance");
 
-    window.onStateResetClick = function() {
+    $("#state-reset-link").on("click", function() {
         dataGrid.state(null);
-    };
+    });
 });

--- a/JSDemos/Demos/TreeList/StatePersistence/Angular/app/app.component.html
+++ b/JSDemos/Demos/TreeList/StatePersistence/Angular/app/app.component.html
@@ -1,4 +1,4 @@
-<div id="descContainer">Sort and filter data, reorder and resize columns, select and expand rows. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a (click)="onStateResetClick()">reset</a> the grid to its initial state.</div>
+<div id="descContainer">Sort and filter data, reorder and resize columns, select and expand rows. Once you are done, <a (click)="onRefreshClick()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a (click)="onStateResetClick()">reset</a> the grid to its initial state.</div>
 <dx-tree-list 
     id="employees"
     [dataSource]="employees"

--- a/JSDemos/Demos/TreeList/StatePersistence/Angular/app/app.component.html
+++ b/JSDemos/Demos/TreeList/StatePersistence/Angular/app/app.component.html
@@ -1,4 +1,4 @@
-<div id="descContainer">Sort and filter data, reorder and resize columns, select and expand rows. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped.</div>
+<div id="descContainer">Sort and filter data, reorder and resize columns, select and expand rows. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a (click)="onStateResetClick()">reset</a> the grid to its initial state.</div>
 <dx-tree-list 
     id="employees"
     [dataSource]="employees"

--- a/JSDemos/Demos/TreeList/StatePersistence/Angular/app/app.component.ts
+++ b/JSDemos/Demos/TreeList/StatePersistence/Angular/app/app.component.ts
@@ -1,7 +1,7 @@
-import { NgModule, Component, enableProdMode } from '@angular/core';
+import { NgModule, Component, enableProdMode, ViewChild } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { DxTreeListModule } from 'devextreme-angular';
+import { DxTreeListModule, DxTreeListComponent } from 'devextreme-angular';
 import { Employee, Service } from './app.service';
 
 if(!/localhost/.test(document.location.host)) {
@@ -15,10 +15,16 @@ if(!/localhost/.test(document.location.host)) {
     providers: [Service]
 })
 export class AppComponent {
+    @ViewChild(DxTreeListComponent, { static: false }) treeList: DxTreeListComponent
+
     employees: Employee[];
 
     constructor(private service: Service) {
         this.employees = service.getEmployees()
+    }
+
+    onStateResetClick() {
+        this.treeList.instance.state(null)
     }
 }
 

--- a/JSDemos/Demos/TreeList/StatePersistence/Angular/app/app.component.ts
+++ b/JSDemos/Demos/TreeList/StatePersistence/Angular/app/app.component.ts
@@ -26,6 +26,10 @@ export class AppComponent {
     onStateResetClick() {
         this.treeList.instance.state(null)
     }
+
+    onRefreshClick() {
+        window.location.reload();
+    }
 }
 
 @NgModule({

--- a/JSDemos/Demos/TreeList/StatePersistence/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/StatePersistence/AngularJS/index.html
@@ -16,7 +16,7 @@
 </head>
 <body class="dx-viewport">
     <div class="demo-container" ng-app="DemoApp" ng-controller="DemoController">
-        <div id="descContainer">Sort and filter data, reorder and resize columns, select and expand rows. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped.</div>
+        <div id="descContainer">Sort and filter data, reorder and resize columns, select and expand rows. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a ng-click="onStateResetClick()">reset</a> the grid to its initial state.</div>
         <div id="employees" dx-tree-list="treeListOptions"> </div>
     </div>
 </body>

--- a/JSDemos/Demos/TreeList/StatePersistence/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/StatePersistence/AngularJS/index.html
@@ -16,7 +16,7 @@
 </head>
 <body class="dx-viewport">
     <div class="demo-container" ng-app="DemoApp" ng-controller="DemoController">
-        <div id="descContainer">Sort and filter data, reorder and resize columns, select and expand rows. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a ng-click="onStateResetClick()">reset</a> the grid to its initial state.</div>
+        <div id="descContainer">Sort and filter data, reorder and resize columns, select and expand rows. Once you are done, <a ng-click="onRefreshClick()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a ng-click="onStateResetClick()">reset</a> the grid to its initial state.</div>
         <div id="employees" dx-tree-list="treeListOptions"> </div>
     </div>
 </body>

--- a/JSDemos/Demos/TreeList/StatePersistence/AngularJS/index.js
+++ b/JSDemos/Demos/TreeList/StatePersistence/AngularJS/index.js
@@ -4,6 +4,9 @@ DemoApp.controller('DemoController', function DemoController($scope) {
     $scope.treeListOptions = {
         dataSource: employees,
         keyExpr: "ID",
+        onInitialized: function (e) {
+            $scope.treeList = e.component;    
+        },
         parentIdExpr: "Head_ID",
         allowColumnReordering: true,
         allowColumnResizing: true,
@@ -32,5 +35,9 @@ DemoApp.controller('DemoController', function DemoController($scope) {
                 width: 160
             }
         ]
-    };    
+    };
+
+    $scope.onStateResetClick = function() {
+        $scope.treeList.state(null);
+    };
 });

--- a/JSDemos/Demos/TreeList/StatePersistence/AngularJS/index.js
+++ b/JSDemos/Demos/TreeList/StatePersistence/AngularJS/index.js
@@ -40,4 +40,8 @@ DemoApp.controller('DemoController', function DemoController($scope) {
     $scope.onStateResetClick = function() {
         $scope.treeList.state(null);
     };
+
+    $scope.onRefreshClick = function() {
+        window.location.reload();
+    };
 });

--- a/JSDemos/Demos/TreeList/StatePersistence/React/App.js
+++ b/JSDemos/Demos/TreeList/StatePersistence/React/App.js
@@ -5,12 +5,24 @@ import { employees } from './data.js';
 const expandedRowKeys = [1, 2, 10];
 
 class App extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.treeList = React.createRef();
+    this.onStateResetClick = this.onStateResetClick.bind(this);
+  }
+
+  onStateResetClick() {
+    this.treeList.current.instance.state(null);
+  }
+
   render() {
     return (
       <div>
-        <div id="descContainer">Sort and filter data, reorder and resize columns, select and expand rows. Once you are done, <a onClick={this.reloadPage}>refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped.</div>
+        <div id="descContainer">Sort and filter data, reorder and resize columns, select and expand rows. Once you are done, <a onClick={this.reloadPage}>refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a onClick={this.onStateResetClick}>reset</a> the grid to its initial state.</div>
         <TreeList
           id="employees"
+          ref={this.treeList}
           dataSource={employees}
           allowColumnReordering={true}
           allowColumnResizing={true}

--- a/JSDemos/Demos/TreeList/StatePersistence/Vue/App.vue
+++ b/JSDemos/Demos/TreeList/StatePersistence/Vue/App.vue
@@ -3,10 +3,12 @@
     <div id="descContainer">
       Sort and filter data, reorder and resize columns, select and expand rows. Once you are done,
       <a onclick="window.location.reload()">refresh</a>
-      the web page to see that the grid’s state is automatically persisted to continue working from where you stopped.
+      the web page to see that the grid’s state is automatically persisted to continue working from where you stopped
+      or you can <a @click="onStateResetClick">reset</a> the grid to its initial state.
     </div>
     <DxTreeList
       id="employees"
+      ref="treeList"
       :data-source="employees"
       :allow-column-reordering="true"
       :allow-column-resizing="true"
@@ -58,6 +60,11 @@ export default {
       employees: employees,
       expandedRowKeys: [1, 2, 10]
     };
+  },
+  methods: {
+    onStateResetClick() {
+      this.$refs['treeList'].instance.state(null);
+    }
   }
 };
 </script>

--- a/JSDemos/Demos/TreeList/StatePersistence/Vue/App.vue
+++ b/JSDemos/Demos/TreeList/StatePersistence/Vue/App.vue
@@ -2,7 +2,7 @@
   <div>
     <div id="descContainer">
       Sort and filter data, reorder and resize columns, select and expand rows. Once you are done,
-      <a onclick="window.location.reload()">refresh</a>
+      <a @click="onRefreshClick">refresh</a>
       the web page to see that the grid’s state is automatically persisted to continue working from where you stopped
       or you can <a @click="onStateResetClick">reset</a> the grid to its initial state.
     </div>
@@ -62,6 +62,9 @@ export default {
     };
   },
   methods: {
+    onRefreshClick() {
+      window.location.reload();
+    },
     onStateResetClick() {
       this.$refs['treeList'].instance.state(null);
     }

--- a/JSDemos/Demos/TreeList/StatePersistence/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/StatePersistence/jQuery/index.html
@@ -15,7 +15,7 @@
 </head>
 <body class="dx-viewport">
     <div class="demo-container">
-        <div id="descContainer">Sort and filter data, reorder and resize columns, select and expand rows. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a onclick="onStateResetClick()">reset</a> the grid to its initial state.</div>
+        <div id="descContainer">Sort and filter data, reorder and resize columns, select and expand rows. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a id="state-reset-link">reset</a> the grid to its initial state.</div>
         <div id="employees"></div>        
     </div>
 </body>

--- a/JSDemos/Demos/TreeList/StatePersistence/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/StatePersistence/jQuery/index.html
@@ -15,7 +15,7 @@
 </head>
 <body class="dx-viewport">
     <div class="demo-container">
-        <div id="descContainer">Sort and filter data, reorder and resize columns, select and expand rows. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped.</div>
+        <div id="descContainer">Sort and filter data, reorder and resize columns, select and expand rows. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a onclick="onStateResetClick()">reset</a> the grid to its initial state.</div>
         <div id="employees"></div>        
     </div>
 </body>

--- a/JSDemos/Demos/TreeList/StatePersistence/jQuery/index.js
+++ b/JSDemos/Demos/TreeList/StatePersistence/jQuery/index.js
@@ -32,7 +32,7 @@ $(function(){
         ]
     }).dxTreeList("instance");
 
-    window.onStateResetClick = function() {
+    $("#state-reset-link").on("click", function() {
         treeList.state(null);
-    };
+    });
 });

--- a/JSDemos/Demos/TreeList/StatePersistence/jQuery/index.js
+++ b/JSDemos/Demos/TreeList/StatePersistence/jQuery/index.js
@@ -1,5 +1,5 @@
 $(function(){
-    $("#employees").dxTreeList({
+    const treeList = $("#employees").dxTreeList({
         dataSource: employees,
         keyExpr: "ID",
         parentIdExpr: "Head_ID",
@@ -30,5 +30,9 @@ $(function(){
                 width: 160
             }
         ]
-    });
+    }).dxTreeList("instance");
+
+    window.onStateResetClick = function() {
+        treeList.state(null);
+    };
 });

--- a/MVCDemos/Views/DataGrid/StatePersistence.cshtml
+++ b/MVCDemos/Views/DataGrid/StatePersistence.cshtml
@@ -2,7 +2,7 @@
 
 @model IEnumerable<Order>
 
-<div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped.</div>
+<div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a onclick="onStateResetClick()">reset</a> the grid to its initial state.</div>
 
 @(Html.DevExtreme().DataGrid<Order>()
     .ID("gridContainer")
@@ -41,3 +41,10 @@
             .GroupIndex(0);
     })
 )
+
+<script>
+    function onStateResetClick() {
+        const dataGrid = $("#gridContainer").dxDataGrid("instance");
+        dataGrid.state(null);
+    }
+</script>

--- a/MVCDemos/Views/TreeList/StatePersistence.cshtml
+++ b/MVCDemos/Views/TreeList/StatePersistence.cshtml
@@ -1,4 +1,4 @@
-﻿<div id="descContainer">Sort and filter data, reorder and resize columns, select and expand rows. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped.</div>
+﻿<div id="descContainer">Sort and filter data, reorder and resize columns, select and expand rows. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a onclick="onStateResetClick()">reset</a> the grid to its initial state.</div>
 
 @(Html.DevExtreme().TreeList<DevExtreme.MVC.Demos.Models.TreeList.Employee>()
     .ID("employees")
@@ -30,3 +30,10 @@
             .Width(160);
     })
 )
+
+<script>
+    function onStateResetClick() {
+        const dataGrid = $("#employees").dxTreeList("instance");
+        dataGrid.state(null);
+    }
+</script>

--- a/NetCoreDemos/Views/DataGrid/StatePersistence.cshtml
+++ b/NetCoreDemos/Views/DataGrid/StatePersistence.cshtml
@@ -2,7 +2,7 @@
 
 @model IEnumerable<Order>
 
-<div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped.</div>
+<div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a onclick="onStateResetClick()">reset</a> the grid to its initial state.</div>
 
 @(Html.DevExtreme().DataGrid<Order>()
     .ID("gridContainer")
@@ -41,3 +41,10 @@
             .GroupIndex(0);
     })
 )
+
+<script>
+    function onStateResetClick() {
+        const dataGrid = $("#gridContainer").dxDataGrid("instance");
+        dataGrid.state(null);
+    }
+</script>

--- a/NetCoreDemos/Views/TreeList/StatePersistence.cshtml
+++ b/NetCoreDemos/Views/TreeList/StatePersistence.cshtml
@@ -1,4 +1,4 @@
-﻿<div id="descContainer">Sort and filter data, reorder and resize columns, select and expand rows. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped.</div>
+﻿<div id="descContainer">Sort and filter data, reorder and resize columns, select and expand rows. Once you are done, <a onclick="window.location.reload()">refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a onclick="onStateResetClick()">reset</a> the grid to its initial state.</div>
 
 @(Html.DevExtreme().TreeList<DevExtreme.NETCore.Demos.Models.TreeList.Employee>()
     .ID("employees")
@@ -30,3 +30,10 @@
             .Width(160);
     })
 )
+
+<script>
+    function onStateResetClick() {
+        const dataGrid = $("#employees").dxTreeList("instance");
+        dataGrid.state(null);
+    }
+</script>


### PR DESCRIPTION
Cherry picks:

- https://github.com/DevExpress/devextreme-demos/pull/892

Trello card: https://trello.com/c/MMv8CdG3/4601-datagrid-state-storing-demo-add-a-button-to-reset-state

---

I added to [DataGrid](https://js.devexpress.com/Demos/WidgetsGallery/Demo/DataGrid/StatePersistence/jQuery/Light/) and [TreeList State Persistence](https://js.devexpress.com/Demos/WidgetsGallery/Demo/TreeList/StatePersistence/Vue/Light/) demos button to reset current state to initial

|from that|to this|
|-|-|
|![image](https://user-images.githubusercontent.com/84017191/118971283-e63df900-b977-11eb-943e-8e4f7ffa5a79.png)|![image](https://user-images.githubusercontent.com/84017191/118971250-db836400-b977-11eb-8db4-f5d0ecc71d36.png)|

(new link in text above the grid)
