### PR TITLE
DataGrid - Add allowAdding/allowDeleting options to editing demos with modes

### DIFF
--- a/JSDemos/Demos/DataGrid/BatchEditing/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/BatchEditing/Angular/app/app.component.html
@@ -7,6 +7,8 @@
         <dxo-paging [enabled]="false"></dxo-paging>
         <dxo-editing mode="batch"
                      [allowUpdating]="true"
+                     [allowAdding]="true"
+                     [allowDeleting]="true"
                      [selectTextOnEditStart]="selectTextOnEditStart"
                      [startEditAction]="startEditAction">
         </dxo-editing>

--- a/JSDemos/Demos/DataGrid/BatchEditing/AngularJS/index.js
+++ b/JSDemos/Demos/DataGrid/BatchEditing/AngularJS/index.js
@@ -13,7 +13,9 @@ DemoApp.controller('DemoController', function DemoController($scope) {
         },
         editing: {
             mode: "batch",
-            allowUpdating: true
+            allowUpdating: true,
+            allowAdding: true,
+            allowDeleting: true
         },
         bindingOptions: {
             "editing.startEditAction": "startEditAction",

--- a/JSDemos/Demos/DataGrid/BatchEditing/React/App.js
+++ b/JSDemos/Demos/DataGrid/BatchEditing/React/App.js
@@ -42,6 +42,8 @@ class App extends React.Component {
           <Editing
             mode="batch"
             allowUpdating={true}
+            allowAdding={true}
+            allowDeleting={true}
             selectTextOnEditStart={this.state.selectTextOnEditStart}
             startEditAction={this.state.startEditAction} />
           <Column dataField="Prefix" caption="Title" width={70} />

--- a/JSDemos/Demos/DataGrid/BatchEditing/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/BatchEditing/Vue/App.vue
@@ -7,6 +7,8 @@
     >
       <DxEditing
         :allow-updating="true"
+        :allow-adding="true"
+        :allow-deleting="true"
         :select-text-on-edit-start="selectTextOnEditStart"
         :start-edit-action="startEditAction"
         mode="batch"

--- a/JSDemos/Demos/DataGrid/BatchEditing/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/BatchEditing/jQuery/index.js
@@ -9,6 +9,8 @@ $(function(){
         editing: {
             mode: "batch",
             allowUpdating: true,
+            allowAdding: true,
+            allowDeleting: true,
             selectTextOnEditStart: true,
             startEditAction: "click"
         },

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.html
@@ -14,7 +14,9 @@
         <dxo-paging [enabled]="false"></dxo-paging>
         <dxo-editing 
             mode="cell"
-            [allowUpdating]="true">
+            [allowUpdating]="true"
+            [allowAdding]="true"
+            [allowDeleting]="true">
         </dxo-editing>
         <dxo-selection mode="multiple"></dxo-selection>
         

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/index.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/index.js
@@ -31,7 +31,9 @@ DemoApp.controller('DemoController', function DemoController($scope) {
         },
         editing: {
             mode: "cell",
-            allowUpdating: true
+            allowUpdating: true,
+            allowAdding: true,
+            allowDeleting: true
         },
         selection: {
             mode: "multiple"

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/App.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/App.js
@@ -50,7 +50,9 @@ class App extends React.Component {
           <Paging enabled={false} />
           <Editing
             mode="cell"
-            allowUpdating={true} />
+            allowUpdating={true}
+            allowAdding={true}
+            allowDeleting={true} />
 
           <Column dataField="Prefix" caption="Title" width={55} />
           <Column dataField="FirstName" />

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Vue/App.vue
@@ -16,6 +16,8 @@
     >
       <DxEditing
         :allow-updating="true"
+        :allow-adding="true"
+        :allow-deleting="true"
         mode="cell"
       />
       <DxPaging :enabled="false"/>

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/jQuery/index.js
@@ -24,7 +24,9 @@ $(function(){
         },
         editing: {
             mode: "cell",
-            allowUpdating: true
+            allowUpdating: true,
+            allowAdding: true,
+            allowDeleting: true
         },
         selection: {
             mode: "multiple"

--- a/JSDemos/Demos/DataGrid/FormEditing/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/FormEditing/Angular/app/app.component.html
@@ -8,7 +8,9 @@
         <dxo-paging [enabled]="false"></dxo-paging>
         <dxo-editing 
             mode="form"
-            [allowUpdating]="true">
+            [allowUpdating]="true"
+            [allowAdding]="true"
+            [allowDeleting]="true">
         </dxo-editing>
         
         <dxi-column dataField="Prefix" caption="Title" [width]="70"></dxi-column>

--- a/JSDemos/Demos/DataGrid/FormEditing/AngularJS/index.js
+++ b/JSDemos/Demos/DataGrid/FormEditing/AngularJS/index.js
@@ -10,7 +10,9 @@ DemoApp.controller('DemoController', function DemoController($scope) {
         },
         editing: {
             mode: "form",
-            allowUpdating: true
+            allowUpdating: true,
+            allowAdding: true,
+            allowDeleting: true
         },
         columns: [
             {

--- a/JSDemos/Demos/DataGrid/FormEditing/React/App.js
+++ b/JSDemos/Demos/DataGrid/FormEditing/React/App.js
@@ -25,7 +25,9 @@ class App extends React.Component {
           <Paging enabled={false} />
           <Editing
             mode="form"
-            allowUpdating={true} />
+            allowUpdating={true}
+            allowAdding={true}
+            allowDeleting={true} />
           <Column dataField="Prefix" caption="Title" width={70} />
           <Column dataField="FirstName" />
           <Column dataField="LastName" />

--- a/JSDemos/Demos/DataGrid/FormEditing/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/FormEditing/Vue/App.vue
@@ -7,6 +7,8 @@
     >
       <DxEditing
         :allow-updating="true"
+        :allow-adding="true"
+        :allow-deleting="true"
         mode="form"
       />
       <DxPaging :enabled="false"/>

--- a/JSDemos/Demos/DataGrid/FormEditing/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/FormEditing/jQuery/index.js
@@ -8,7 +8,9 @@ $(function(){
         },
         editing: {
             mode: "form",
-            allowUpdating: true
+            allowUpdating: true,
+            allowAdding: true,
+            allowDeleting: true
         },
         columns: [
             {

--- a/JSDemos/Demos/DataGrid/PopupEditing/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/PopupEditing/Angular/app/app.component.html
@@ -8,7 +8,9 @@
         <dxo-paging [enabled]="false"></dxo-paging>
         <dxo-editing 
             mode="popup"
-            [allowUpdating]="true">
+            [allowUpdating]="true"
+            [allowAdding]="true"
+            [allowDeleting]="true">
             <dxo-popup
                 title="Employee Info"
                 [showTitle]="true"

--- a/JSDemos/Demos/DataGrid/PopupEditing/AngularJS/index.js
+++ b/JSDemos/Demos/DataGrid/PopupEditing/AngularJS/index.js
@@ -8,6 +8,8 @@ DemoApp.controller('DemoController', function DemoController($scope) {
         editing: {
             mode: "popup",
             allowUpdating: true,
+            allowAdding: true,
+            allowDeleting: true,
             popup: {
                 title: "Employee Info",
                 showTitle: true,

--- a/JSDemos/Demos/DataGrid/PopupEditing/React/App.js
+++ b/JSDemos/Demos/DataGrid/PopupEditing/React/App.js
@@ -26,7 +26,9 @@ class App extends React.Component {
           <Paging enabled={false} />
           <Editing
             mode="popup"
-            allowUpdating={true}>
+            allowUpdating={true}
+            allowAdding={true}
+            allowDeleting={true}>
             <Popup title="Employee Info" showTitle={true} width={700} height={525} />
             <Form>
               <Item itemType="group" colCount={2} colSpan={2}>

--- a/JSDemos/Demos/DataGrid/PopupEditing/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/PopupEditing/Vue/App.vue
@@ -8,6 +8,8 @@
       <DxPaging :enabled="false"/>
       <DxEditing
         :allow-updating="true"
+        :allow-adding="true"
+        :allow-deleting="true"
         mode="popup"
       >
         <DxPopup

--- a/JSDemos/Demos/DataGrid/PopupEditing/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/PopupEditing/jQuery/index.js
@@ -6,6 +6,8 @@ $(function(){
         editing: {
             mode: "popup",
             allowUpdating: true,
+            allowAdding: true,
+            allowDeleting: true,
             popup: {
                 title: "Employee Info",
                 showTitle: true,

--- a/MVCDemos/Views/DataGrid/BatchEditing.cshtml
+++ b/MVCDemos/Views/DataGrid/BatchEditing.cshtml
@@ -32,7 +32,7 @@
 
             columns.AddFor(m => m.BirthDate);
         })
-        .DataSource(d => d.WebApi().Controller("DataGridEmployees").UpdateAction(true).Key("ID"))
+        .DataSource(d => d.WebApi().Controller("DataGridEmployees").UpdateAction(true).InsertAction(true).DeleteAction(true).Key("ID"))
     )
 
     <div class="options">

--- a/MVCDemos/Views/DataGrid/BatchEditing.cshtml
+++ b/MVCDemos/Views/DataGrid/BatchEditing.cshtml
@@ -6,6 +6,8 @@
         .Editing(editing => {
             editing.Mode(GridEditMode.Batch);
             editing.AllowUpdating(true);
+            editing.AllowAdding(true);
+            editing.AllowDeleting(true);
             editing.SelectTextOnEditStart(true);
             editing.StartEditAction(GridStartEditAction.Click);
         })

--- a/MVCDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
+++ b/MVCDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
@@ -14,6 +14,8 @@
         .Editing(editing => {
             editing.Mode(GridEditMode.Cell);
             editing.AllowUpdating(true);
+            editing.AllowAdding(true);
+            editing.AllowDeleting(true);
         })
         .Selection(selection => selection.Mode(SelectionMode.Multiple))
         .OnSelectionChanged("onSelectionChanged")

--- a/MVCDemos/Views/DataGrid/FormEditing.cshtml
+++ b/MVCDemos/Views/DataGrid/FormEditing.cshtml
@@ -6,6 +6,8 @@
         .Editing(editing => {
             editing.Mode(GridEditMode.Form);
             editing.AllowUpdating(true);
+            editing.AllowAdding(true);
+            editing.AllowDeleting(true);
         })
         .Columns(columns => {
             columns.AddFor(m => m.Prefix)

--- a/MVCDemos/Views/DataGrid/PopupEditing.cshtml
+++ b/MVCDemos/Views/DataGrid/PopupEditing.cshtml
@@ -5,6 +5,8 @@
         .Paging(p => p.Enabled(false))
         .Editing(e => e.Mode(GridEditMode.Popup)
             .AllowUpdating(true)
+            .AllowAdding(true)
+            .AllowDeleting(true)
             .Popup(p => p
                 .Title("Employee Info")
                 .ShowTitle(true)

--- a/NetCoreDemos/Views/DataGrid/BatchEditing.cshtml
+++ b/NetCoreDemos/Views/DataGrid/BatchEditing.cshtml
@@ -36,6 +36,8 @@
             .Controller("DataGridEmployees")
             .LoadAction("Get")
             .UpdateAction("Put")
+            .InsertAction("Post")
+            .DeleteAction("Delete")
             .Key("ID")
         )
     )

--- a/NetCoreDemos/Views/DataGrid/BatchEditing.cshtml
+++ b/NetCoreDemos/Views/DataGrid/BatchEditing.cshtml
@@ -6,6 +6,8 @@
         .Editing(editing => {
             editing.Mode(GridEditMode.Batch);
             editing.AllowUpdating(true);
+            editing.AllowAdding(true);
+            editing.AllowDeleting(true);
             editing.SelectTextOnEditStart(true);
             editing.StartEditAction(GridStartEditAction.Click);
         })

--- a/NetCoreDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
+++ b/NetCoreDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
@@ -14,6 +14,8 @@
         .Editing(editing => {
             editing.Mode(GridEditMode.Cell);
             editing.AllowUpdating(true);
+            editing.AllowAdding(true);
+            editing.AllowDeleting(true);
         })
         .Selection(selection => selection.Mode(SelectionMode.Multiple))
         .OnSelectionChanged("onSelectionChanged")

--- a/NetCoreDemos/Views/DataGrid/FormEditing.cshtml
+++ b/NetCoreDemos/Views/DataGrid/FormEditing.cshtml
@@ -6,6 +6,8 @@
         .Editing(editing => {
             editing.Mode(GridEditMode.Form);
             editing.AllowUpdating(true);
+            editing.AllowAdding(true);
+            editing.AllowDeleting(true);
         })
         .Columns(columns => {
             columns.AddFor(m => m.Prefix)

--- a/NetCoreDemos/Views/DataGrid/PopupEditing.cshtml
+++ b/NetCoreDemos/Views/DataGrid/PopupEditing.cshtml
@@ -5,6 +5,8 @@
         .Paging(p => p.Enabled(false))
         .Editing(e => e.Mode(GridEditMode.Popup)
             .AllowUpdating(true)
+            .AllowAdding(true)
+            .AllowDeleting(true)
             .Popup(p => p
                 .Title("Employee Info")
                 .ShowTitle(true)


### PR DESCRIPTION
Trello card: https://trello.com/c/2PGEE5dt/5156-add-allowadding-allowdeleting-options-to-editing-demos-with-modes

Cherry picks:

- https://github.com/DevExpress/devextreme-demos/pull/896

---

I added `allowAdding` and `allowDeleting` options to BatchEditing, CellEditingAndEditingAPI, FormEditing, PopupEditing demos