### PR TITLE
Data grid add allow adding to editing demos 21 1

### DIFF
--- a/JSDemos/Demos/DataGrid/BatchEditing/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/BatchEditing/Angular/app/app.component.html
@@ -7,6 +7,8 @@
         <dxo-paging [enabled]="false"></dxo-paging>
         <dxo-editing mode="batch"
                      [allowUpdating]="true"
+                     [allowAdding]="true"
+                     [allowDeleting]="true"
                      [selectTextOnEditStart]="selectTextOnEditStart"
                      [startEditAction]="startEditAction">
         </dxo-editing>

--- a/JSDemos/Demos/DataGrid/BatchEditing/AngularJS/index.js
+++ b/JSDemos/Demos/DataGrid/BatchEditing/AngularJS/index.js
@@ -13,7 +13,9 @@ DemoApp.controller('DemoController', function DemoController($scope) {
         },
         editing: {
             mode: "batch",
-            allowUpdating: true
+            allowUpdating: true,
+            allowAdding: true,
+            allowDeleting: true
         },
         bindingOptions: {
             "editing.startEditAction": "startEditAction",

--- a/JSDemos/Demos/DataGrid/BatchEditing/React/App.js
+++ b/JSDemos/Demos/DataGrid/BatchEditing/React/App.js
@@ -42,6 +42,8 @@ class App extends React.Component {
           <Editing
             mode="batch"
             allowUpdating={true}
+            allowAdding={true}
+            allowDeleting={true}
             selectTextOnEditStart={this.state.selectTextOnEditStart}
             startEditAction={this.state.startEditAction} />
           <Column dataField="Prefix" caption="Title" width={70} />

--- a/JSDemos/Demos/DataGrid/BatchEditing/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/BatchEditing/Vue/App.vue
@@ -7,6 +7,8 @@
     >
       <DxEditing
         :allow-updating="true"
+        :allow-adding="true"
+        :allow-deleting="true"
         :select-text-on-edit-start="selectTextOnEditStart"
         :start-edit-action="startEditAction"
         mode="batch"

--- a/JSDemos/Demos/DataGrid/BatchEditing/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/BatchEditing/jQuery/index.js
@@ -9,6 +9,8 @@ $(function(){
         editing: {
             mode: "batch",
             allowUpdating: true,
+            allowAdding: true,
+            allowDeleting: true,
             selectTextOnEditStart: true,
             startEditAction: "click"
         },

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.css
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.css
@@ -2,9 +2,6 @@
     min-height: 700px;
 }
 
-::ng-deep #gridContainer {
-    padding-top: 45px;
-}
 ::ng-deep #gridDeleteSelected {
     position: absolute;
     z-index: 1;

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.html
@@ -1,15 +1,10 @@
 <div id="data-grid-demo">
-    <dx-button id="gridDeleteSelected"
-        text="Delete Selected Records"
-        [height]="34"
-        [disabled]="!selectedItemKeys.length"
-        (onClick)="deleteRecords()">
-    </dx-button>
     <dx-data-grid 
         id="gridContainer"
         [dataSource]="dataSource"
         [showBorders]="true"
-        (onSelectionChanged)="selectionChanged($event)">
+        (onSelectionChanged)="selectionChanged($event)"
+        (onToolbarPreparing)="onToolbarPreparing($event)">
         
         <dxo-paging [enabled]="false"></dxo-paging>
         <dxo-editing 

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.html
@@ -14,7 +14,9 @@
         <dxo-paging [enabled]="false"></dxo-paging>
         <dxo-editing 
             mode="cell"
-            [allowUpdating]="true">
+            [allowUpdating]="true"
+            [allowAdding]="true"
+            [allowDeleting]="true">
         </dxo-editing>
         <dxo-selection mode="multiple"></dxo-selection>
         

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.ts
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.ts
@@ -22,6 +22,7 @@ export class AppComponent {
     dataSource: ArrayStore;
     states: State[];
     selectedItemKeys: any[] = [];
+    deleteButton: any;
 
     constructor(service: Service) {
         this.dataSource = new ArrayStore({
@@ -33,12 +34,33 @@ export class AppComponent {
 
     selectionChanged(data: any) {
         this.selectedItemKeys = data.selectedRowKeys;
+        this.deleteButton.option("disabled", !data.selectedRowsData.length);
     }
+
     deleteRecords() {
         this.selectedItemKeys.forEach((key) => {
             this.dataSource.remove(key);
         });
         this.dataGrid.instance.refresh();
+        this.deleteButton.option("disabled", true);
+    }
+
+    onToolbarPreparing(e) {
+        e.toolbarOptions.items[0].showText = 'always';
+
+        e.toolbarOptions.items.unshift({
+            location: "after",
+            widget: "dxButton",
+            options: {
+                text: "Delete Selected Records",
+                icon: "trash",
+                disabled: true,
+                onClick: this.deleteRecords.bind(this),
+                onInitialized: (e) => {
+                    this.deleteButton = e.component;
+                }
+            }
+        });
     }
 }
 

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/index.html
@@ -17,7 +17,6 @@
 <body class="dx-viewport">
     <div class="demo-container" ng-app="DemoApp" ng-controller="DemoController">
         <div id="data-grid-demo">
-            <div id="gridDeleteSelected" dx-button="buttonOptions"></div>
             <div id="gridContainer" dx-data-grid="dataGridOptions"></div>
         </div>
     </div>

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/index.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/index.js
@@ -31,7 +31,9 @@ DemoApp.controller('DemoController', function DemoController($scope) {
         },
         editing: {
             mode: "cell",
-            allowUpdating: true
+            allowUpdating: true,
+            allowAdding: true,
+            allowDeleting: true
         },
         selection: {
             mode: "multiple"

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/index.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/index.js
@@ -9,20 +9,6 @@ DemoApp.controller('DemoController', function DemoController($scope) {
     $scope.selectedItemKeys = [];
     $scope.disabled = true;
     
-    $scope.buttonOptions = {
-        text: "Delete Selected Records",
-        height: 34,
-        onClick: function () {
-            $.each($scope.selectedItemKeys, function() {
-                employeesStore.remove(this);
-            });
-            $("#gridContainer").dxDataGrid("instance").refresh();
-        },
-        bindingOptions: {
-            disabled: "disabled"
-        }
-    };
-    
     $scope.dataGridOptions = {
         dataSource: employeesStore,
         showBorders: true,
@@ -65,7 +51,31 @@ DemoApp.controller('DemoController', function DemoController($scope) {
                 dataField: "BirthDate",
                 dataType: "date"
             }
-        ]
+        ],
+        onToolbarPreparing: function(e) {
+            var dataGrid = e.component;
+            
+            e.toolbarOptions.items[0].showText = 'always';
+
+            e.toolbarOptions.items.unshift({
+                location: "after",
+                widget: "dxButton",
+                options: {
+                    text: "Delete Selected Records",
+                    icon: "trash",
+                    disabled: true,
+                    onClick: function() {
+                        dataGrid.getSelectedRowKeys().forEach((key) => {
+                            employeesStore.remove(key);
+                        });
+                        dataGrid.refresh();
+                    },
+                    bindingOptions: {
+                        disabled: "disabled"
+                    }
+                }
+            });
+        }
     };
     
 });

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/styles.css
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/styles.css
@@ -2,10 +2,6 @@
     min-height: 700px;
 }
 
-#gridContainer {
-    padding-top: 45px;
-}
-
 #gridDeleteSelected {
     position: absolute;
     z-index: 1;

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/App.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/App.js
@@ -7,7 +7,6 @@ import DataGrid, {
   Selection,
   Lookup
 } from 'devextreme-react/data-grid';
-import { Button } from 'devextreme-react/button';
 
 import ArrayStore from 'devextreme/data/array_store';
 import DataSource from 'devextreme/data/data_source';
@@ -28,23 +27,19 @@ class App extends React.Component {
     };
     this.selectionChanged = this.selectionChanged.bind(this);
     this.deleteRecords = this.deleteRecords.bind(this);
+    this.onToolbarPreparing = this.onToolbarPreparing.bind(this);
   }
 
   render() {
 
     return (
       <div id="data-grid-demo">
-        <Button id="gridDeleteSelected"
-          text="Delete Selected Records"
-          height={34}
-          disabled={!this.state.selectedItemKeys.length}
-          onClick={this.deleteRecords} />
-
         <DataGrid id="gridContainer"
           dataSource={dataSource}
           showBorders={true}
           selectedRowKeys={this.state.selectedItemKeys}
           onSelectionChanged={this.selectionChanged}
+          onToolbarPreparing={this.onToolbarPreparing}
         >
           <Selection mode="multiple" />
           <Paging enabled={false} />
@@ -74,10 +69,29 @@ class App extends React.Component {
       selectedItemKeys: []
     });
     dataSource.reload();
+    this.deleteButton.option('disabled', true);
   }
   selectionChanged(data) {
     this.setState({
       selectedItemKeys: data.selectedRowKeys
+    });
+    this.deleteButton.option('disabled', !data.selectedRowsData.length);
+  }
+  onToolbarPreparing(e) {
+    e.toolbarOptions.items[0].showText = 'always';
+
+    e.toolbarOptions.items.unshift({
+      location: 'after',
+      widget: 'dxButton',
+      options: {
+        text: 'Delete Selected Records',
+        icon: 'trash',
+        disabled: true,
+        onClick: this.deleteRecords.bind(this),
+        onInitialized: (e) => {
+          this.deleteButton = e.component;
+        }
+      }
     });
   }
 }

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/App.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/App.js
@@ -50,7 +50,9 @@ class App extends React.Component {
           <Paging enabled={false} />
           <Editing
             mode="cell"
-            allowUpdating={true} />
+            allowUpdating={true}
+            allowAdding={true}
+            allowDeleting={true} />
 
           <Column dataField="Prefix" caption="Title" width={55} />
           <Column dataField="FirstName" />

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/styles.css
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/styles.css
@@ -2,10 +2,6 @@
     min-height: 700px;
 }
 
-#gridContainer {
-    padding-top: 45px;
-}
-
 #gridDeleteSelected {
     position: absolute;
     z-index: 1;

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Vue/App.vue
@@ -1,18 +1,12 @@
 <template>
   <div id="data-grid-demo">
-    <DxButton
-      id="gridDeleteSelected"
-      :height="34"
-      :disabled="!selectedItemKeys.length"
-      text="Delete Selected Records"
-      @click="deleteRecords"
-    />
     <DxDataGrid
       id="gridContainer"
       :data-source="dataSource"
       :show-borders="true"
       :selected-row-keys="selectedItemKeys"
       @selection-changed="selectionChanged"
+      @toolbar-preparing="onToolbarPreparing"
     >
       <DxEditing
         :allow-updating="true"
@@ -93,6 +87,7 @@ export default {
       states: states,
       selectionChanged: (data)=>{
         this.selectedItemKeys = data.selectedRowKeys;
+        this.deleteButton.option('disabled', !data.selectedRowsData.length);
       },
       deleteRecords:()=>{
         this.selectedItemKeys.forEach((key) => {
@@ -100,18 +95,34 @@ export default {
         });
         this.selectedItemKeys = [];
         this.dataSource.reload();
+        this.deleteButton.option('disabled', true);
       }
     };
+  },
+  methods: {
+    onToolbarPreparing(e) {
+      e.toolbarOptions.items[0].showText = 'always';
+
+      e.toolbarOptions.items.unshift({
+        location: 'after',
+        widget: 'dxButton',
+        options: {
+          text: 'Delete Selected Records',
+          icon: 'trash',
+          disabled: true,
+          onClick: this.deleteRecords.bind(this),
+          onInitialized: (e) => {
+            this.deleteButton = e.component;
+          }
+        }
+      });
+    }
   }
 };
 </script>
 <style>
 #data-grid-demo {
     min-height: 700px;
-}
-
-#gridContainer {
-    padding-top: 45px;
 }
 
 #gridDeleteSelected {

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Vue/App.vue
@@ -16,6 +16,8 @@
     >
       <DxEditing
         :allow-updating="true"
+        :allow-adding="true"
+        :allow-deleting="true"
         mode="cell"
       />
       <DxPaging :enabled="false"/>

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/jQuery/index.js
@@ -24,7 +24,9 @@ $(function(){
         },
         editing: {
             mode: "cell",
-            allowUpdating: true
+            allowUpdating: true,
+            allowAdding: true,
+            allowDeleting: true
         },
         selection: {
             mode: "multiple"

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/jQuery/index.js
@@ -4,17 +4,7 @@ $(function(){
         data: employees
     });
     
-    var deleteButton = $("#gridDeleteSelected").dxButton({
-        text: "Delete Selected Records",
-        height: 34,
-        disabled: true,
-        onClick: function () {
-            $.each(dataGrid.getSelectedRowKeys(), function() {
-                employeesStore.remove(this);
-            });
-            dataGrid.refresh();
-        }
-    }).dxButton("instance");
+    var deleteButton;
     
     var dataGrid = $("#gridContainer").dxDataGrid({
         dataSource: employeesStore,
@@ -31,9 +21,6 @@ $(function(){
         selection: {
             mode: "multiple"
         },
-        onSelectionChanged: function(data) {
-            deleteButton.option("disabled", !data.selectedRowsData.length);
-        }, 
         columns: [
             {
                 dataField: "Prefix",
@@ -56,8 +43,35 @@ $(function(){
             }, {
                 dataField: "BirthDate",
                 dataType: "date"
-            }
-        ]
+            },
+        ],
+        onToolbarPreparing: function(e) {
+            var dataGrid = e.component;
+            
+            e.toolbarOptions.items[0].showText = 'always';
+
+            e.toolbarOptions.items.unshift({
+                location: "after",
+                widget: "dxButton",
+                options: {
+                    text: "Delete Selected Records",
+                    icon: "trash",
+                    disabled: true,
+                    onClick: function() {
+                        dataGrid.getSelectedRowKeys().forEach((key) => {
+                            employeesStore.remove(key);
+                        });
+                        dataGrid.refresh();
+                    },
+                    onInitialized: function(e) {
+                        deleteButton = e.component;
+                    }
+                }
+            });
+        },
+        onSelectionChanged: function(data) {
+            deleteButton.option("disabled", !data.selectedRowsData.length);
+        },
     }).dxDataGrid("instance");
     
     

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/jQuery/styles.css
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/jQuery/styles.css
@@ -2,10 +2,6 @@
     min-height: 700px;
 }
 
-#gridContainer {
-    padding-top: 45px;
-}
-
 #gridDeleteSelected {
     position: absolute;
     z-index: 1;

--- a/JSDemos/Demos/DataGrid/FormEditing/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/FormEditing/Angular/app/app.component.html
@@ -8,7 +8,9 @@
         <dxo-paging [enabled]="false"></dxo-paging>
         <dxo-editing 
             mode="form"
-            [allowUpdating]="true">
+            [allowUpdating]="true"
+            [allowAdding]="true"
+            [allowDeleting]="true">
         </dxo-editing>
         
         <dxi-column dataField="Prefix" caption="Title" [width]="70"></dxi-column>

--- a/JSDemos/Demos/DataGrid/FormEditing/AngularJS/index.js
+++ b/JSDemos/Demos/DataGrid/FormEditing/AngularJS/index.js
@@ -10,7 +10,9 @@ DemoApp.controller('DemoController', function DemoController($scope) {
         },
         editing: {
             mode: "form",
-            allowUpdating: true
+            allowUpdating: true,
+            allowAdding: true,
+            allowDeleting: true
         },
         columns: [
             {

--- a/JSDemos/Demos/DataGrid/FormEditing/React/App.js
+++ b/JSDemos/Demos/DataGrid/FormEditing/React/App.js
@@ -25,7 +25,9 @@ class App extends React.Component {
           <Paging enabled={false} />
           <Editing
             mode="form"
-            allowUpdating={true} />
+            allowUpdating={true}
+            allowAdding={true}
+            allowDeleting={true} />
           <Column dataField="Prefix" caption="Title" width={70} />
           <Column dataField="FirstName" />
           <Column dataField="LastName" />

--- a/JSDemos/Demos/DataGrid/FormEditing/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/FormEditing/Vue/App.vue
@@ -7,6 +7,8 @@
     >
       <DxEditing
         :allow-updating="true"
+        :allow-adding="true"
+        :allow-deleting="true"
         mode="form"
       />
       <DxPaging :enabled="false"/>

--- a/JSDemos/Demos/DataGrid/FormEditing/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/FormEditing/jQuery/index.js
@@ -8,7 +8,9 @@ $(function(){
         },
         editing: {
             mode: "form",
-            allowUpdating: true
+            allowUpdating: true,
+            allowAdding: true,
+            allowDeleting: true
         },
         columns: [
             {

--- a/JSDemos/Demos/DataGrid/PopupEditing/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/PopupEditing/Angular/app/app.component.html
@@ -8,7 +8,9 @@
         <dxo-paging [enabled]="false"></dxo-paging>
         <dxo-editing 
             mode="popup"
-            [allowUpdating]="true">
+            [allowUpdating]="true"
+            [allowAdding]="true"
+            [allowDeleting]="true">
             <dxo-popup
                 title="Employee Info"
                 [showTitle]="true"

--- a/JSDemos/Demos/DataGrid/PopupEditing/AngularJS/index.js
+++ b/JSDemos/Demos/DataGrid/PopupEditing/AngularJS/index.js
@@ -8,6 +8,8 @@ DemoApp.controller('DemoController', function DemoController($scope) {
         editing: {
             mode: "popup",
             allowUpdating: true,
+            allowAdding: true,
+            allowDeleting: true,
             popup: {
                 title: "Employee Info",
                 showTitle: true,

--- a/JSDemos/Demos/DataGrid/PopupEditing/React/App.js
+++ b/JSDemos/Demos/DataGrid/PopupEditing/React/App.js
@@ -26,7 +26,9 @@ class App extends React.Component {
           <Paging enabled={false} />
           <Editing
             mode="popup"
-            allowUpdating={true}>
+            allowUpdating={true}
+            allowAdding={true}
+            allowDeleting={true}>
             <Popup title="Employee Info" showTitle={true} width={700} height={525} />
             <Form>
               <Item itemType="group" colCount={2} colSpan={2}>

--- a/JSDemos/Demos/DataGrid/PopupEditing/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/PopupEditing/Vue/App.vue
@@ -8,6 +8,8 @@
       <DxPaging :enabled="false"/>
       <DxEditing
         :allow-updating="true"
+        :allow-adding="true"
+        :allow-deleting="true"
         mode="popup"
       >
         <DxPopup

--- a/JSDemos/Demos/DataGrid/PopupEditing/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/PopupEditing/jQuery/index.js
@@ -6,6 +6,8 @@ $(function(){
         editing: {
             mode: "popup",
             allowUpdating: true,
+            allowAdding: true,
+            allowDeleting: true,
             popup: {
                 title: "Employee Info",
                 showTitle: true,

--- a/MVCDemos/Views/DataGrid/BatchEditing.cshtml
+++ b/MVCDemos/Views/DataGrid/BatchEditing.cshtml
@@ -32,7 +32,7 @@
 
             columns.AddFor(m => m.BirthDate);
         })
-        .DataSource(d => d.WebApi().Controller("DataGridEmployees").UpdateAction(true).Key("ID"))
+        .DataSource(d => d.WebApi().Controller("DataGridEmployees").UpdateAction(true).InsertAction(true).DeleteAction(true).Key("ID"))
     )
 
     <div class="options">

--- a/MVCDemos/Views/DataGrid/BatchEditing.cshtml
+++ b/MVCDemos/Views/DataGrid/BatchEditing.cshtml
@@ -6,6 +6,8 @@
         .Editing(editing => {
             editing.Mode(GridEditMode.Batch);
             editing.AllowUpdating(true);
+            editing.AllowAdding(true);
+            editing.AllowDeleting(true);
             editing.SelectTextOnEditStart(true);
             editing.StartEditAction(GridStartEditAction.Click);
         })

--- a/MVCDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
+++ b/MVCDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
@@ -14,6 +14,8 @@
         .Editing(editing => {
             editing.Mode(GridEditMode.Cell);
             editing.AllowUpdating(true);
+            editing.AllowAdding(true);
+            editing.AllowDeleting(true);
         })
         .Selection(selection => selection.Mode(SelectionMode.Multiple))
         .OnSelectionChanged("onSelectionChanged")

--- a/MVCDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
+++ b/MVCDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
@@ -1,12 +1,4 @@
 ﻿<div id="data-grid-demo">
-    @(Html.DevExtreme().Button()
-        .ID("gridDeleteSelected")
-        .Text("Delete Selected Records")
-        .Height(34)
-        .Disabled(true)
-        .OnClick("onDeleteBtnClick")
-    )
-
     @(Html.DevExtreme().DataGrid<DevExtreme.MVC.Demos.Models.DataGrid.Employee>()
         .ID("gridContainer")
         .Paging(paging => paging.Enabled(false))
@@ -41,10 +33,33 @@
             columns.AddFor(m => m.BirthDate);
         })
         .DataSource(d => d.WebApi().Controller("DataGridEmployees").UpdateAction(true).DeleteAction(true).Key("ID"))
+        .OnToolbarPreparing("onToolbarPreparing")
     )
 </div>
 
 <script>
+    let deleteButton;
+
+    function onToolbarPreparing(e) {
+        var dataGrid = e.component;
+
+        e.toolbarOptions.items[0].showText = 'always';
+
+        e.toolbarOptions.items.unshift({
+            location: "after",
+            widget: "dxButton",
+            options: {
+                text: "Delete Selected Records",
+                icon: "trash",
+                disabled: true,
+                onClick: onDeleteBtnClick,
+                onInitialized: function(e) {
+                    deleteButton = e.component;
+                }
+            }
+        });
+    }
+
     function onDeleteBtnClick(){
         let dataGrid = $("#gridContainer").dxDataGrid("instance");
         $.when.apply($, dataGrid.getSelectedRowsData().map(function(data) {
@@ -55,7 +70,6 @@
     }
 
     function onSelectionChanged(data){
-        let deleteButton = $("#gridDeleteSelected").dxButton("instance");
         deleteButton.option("disabled", !data.selectedRowsData.length);
     }
 </script>

--- a/MVCDemos/Views/DataGrid/FormEditing.cshtml
+++ b/MVCDemos/Views/DataGrid/FormEditing.cshtml
@@ -6,6 +6,8 @@
         .Editing(editing => {
             editing.Mode(GridEditMode.Form);
             editing.AllowUpdating(true);
+            editing.AllowAdding(true);
+            editing.AllowDeleting(true);
         })
         .Columns(columns => {
             columns.AddFor(m => m.Prefix)

--- a/MVCDemos/Views/DataGrid/PopupEditing.cshtml
+++ b/MVCDemos/Views/DataGrid/PopupEditing.cshtml
@@ -5,6 +5,8 @@
         .Paging(p => p.Enabled(false))
         .Editing(e => e.Mode(GridEditMode.Popup)
             .AllowUpdating(true)
+            .AllowAdding(true)
+            .AllowDeleting(true)
             .Popup(p => p
                 .Title("Employee Info")
                 .ShowTitle(true)

--- a/NetCoreDemos/Views/DataGrid/BatchEditing.cshtml
+++ b/NetCoreDemos/Views/DataGrid/BatchEditing.cshtml
@@ -36,6 +36,8 @@
             .Controller("DataGridEmployees")
             .LoadAction("Get")
             .UpdateAction("Put")
+            .InsertAction("Post")
+            .DeleteAction("Delete")
             .Key("ID")
         )
     )

--- a/NetCoreDemos/Views/DataGrid/BatchEditing.cshtml
+++ b/NetCoreDemos/Views/DataGrid/BatchEditing.cshtml
@@ -6,6 +6,8 @@
         .Editing(editing => {
             editing.Mode(GridEditMode.Batch);
             editing.AllowUpdating(true);
+            editing.AllowAdding(true);
+            editing.AllowDeleting(true);
             editing.SelectTextOnEditStart(true);
             editing.StartEditAction(GridStartEditAction.Click);
         })

--- a/NetCoreDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
+++ b/NetCoreDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
@@ -14,6 +14,8 @@
         .Editing(editing => {
             editing.Mode(GridEditMode.Cell);
             editing.AllowUpdating(true);
+            editing.AllowAdding(true);
+            editing.AllowDeleting(true);
         })
         .Selection(selection => selection.Mode(SelectionMode.Multiple))
         .OnSelectionChanged("onSelectionChanged")

--- a/NetCoreDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
+++ b/NetCoreDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
@@ -1,12 +1,4 @@
 ﻿<div id="data-grid-demo">
-    @(Html.DevExtreme().Button()
-        .ID("gridDeleteSelected")
-        .Text("Delete Selected Records")
-        .Height(34)
-        .Disabled(true)
-        .OnClick("onDeleteBtnClick")
-    )
-
     @(Html.DevExtreme().DataGrid<DevExtreme.NETCore.Demos.Models.DataGrid.Employee>()
         .ID("gridContainer")
         .ShowBorders(true)
@@ -47,10 +39,33 @@
             .DeleteAction("Delete")
             .Key("ID")
         )
+        .OnToolbarPreparing("onToolbarPreparing")
     )
 </div>
 
 <script>
+    let deleteButton;
+
+    function onToolbarPreparing(e) {
+        var dataGrid = e.component;
+
+        e.toolbarOptions.items[0].showText = 'always';
+
+        e.toolbarOptions.items.unshift({
+            location: "after",
+            widget: "dxButton",
+            options: {
+                text: "Delete Selected Records",
+                icon: "trash",
+                disabled: true,
+                onClick: onDeleteBtnClick,
+                onInitialized: function(e) {
+                    deleteButton = e.component;
+                }
+            }
+        });
+    }
+
     function onDeleteBtnClick(){
         let dataGrid = $("#gridContainer").dxDataGrid("instance");
         $.when.apply($, dataGrid.getSelectedRowsData().map(function(data) {
@@ -61,7 +76,6 @@
     }
 
     function onSelectionChanged(data){
-        let deleteButton = $("#gridDeleteSelected").dxButton("instance");
         deleteButton.option("disabled", !data.selectedRowsData.length);
     }
 </script>

--- a/NetCoreDemos/Views/DataGrid/FormEditing.cshtml
+++ b/NetCoreDemos/Views/DataGrid/FormEditing.cshtml
@@ -6,6 +6,8 @@
         .Editing(editing => {
             editing.Mode(GridEditMode.Form);
             editing.AllowUpdating(true);
+            editing.AllowAdding(true);
+            editing.AllowDeleting(true);
         })
         .Columns(columns => {
             columns.AddFor(m => m.Prefix)

--- a/NetCoreDemos/Views/DataGrid/PopupEditing.cshtml
+++ b/NetCoreDemos/Views/DataGrid/PopupEditing.cshtml
@@ -5,6 +5,8 @@
         .Paging(p => p.Enabled(false))
         .Editing(e => e.Mode(GridEditMode.Popup)
             .AllowUpdating(true)
+            .AllowAdding(true)
+            .AllowDeleting(true)
             .Popup(p => p
                 .Title("Employee Info")
                 .ShowTitle(true)


### PR DESCRIPTION
Trello card: https://trello.com/c/2PGEE5dt/5156-add-allowadding-allowdeleting-options-to-editing-demos-with-modes

Cherry picks:

- https://github.com/DevExpress/devextreme-demos/pull/914

Previous pull requests that failed the tests:

- https://github.com/DevExpress/devextreme-demos/pull/895
- https://github.com/DevExpress/devextreme-demos/pull/896

---

I changed DataGrid CellEditingAndEditingAPI

| from this | to that |
|-|-|
| ![image](https://user-images.githubusercontent.com/84017191/119658806-387a9080-be36-11eb-91f3-d2571208a57c.png) | ![image](https://user-images.githubusercontent.com/84017191/119658653-13861d80-be36-11eb-9506-e2bab9154ec6.png) |

(button placement in header is changed)
