### PR TITLE
DataGrid CellEditing Demo - fix buttons placement (21.1)

### DIFF
--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.css
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.css
@@ -2,9 +2,6 @@
     min-height: 700px;
 }
 
-::ng-deep #gridContainer {
-    padding-top: 45px;
-}
 ::ng-deep #gridDeleteSelected {
     position: absolute;
     z-index: 1;

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.html
@@ -1,15 +1,10 @@
 <div id="data-grid-demo">
-    <dx-button id="gridDeleteSelected"
-        text="Delete Selected Records"
-        [height]="34"
-        [disabled]="!selectedItemKeys.length"
-        (onClick)="deleteRecords()">
-    </dx-button>
     <dx-data-grid 
         id="gridContainer"
         [dataSource]="dataSource"
         [showBorders]="true"
-        (onSelectionChanged)="selectionChanged($event)">
+        (onSelectionChanged)="selectionChanged($event)"
+        (onToolbarPreparing)="onToolbarPreparing($event)">
         
         <dxo-paging [enabled]="false"></dxo-paging>
         <dxo-editing 

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.html
@@ -33,6 +33,15 @@
             dataField="BirthDate"
             dataType="date">
         </dxi-column>
+
+        <dx-button
+            *dxTemplate="let data of 'deleteButton'"
+            (onClick)="deleteRecords()"
+            [disabled]="!selectedItemKeys.length"
+            icon="trash"
+            text="Delete Selected Records">
+        </dx-button>
+
     </dx-data-grid>
 </div>
 

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.ts
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.ts
@@ -22,6 +22,7 @@ export class AppComponent {
     dataSource: ArrayStore;
     states: State[];
     selectedItemKeys: any[] = [];
+    deleteButton: any;
 
     constructor(service: Service) {
         this.dataSource = new ArrayStore({
@@ -33,12 +34,33 @@ export class AppComponent {
 
     selectionChanged(data: any) {
         this.selectedItemKeys = data.selectedRowKeys;
+        this.deleteButton.option("disabled", !data.selectedRowsData.length);
     }
+
     deleteRecords() {
         this.selectedItemKeys.forEach((key) => {
             this.dataSource.remove(key);
         });
         this.dataGrid.instance.refresh();
+        this.deleteButton.option("disabled", true);
+    }
+
+    onToolbarPreparing(e) {
+        e.toolbarOptions.items[0].showText = 'always';
+
+        e.toolbarOptions.items.unshift({
+            location: "after",
+            widget: "dxButton",
+            options: {
+                text: "Delete Selected Records",
+                icon: "trash",
+                disabled: true,
+                onClick: this.deleteRecords.bind(this),
+                onInitialized: (e) => {
+                    this.deleteButton = e.component;
+                }
+            }
+        });
     }
 }
 

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.ts
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.ts
@@ -48,7 +48,7 @@ export class AppComponent {
     onToolbarPreparing(e) {
         e.toolbarOptions.items[0].showText = 'always';
 
-        e.toolbarOptions.items.unshift({
+        e.toolbarOptions.items.push({
             location: "after",
             widget: "dxButton",
             options: {

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.ts
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/app/app.component.ts
@@ -22,7 +22,6 @@ export class AppComponent {
     dataSource: ArrayStore;
     states: State[];
     selectedItemKeys: any[] = [];
-    deleteButton: any;
 
     constructor(service: Service) {
         this.dataSource = new ArrayStore({
@@ -34,7 +33,6 @@ export class AppComponent {
 
     selectionChanged(data: any) {
         this.selectedItemKeys = data.selectedRowKeys;
-        this.deleteButton.option("disabled", !data.selectedRowsData.length);
     }
 
     deleteRecords() {
@@ -42,7 +40,6 @@ export class AppComponent {
             this.dataSource.remove(key);
         });
         this.dataGrid.instance.refresh();
-        this.deleteButton.option("disabled", true);
     }
 
     onToolbarPreparing(e) {
@@ -50,16 +47,7 @@ export class AppComponent {
 
         e.toolbarOptions.items.push({
             location: "after",
-            widget: "dxButton",
-            options: {
-                text: "Delete Selected Records",
-                icon: "trash",
-                disabled: true,
-                onClick: this.deleteRecords.bind(this),
-                onInitialized: (e) => {
-                    this.deleteButton = e.component;
-                }
-            }
+            template: "deleteButton"
         });
     }
 }

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/index.html
@@ -17,7 +17,6 @@
 <body class="dx-viewport">
     <div class="demo-container" ng-app="DemoApp" ng-controller="DemoController">
         <div id="data-grid-demo">
-            <div id="gridDeleteSelected" dx-button="buttonOptions"></div>
             <div id="gridContainer" dx-data-grid="dataGridOptions"></div>
         </div>
     </div>

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/index.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/index.js
@@ -9,20 +9,6 @@ DemoApp.controller('DemoController', function DemoController($scope) {
     $scope.selectedItemKeys = [];
     $scope.disabled = true;
     
-    $scope.buttonOptions = {
-        text: "Delete Selected Records",
-        height: 34,
-        onClick: function () {
-            $.each($scope.selectedItemKeys, function() {
-                employeesStore.remove(this);
-            });
-            $("#gridContainer").dxDataGrid("instance").refresh();
-        },
-        bindingOptions: {
-            disabled: "disabled"
-        }
-    };
-    
     $scope.dataGridOptions = {
         dataSource: employeesStore,
         showBorders: true,
@@ -65,7 +51,31 @@ DemoApp.controller('DemoController', function DemoController($scope) {
                 dataField: "BirthDate",
                 dataType: "date"
             }
-        ]
+        ],
+        onToolbarPreparing: function(e) {
+            var dataGrid = e.component;
+            
+            e.toolbarOptions.items[0].showText = 'always';
+
+            e.toolbarOptions.items.unshift({
+                location: "after",
+                widget: "dxButton",
+                options: {
+                    text: "Delete Selected Records",
+                    icon: "trash",
+                    disabled: true,
+                    onClick: function() {
+                        dataGrid.getSelectedRowKeys().forEach((key) => {
+                            employeesStore.remove(key);
+                        });
+                        dataGrid.refresh();
+                    },
+                    bindingOptions: {
+                        disabled: "disabled"
+                    }
+                }
+            });
+        }
     };
     
 });

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/index.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/index.js
@@ -57,7 +57,7 @@ DemoApp.controller('DemoController', function DemoController($scope) {
             
             e.toolbarOptions.items[0].showText = 'always';
 
-            e.toolbarOptions.items.unshift({
+            e.toolbarOptions.items.push({
                 location: "after",
                 widget: "dxButton",
                 options: {

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/index.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/index.js
@@ -8,6 +8,20 @@ DemoApp.controller('DemoController', function DemoController($scope) {
         
     $scope.selectedItemKeys = [];
     $scope.disabled = true;
+
+    $scope.buttonOptions = {
+        text: "Delete Selected Records",
+        icon: "trash",
+        onClick: function () {
+            $.each($scope.selectedItemKeys, function() {
+                employeesStore.remove(this);
+            });
+            $("#gridContainer").dxDataGrid("instance").refresh();
+        },
+        bindingOptions: {
+            disabled: "disabled"
+        }
+    };   
     
     $scope.dataGridOptions = {
         dataSource: employeesStore,
@@ -53,27 +67,12 @@ DemoApp.controller('DemoController', function DemoController($scope) {
             }
         ],
         onToolbarPreparing: function(e) {
-            var dataGrid = e.component;
-            
             e.toolbarOptions.items[0].showText = 'always';
 
             e.toolbarOptions.items.push({
                 location: "after",
                 widget: "dxButton",
-                options: {
-                    text: "Delete Selected Records",
-                    icon: "trash",
-                    disabled: true,
-                    onClick: function() {
-                        dataGrid.getSelectedRowKeys().forEach((key) => {
-                            employeesStore.remove(key);
-                        });
-                        dataGrid.refresh();
-                    },
-                    bindingOptions: {
-                        disabled: "disabled"
-                    }
-                }
+                options: $scope.buttonOptions
             });
         }
     };

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/styles.css
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/styles.css
@@ -2,10 +2,6 @@
     min-height: 700px;
 }
 
-#gridContainer {
-    padding-top: 45px;
-}
-
 #gridDeleteSelected {
     position: absolute;
     z-index: 1;

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/App.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/App.js
@@ -80,7 +80,7 @@ class App extends React.Component {
   onToolbarPreparing(e) {
     e.toolbarOptions.items[0].showText = 'always';
 
-    e.toolbarOptions.items.unshift({
+    e.toolbarOptions.items.push({
       location: 'after',
       widget: 'dxButton',
       options: {

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/App.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/App.js
@@ -7,7 +7,6 @@ import DataGrid, {
   Selection,
   Lookup
 } from 'devextreme-react/data-grid';
-import { Button } from 'devextreme-react/button';
 
 import ArrayStore from 'devextreme/data/array_store';
 import DataSource from 'devextreme/data/data_source';
@@ -28,23 +27,19 @@ class App extends React.Component {
     };
     this.selectionChanged = this.selectionChanged.bind(this);
     this.deleteRecords = this.deleteRecords.bind(this);
+    this.onToolbarPreparing = this.onToolbarPreparing.bind(this);
   }
 
   render() {
 
     return (
       <div id="data-grid-demo">
-        <Button id="gridDeleteSelected"
-          text="Delete Selected Records"
-          height={34}
-          disabled={!this.state.selectedItemKeys.length}
-          onClick={this.deleteRecords} />
-
         <DataGrid id="gridContainer"
           dataSource={dataSource}
           showBorders={true}
           selectedRowKeys={this.state.selectedItemKeys}
           onSelectionChanged={this.selectionChanged}
+          onToolbarPreparing={this.onToolbarPreparing}
         >
           <Selection mode="multiple" />
           <Paging enabled={false} />
@@ -74,10 +69,29 @@ class App extends React.Component {
       selectedItemKeys: []
     });
     dataSource.reload();
+    this.deleteButton.option('disabled', true);
   }
   selectionChanged(data) {
     this.setState({
       selectedItemKeys: data.selectedRowKeys
+    });
+    this.deleteButton.option('disabled', !data.selectedRowsData.length);
+  }
+  onToolbarPreparing(e) {
+    e.toolbarOptions.items[0].showText = 'always';
+
+    e.toolbarOptions.items.unshift({
+      location: 'after',
+      widget: 'dxButton',
+      options: {
+        text: 'Delete Selected Records',
+        icon: 'trash',
+        disabled: true,
+        onClick: this.deleteRecords.bind(this),
+        onInitialized: (e) => {
+          this.deleteButton = e.component;
+        }
+      }
     });
   }
 }

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/App.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/App.js
@@ -8,6 +8,9 @@ import DataGrid, {
   Lookup
 } from 'devextreme-react/data-grid';
 
+import { Button } from 'devextreme-react/button';
+import { Template } from 'devextreme-react/core/template';
+
 import ArrayStore from 'devextreme/data/array_store';
 import DataSource from 'devextreme/data/data_source';
 import { employees, states } from './data.js';
@@ -27,6 +30,7 @@ class App extends React.Component {
     };
     this.selectionChanged = this.selectionChanged.bind(this);
     this.deleteRecords = this.deleteRecords.bind(this);
+    this.deleteButtonRender = this.deleteButtonRender.bind(this);
     this.onToolbarPreparing = this.onToolbarPreparing.bind(this);
   }
 
@@ -57,9 +61,18 @@ class App extends React.Component {
             <Lookup dataSource={states} valueExpr="ID" displayExpr="Name" />
           </Column>
           <Column dataField="BirthDate" dataType="date" />
+          <Template name="deleteButton" render={this.deleteButtonRender} />
         </DataGrid>
       </div>
     );
+  }
+  deleteButtonRender() {
+    return <Button
+      onClick={this.deleteRecords}
+      icon="trash"
+      disabled={!this.state.selectedItemKeys.length}
+      text="Delete Selected Records">
+    </Button>
   }
   deleteRecords() {
     this.state.selectedItemKeys.forEach((key) => {
@@ -69,29 +82,18 @@ class App extends React.Component {
       selectedItemKeys: []
     });
     dataSource.reload();
-    this.deleteButton.option('disabled', true);
   }
   selectionChanged(data) {
     this.setState({
       selectedItemKeys: data.selectedRowKeys
     });
-    this.deleteButton.option('disabled', !data.selectedRowsData.length);
   }
   onToolbarPreparing(e) {
     e.toolbarOptions.items[0].showText = 'always';
 
     e.toolbarOptions.items.push({
       location: 'after',
-      widget: 'dxButton',
-      options: {
-        text: 'Delete Selected Records',
-        icon: 'trash',
-        disabled: true,
-        onClick: this.deleteRecords.bind(this),
-        onInitialized: (e) => {
-          this.deleteButton = e.component;
-        }
-      }
+      template: 'deleteButton'
     });
   }
 }

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/App.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/App.js
@@ -72,7 +72,7 @@ class App extends React.Component {
       icon="trash"
       disabled={!this.state.selectedItemKeys.length}
       text="Delete Selected Records">
-    </Button>
+    </Button>;
   }
   deleteRecords() {
     this.state.selectedItemKeys.forEach((key) => {

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/styles.css
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/styles.css
@@ -2,10 +2,6 @@
     min-height: 700px;
 }
 
-#gridContainer {
-    padding-top: 45px;
-}
-
 #gridDeleteSelected {
     position: absolute;
     z-index: 1;

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Vue/App.vue
@@ -1,18 +1,12 @@
 <template>
   <div id="data-grid-demo">
-    <DxButton
-      id="gridDeleteSelected"
-      :height="34"
-      :disabled="!selectedItemKeys.length"
-      text="Delete Selected Records"
-      @click="deleteRecords"
-    />
     <DxDataGrid
       id="gridContainer"
       :data-source="dataSource"
       :show-borders="true"
       :selected-row-keys="selectedItemKeys"
       @selection-changed="selectionChanged"
+      @toolbar-preparing="onToolbarPreparing"
     >
       <DxEditing
         :allow-updating="true"
@@ -93,6 +87,7 @@ export default {
       states: states,
       selectionChanged: (data)=>{
         this.selectedItemKeys = data.selectedRowKeys;
+        this.deleteButton.option('disabled', !data.selectedRowsData.length);
       },
       deleteRecords:()=>{
         this.selectedItemKeys.forEach((key) => {
@@ -100,18 +95,34 @@ export default {
         });
         this.selectedItemKeys = [];
         this.dataSource.reload();
+        this.deleteButton.option('disabled', true);
       }
     };
+  },
+  methods: {
+    onToolbarPreparing(e) {
+      e.toolbarOptions.items[0].showText = 'always';
+
+      e.toolbarOptions.items.unshift({
+        location: 'after',
+        widget: 'dxButton',
+        options: {
+          text: 'Delete Selected Records',
+          icon: 'trash',
+          disabled: true,
+          onClick: this.deleteRecords.bind(this),
+          onInitialized: (e) => {
+            this.deleteButton = e.component;
+          }
+        }
+      });
+    }
   }
 };
 </script>
 <style>
 #data-grid-demo {
     min-height: 700px;
-}
-
-#gridContainer {
-    padding-top: 45px;
 }
 
 #gridDeleteSelected {

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Vue/App.vue
@@ -103,7 +103,7 @@ export default {
     onToolbarPreparing(e) {
       e.toolbarOptions.items[0].showText = 'always';
 
-      e.toolbarOptions.items.unshift({
+      e.toolbarOptions.items.push({
         location: 'after',
         widget: 'dxButton',
         options: {

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Vue/App.vue
@@ -46,6 +46,14 @@
         data-field="BirthDate"
         data-type="date"
       />
+      <template #deleteButton>
+        <DxButton
+          @click="deleteRecords()"
+          :disabled="!selectedItemKeys.length"
+          icon="trash"
+          text="Delete Selected Records">
+        </DxButton>
+      </template>
     </DxDataGrid>
   </div>
 </template>
@@ -87,7 +95,6 @@ export default {
       states: states,
       selectionChanged: (data)=>{
         this.selectedItemKeys = data.selectedRowKeys;
-        this.deleteButton.option('disabled', !data.selectedRowsData.length);
       },
       deleteRecords:()=>{
         this.selectedItemKeys.forEach((key) => {
@@ -95,7 +102,6 @@ export default {
         });
         this.selectedItemKeys = [];
         this.dataSource.reload();
-        this.deleteButton.option('disabled', true);
       }
     };
   },
@@ -105,16 +111,7 @@ export default {
 
       e.toolbarOptions.items.push({
         location: 'after',
-        widget: 'dxButton',
-        options: {
-          text: 'Delete Selected Records',
-          icon: 'trash',
-          disabled: true,
-          onClick: this.deleteRecords.bind(this),
-          onInitialized: (e) => {
-            this.deleteButton = e.component;
-          }
-        }
+        template: 'deleteButton'
       });
     }
   }

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Vue/App.vue
@@ -51,8 +51,8 @@
           @click="deleteRecords()"
           :disabled="!selectedItemKeys.length"
           icon="trash"
-          text="Delete Selected Records">
-        </DxButton>
+          text="Delete Selected Records"
+        />
       </template>
     </DxDataGrid>
   </div>

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/jQuery/index.js
@@ -50,7 +50,7 @@ $(function(){
             
             e.toolbarOptions.items[0].showText = 'always';
 
-            e.toolbarOptions.items.unshift({
+            e.toolbarOptions.items.push({
                 location: "after",
                 widget: "dxButton",
                 options: {

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/jQuery/index.js
@@ -4,17 +4,7 @@ $(function(){
         data: employees
     });
     
-    var deleteButton = $("#gridDeleteSelected").dxButton({
-        text: "Delete Selected Records",
-        height: 34,
-        disabled: true,
-        onClick: function () {
-            $.each(dataGrid.getSelectedRowKeys(), function() {
-                employeesStore.remove(this);
-            });
-            dataGrid.refresh();
-        }
-    }).dxButton("instance");
+    var deleteButton;
     
     var dataGrid = $("#gridContainer").dxDataGrid({
         dataSource: employeesStore,
@@ -31,9 +21,6 @@ $(function(){
         selection: {
             mode: "multiple"
         },
-        onSelectionChanged: function(data) {
-            deleteButton.option("disabled", !data.selectedRowsData.length);
-        }, 
         columns: [
             {
                 dataField: "Prefix",
@@ -56,8 +43,35 @@ $(function(){
             }, {
                 dataField: "BirthDate",
                 dataType: "date"
-            }
-        ]
+            },
+        ],
+        onToolbarPreparing: function(e) {
+            var dataGrid = e.component;
+            
+            e.toolbarOptions.items[0].showText = 'always';
+
+            e.toolbarOptions.items.unshift({
+                location: "after",
+                widget: "dxButton",
+                options: {
+                    text: "Delete Selected Records",
+                    icon: "trash",
+                    disabled: true,
+                    onClick: function() {
+                        dataGrid.getSelectedRowKeys().forEach((key) => {
+                            employeesStore.remove(key);
+                        });
+                        dataGrid.refresh();
+                    },
+                    onInitialized: function(e) {
+                        deleteButton = e.component;
+                    }
+                }
+            });
+        },
+        onSelectionChanged: function(data) {
+            deleteButton.option("disabled", !data.selectedRowsData.length);
+        },
     }).dxDataGrid("instance");
     
     

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/jQuery/index.js
@@ -5,6 +5,20 @@ $(function(){
     });
     
     var deleteButton;
+    var deleteButtonOptions = {
+        text: "Delete Selected Records",
+        icon: "trash",
+        disabled: true,
+        onClick: function() {
+            dataGrid.getSelectedRowKeys().forEach((key) => {
+                employeesStore.remove(key);
+            });
+            dataGrid.refresh();
+        },
+        onInitialized: function(e) {
+            deleteButton = e.component;
+        }
+    };
     
     var dataGrid = $("#gridContainer").dxDataGrid({
         dataSource: employeesStore,
@@ -53,20 +67,7 @@ $(function(){
             e.toolbarOptions.items.push({
                 location: "after",
                 widget: "dxButton",
-                options: {
-                    text: "Delete Selected Records",
-                    icon: "trash",
-                    disabled: true,
-                    onClick: function() {
-                        dataGrid.getSelectedRowKeys().forEach((key) => {
-                            employeesStore.remove(key);
-                        });
-                        dataGrid.refresh();
-                    },
-                    onInitialized: function(e) {
-                        deleteButton = e.component;
-                    }
-                }
+                options: deleteButtonOptions
             });
         },
         onSelectionChanged: function(data) {

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/jQuery/styles.css
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/jQuery/styles.css
@@ -2,10 +2,6 @@
     min-height: 700px;
 }
 
-#gridContainer {
-    padding-top: 45px;
-}
-
 #gridDeleteSelected {
     position: absolute;
     z-index: 1;

--- a/MVCDemos/Content/DemosStyles/DataGrid/CellEditingAndEditingAPI.css
+++ b/MVCDemos/Content/DemosStyles/DataGrid/CellEditingAndEditingAPI.css
@@ -2,10 +2,6 @@
     min-height: 700px;
 }
 
-#gridContainer {
-    padding-top: 45px;
-}
-
 #gridDeleteSelected {
     position: absolute;
     z-index: 1;

--- a/MVCDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
+++ b/MVCDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
@@ -1,12 +1,4 @@
 ﻿<div id="data-grid-demo">
-    @(Html.DevExtreme().Button()
-        .ID("gridDeleteSelected")
-        .Text("Delete Selected Records")
-        .Height(34)
-        .Disabled(true)
-        .OnClick("onDeleteBtnClick")
-    )
-
     @(Html.DevExtreme().DataGrid<DevExtreme.MVC.Demos.Models.DataGrid.Employee>()
         .ID("gridContainer")
         .Paging(paging => paging.Enabled(false))
@@ -41,10 +33,33 @@
             columns.AddFor(m => m.BirthDate);
         })
         .DataSource(d => d.WebApi().Controller("DataGridEmployees").UpdateAction(true).DeleteAction(true).Key("ID"))
+        .OnToolbarPreparing("onToolbarPreparing")
     )
 </div>
 
 <script>
+    let deleteButton;
+
+    function onToolbarPreparing(e) {
+        var dataGrid = e.component;
+
+        e.toolbarOptions.items[0].showText = 'always';
+
+        e.toolbarOptions.items.unshift({
+            location: "after",
+            widget: "dxButton",
+            options: {
+                text: "Delete Selected Records",
+                icon: "trash",
+                disabled: true,
+                onClick: onDeleteBtnClick,
+                onInitialized: function(e) {
+                    deleteButton = e.component;
+                }
+            }
+        });
+    }
+
     function onDeleteBtnClick(){
         let dataGrid = $("#gridContainer").dxDataGrid("instance");
         $.when.apply($, dataGrid.getSelectedRowsData().map(function(data) {
@@ -55,7 +70,6 @@
     }
 
     function onSelectionChanged(data){
-        let deleteButton = $("#gridDeleteSelected").dxButton("instance");
         deleteButton.option("disabled", !data.selectedRowsData.length);
     }
 </script>

--- a/NetCoreDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
+++ b/NetCoreDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
@@ -1,12 +1,4 @@
 ﻿<div id="data-grid-demo">
-    @(Html.DevExtreme().Button()
-        .ID("gridDeleteSelected")
-        .Text("Delete Selected Records")
-        .Height(34)
-        .Disabled(true)
-        .OnClick("onDeleteBtnClick")
-    )
-
     @(Html.DevExtreme().DataGrid<DevExtreme.NETCore.Demos.Models.DataGrid.Employee>()
         .ID("gridContainer")
         .ShowBorders(true)
@@ -47,10 +39,33 @@
             .DeleteAction("Delete")
             .Key("ID")
         )
+        .OnToolbarPreparing("onToolbarPreparing")
     )
 </div>
 
 <script>
+    let deleteButton;
+
+    function onToolbarPreparing(e) {
+        var dataGrid = e.component;
+
+        e.toolbarOptions.items[0].showText = 'always';
+
+        e.toolbarOptions.items.unshift({
+            location: "after",
+            widget: "dxButton",
+            options: {
+                text: "Delete Selected Records",
+                icon: "trash",
+                disabled: true,
+                onClick: onDeleteBtnClick,
+                onInitialized: function(e) {
+                    deleteButton = e.component;
+                }
+            }
+        });
+    }
+
     function onDeleteBtnClick(){
         let dataGrid = $("#gridContainer").dxDataGrid("instance");
         $.when.apply($, dataGrid.getSelectedRowsData().map(function(data) {
@@ -61,7 +76,6 @@
     }
 
     function onSelectionChanged(data){
-        let deleteButton = $("#gridDeleteSelected").dxButton("instance");
         deleteButton.option("disabled", !data.selectedRowsData.length);
     }
 </script>

--- a/NetCoreDemos/wwwroot/css/DemosStyles/DataGrid/CellEditingAndEditingAPI.css
+++ b/NetCoreDemos/wwwroot/css/DemosStyles/DataGrid/CellEditingAndEditingAPI.css
@@ -2,10 +2,6 @@
     min-height: 700px;
 }
 
-#gridContainer {
-    padding-top: 45px;
-}
-
 #gridDeleteSelected {
     position: absolute;
     z-index: 1;


### PR DESCRIPTION
Trello card: https://trello.com/c/2PGEE5dt/5156-add-allowadding-allowdeleting-options-to-editing-demos-with-modes

Cherry picks:

- https://github.com/DevExpress/devextreme-demos/pull/932

Previous pull requests which failed the tests:

- https://github.com/DevExpress/devextreme-demos/pull/895
- https://github.com/DevExpress/devextreme-demos/pull/896

---

I changed DataGrid CellEditingAndEditingAPI

| from this | to that |
|-|-|
| ![image](https://user-images.githubusercontent.com/84017191/119658806-387a9080-be36-11eb-91f3-d2571208a57c.png) | ![image](https://user-images.githubusercontent.com/84017191/119831561-12bcbc80-bf06-11eb-899d-78ba920eaa91.png) |

(button placement in header is changed)
