### PR TITLE
DataGrid - fix button order in CellEditing demo in MVC and netcore

### DIFF
--- a/MVCDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
+++ b/MVCDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
@@ -45,7 +45,7 @@
 
         e.toolbarOptions.items[0].showText = 'always';
 
-        e.toolbarOptions.items.unshift({
+        e.toolbarOptions.items.push({
             location: "after",
             widget: "dxButton",
             options: {

--- a/NetCoreDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
+++ b/NetCoreDemos/Views/DataGrid/CellEditingAndEditingAPI.cshtml
@@ -51,7 +51,7 @@
 
         e.toolbarOptions.items[0].showText = 'always';
 
-        e.toolbarOptions.items.unshift({
+        e.toolbarOptions.items.push({
             location: "after",
             widget: "dxButton",
             options: {


### PR DESCRIPTION
Trello card: https://trello.com/c/2PGEE5dt/5156-add-allowadding-allowdeleting-options-to-editing-demos-with-modes

Cherry picks:

- https://github.com/DevExpress/devextreme-demos/pull/944

Previous PRs that failed the tests:

- https://github.com/DevExpress/devextreme-demos/pull/931
- https://github.com/DevExpress/devextreme-demos/pull/932

---

I changed button order in `CellEditingAndEditingAPI`, but forgot about MVC and NETCore