### PR TITLE
TreeList - Row "data" property is missing (T1004318)

### DIFF
--- a/JSDemos/Demos/TreeList/LocalReordering/Angular/app/app.component.ts
+++ b/JSDemos/Demos/TreeList/LocalReordering/Angular/app/app.component.ts
@@ -46,7 +46,7 @@ export class AppComponent {
     onReorder(e) {
         let visibleRows =  e.component.getVisibleRows(),
             sourceData = e.itemData,
-            targetData = visibleRows[e.toIndex].data;
+            targetData = visibleRows[e.toIndex].node.data;
 
         if (e.dropInsideItem) {
             e.itemData.Head_ID = targetData.ID;

--- a/JSDemos/Demos/TreeList/LocalReordering/React/App.js
+++ b/JSDemos/Demos/TreeList/LocalReordering/React/App.js
@@ -98,7 +98,7 @@ class App extends React.Component {
   onReorder(e) {
     let visibleRows = e.component.getVisibleRows(),
       sourceData = e.itemData,
-      targetData = visibleRows[e.toIndex].data,
+      targetData = visibleRows[e.toIndex].node.data,
       employees = this.state.employees,
       sourceIndex = employees.indexOf(sourceData),
       targetIndex = employees.indexOf(targetData);

--- a/JSDemos/Demos/TreeList/LocalReordering/Vue/App.vue
+++ b/JSDemos/Demos/TreeList/LocalReordering/Vue/App.vue
@@ -93,7 +93,7 @@ export default {
     onReorder(e) {
       let visibleRows = e.component.getVisibleRows(),
         sourceData = e.itemData,
-        targetData = visibleRows[e.toIndex].data,
+        targetData = visibleRows[e.toIndex].node.data,
         employees = [...this.employees];
 
       if (e.dropInsideItem) {

--- a/JSDemos/Demos/TreeList/LocalReordering/jQuery/index.js
+++ b/JSDemos/Demos/TreeList/LocalReordering/jQuery/index.js
@@ -22,7 +22,7 @@ $(function() {
             onReorder: function(e) {
                 var visibleRows = e.component.getVisibleRows(),
                     sourceData = e.itemData,
-                    targetData = visibleRows[e.toIndex].data;
+                    targetData = visibleRows[e.toIndex].node.data;
 
                 if (e.dropInsideItem) {
                     e.itemData.Head_ID = targetData.ID;

--- a/MVCDemos/Views/TreeList/LocalReordering.cshtml
+++ b/MVCDemos/Views/TreeList/LocalReordering.cshtml
@@ -93,7 +93,7 @@
         var treeList = e.component,
             visibleRows = treeList.getVisibleRows(),
             sourceData = e.itemData,
-            targetData = visibleRows[e.toIndex].data;
+            targetData = visibleRows[e.toIndex].node.data;
 
         if (e.dropInsideItem) {
             e.itemData.Head_ID = targetData.ID;

--- a/NetCoreDemos/Views/TreeList/LocalReordering.cshtml
+++ b/NetCoreDemos/Views/TreeList/LocalReordering.cshtml
@@ -93,7 +93,7 @@
         var treeList = e.component,
             visibleRows = treeList.getVisibleRows(),
             sourceData = e.itemData,
-            targetData = visibleRows[e.toIndex].data;
+            targetData = visibleRows[e.toIndex].node.data;
 
         if (e.dropInsideItem) {
             e.itemData.Head_ID = targetData.ID;


### PR DESCRIPTION
|||
|-|-|
Trello | https://trello.com/c/JWfCpKuw/5794-t1004318-treelist-row-data-property-is-missing
Bug | https://supportcenter.devexpress.com/ticket/details/t1004318/treelist-row-data-property-is-missing

Cherry picks:

- https://github.com/DevExpress/devextreme-demos/pull/979

---

[Demo Node Drag & Drop of TreeList](https://js.devexpress.com/Demos/WidgetsGallery/Demo/TreeList/LocalReordering/Angular/Light/) used `.data` parameter instead of [`.node.data`](https://js.devexpress.com/Documentation/ApiReference/UI_Components/dxTreeList/Node/#data)