### PR TITLE
Scheduler - Remove extra method from the Angular time zones demo

### DIFF
--- a/JSDemos/Demos/Scheduler/TimeZonesSupport/Angular/app/app.component.ts
+++ b/JSDemos/Demos/Scheduler/TimeZonesSupport/Angular/app/app.component.ts
@@ -36,10 +36,6 @@ export class AppComponent {
             return service.getLocations().indexOf(timeZone.id) !== -1;
         });
     };
-
-    onValueChanged(e: any) {
-        this.timezone = e.value;
-    }
     
     onAppointmentFormOpening(e: any) {
         const form = e.form;


### PR DESCRIPTION
The extra method from the Angular demo is removed. Looks like a rudiment from the jQuery demos. 