### PR TITLE
Fix peer deps problem in renovate bot

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps = true


### PR DESCRIPTION
The following error is occured:
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! While resolving: devextreme-demos@21.2.0
npm ERR! Found: typescript@3.9.10
npm ERR! node_modules/typescript
npm ERR!   dev typescript@\"^3.7.2\" from the root project
npm ERR! npm ERR! Could not resolve dependency:
npm ERR! peer typescript@\"^2.4.0\" from plugin-typescript@8.0.0
npm ERR! node_modules/plugin-typescript
npm ERR!   plugin-typescript@\"8.0.0\" from the root project
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

in the renovate bot script: 
https://app.renovatebot.com/dashboard#github/DevExpress/devextreme-demos/445374293