### PR TITLE
DataGrid - fix MultipleRecordSelectionAPI 

### DIFF
--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/jQuery/index.js
@@ -1,6 +1,7 @@
 $(() => {
   let changedBySelectBox;
   let titleSelectBox;
+  let clearSelectionButton;
 
   const dataGrid = $('#grid-container').dxDataGrid({
     dataSource: employees,
@@ -26,13 +27,14 @@ $(() => {
       dataField: 'HireDate',
       dataType: 'date',
       width: 125,
-    },
-    ],
+    }],
     onSelectionChanged(selectedItems) {
       const data = selectedItems.selectedRowsData;
       if (data.length > 0) {
         $('#selected-items-container').text(
-          $.map(data, (value) => `${value.FirstName} ${value.LastName}`).join(', '),
+          data
+            .map((value) => `${value.FirstName} ${value.LastName}`)
+            .join(', '),
         );
       } else {
         $('#selected-items-container').text('Nobody has been selected');
@@ -42,7 +44,7 @@ $(() => {
       }
 
       changedBySelectBox = false;
-      dataGrid.option('toolbar.items[1].options.disabled', !data.length);
+      clearSelectionButton.option('disabled', !data.length);
     },
     toolbar: {
       items: [
@@ -54,12 +56,17 @@ $(() => {
             placeholder: 'Select title',
             width: '150px',
             onValueChanged(data) {
-              if (!data.value) { return; }
+              if (!data.value) {
+                return;
+              }
+
               changedBySelectBox = true;
               if (data.value === 'All') {
                 dataGrid.selectAll();
               } else {
-                const employeesToSelect = $.map($.grep(dataGrid.option('dataSource'), (item) => item.Prefix === data.value), (item) => item.ID);
+                const employeesToSelect = employees
+                  .filter((employee) => employee.Prefix === data.value)
+                  .map((employee) => employee.ID);
                 dataGrid.selectRows(employeesToSelect);
               }
             },
@@ -74,6 +81,9 @@ $(() => {
           options: {
             text: 'Clear Selection',
             disabled: true,
+            onInitialized(e) {
+              clearSelectionButton = e.component;
+            },
             onClick() {
               dataGrid.clearSelection();
             },

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/jQuery/index.js
@@ -49,6 +49,7 @@ $(() => {
             placeholder: 'Select title',
             width: '150px',
             onValueChanged(data) {
+              dataGrid.option('toolbar.items[0].options.value', data.value);
               if (!data.value) { return; }
               changedBySelectBox = true;
               if (data.value === 'All') {

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/jQuery/index.js
@@ -1,5 +1,6 @@
 $(() => {
   let changedBySelectBox;
+  let titleSelectBox;
 
   const dataGrid = $('#grid-container').dxDataGrid({
     dataSource: employees,
@@ -33,8 +34,12 @@ $(() => {
         $('#selected-items-container').text(
           $.map(data, (value) => `${value.FirstName} ${value.LastName}`).join(', '),
         );
-      } else { $('#selected-items-container').text('Nobody has been selected'); }
-      if (!changedBySelectBox) { dataGrid.option('toolbar.items[0].options.value', null); }
+      } else {
+        $('#selected-items-container').text('Nobody has been selected'); 
+      }
+      if (!changedBySelectBox) {
+        titleSelectBox.option('value', null);
+      }
 
       changedBySelectBox = false;
       dataGrid.option('toolbar.items[1].options.disabled', !data.length);
@@ -58,6 +63,9 @@ $(() => {
                 dataGrid.selectRows(employeesToSelect);
               }
             },
+            onInitialize(e) {
+              titleSelectBox = e.component;
+            }
           },
         },
         {

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/jQuery/index.js
@@ -35,7 +35,7 @@ $(() => {
           $.map(data, (value) => `${value.FirstName} ${value.LastName}`).join(', '),
         );
       } else {
-        $('#selected-items-container').text('Nobody has been selected'); 
+        $('#selected-items-container').text('Nobody has been selected');
       }
       if (!changedBySelectBox) {
         titleSelectBox.option('value', null);
@@ -65,7 +65,7 @@ $(() => {
             },
             onInitialized(e) {
               titleSelectBox = e.component;
-            }
+            },
           },
         },
         {

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/jQuery/index.js
@@ -63,7 +63,7 @@ $(() => {
                 dataGrid.selectRows(employeesToSelect);
               }
             },
-            onInitialize(e) {
+            onInitialized(e) {
               titleSelectBox = e.component;
             }
           },

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/jQuery/index.js
@@ -49,7 +49,6 @@ $(() => {
             placeholder: 'Select title',
             width: '150px',
             onValueChanged(data) {
-              dataGrid.option('toolbar.items[0].options.value', data.value);
               if (!data.value) { return; }
               changedBySelectBox = true;
               if (data.value === 'All') {

--- a/MVCDemos/Views/DataGrid/MultipleRecordSelectionAPI.cshtml
+++ b/MVCDemos/Views/DataGrid/MultipleRecordSelectionAPI.cshtml
@@ -79,10 +79,11 @@
     }
 
     function selectBox_valueChanged(data) {
+        var dataGrid = getDataGridInstance();
+        dataGrid.option('toolbar.items[0].options.value', data.value);
+
         if(!data.value)
             return;
-
-        var dataGrid = getDataGridInstance();
 
         changedBySelectBox = true;
         if(data.value == "All") {

--- a/MVCDemos/Views/DataGrid/MultipleRecordSelectionAPI.cshtml
+++ b/MVCDemos/Views/DataGrid/MultipleRecordSelectionAPI.cshtml
@@ -44,6 +44,7 @@
                         .Text("Clear Selection")
                         .Disabled(true)
                         .OnClick("button_click")
+                        .OnClick("button_onInitialized")
                 );
         });
     })
@@ -58,6 +59,7 @@
 <script>
     var changedBySelectBox;
     var titleSelectBox;
+    var clearSelectionButton;
 
     function getDataGridInstance() {
         return $("#grid-container").dxDataGrid("instance");
@@ -66,18 +68,23 @@
     function selection_changed(selectedItems) {
         var dataGrid = getDataGridInstance();
         var data = selectedItems.selectedRowsData;
-        if(data.length > 0)
+
+        if(data.length > 0) {
             $("#selectedItemsContainer").text(
-            $.map(data, function(value) {
-                return value.FirstName + " " + value.LastName;
-            }).join(", "));
-        else
+                data
+                    .map((value) => `${value.FirstName} ${value.LastName}`)
+                    .join(", ")
+            );
+        } else {
             $("#selectedItemsContainer").text("Nobody has been selected");
-        if (!changedBySelectBox)
+        }
+
+        if (!changedBySelectBox) {
             titleSelectBox.option('value', null);
+        }
 
         changedBySelectBox = false;
-        dataGrid.option("toolbar.items[1].options.disabled", !data.length);
+        clearSelectionButton.option('disabled', !data.length);
     }
 
     function selectBox_valueChanged(data) {
@@ -90,7 +97,7 @@
         if(data.value == "All") {
             dataGrid.selectAll();
         } else {
-            var employeesToSelect = $.map(dataGrid.getDataSource().items(), function(item) {
+            var employeesToSelect = dataGrid.getDataSource().items().map(function(item) {
                 if(item.Prefix === data.value) {
                     return item.ID;
                 }
@@ -102,6 +109,10 @@
 
     function selectBox_onInitialized(e) {
         titleSelectBox = e.component;
+    }
+
+    function button_onInitialized(e) {
+        clearSelectionButton = e.component;
     }
 
     function button_click() {

--- a/MVCDemos/Views/DataGrid/MultipleRecordSelectionAPI.cshtml
+++ b/MVCDemos/Views/DataGrid/MultipleRecordSelectionAPI.cshtml
@@ -34,6 +34,7 @@
                         .DataSource(new[] { "All", "Dr.", "Mr.", "Mrs.", "Ms." })
                         .Placeholder("Select title")
                         .OnValueChanged("selectBox_valueChanged")
+                        .onInitialized("selectBox_onInitialized")
                 );
 
             items.Add()
@@ -56,6 +57,7 @@
 
 <script>
     var changedBySelectBox;
+    var titleSelectBox;
 
     function getDataGridInstance() {
         return $("#grid-container").dxDataGrid("instance");
@@ -72,7 +74,7 @@
         else
             $("#selectedItemsContainer").text("Nobody has been selected");
         if (!changedBySelectBox)
-            dataGrid.option("toolbar.items[0].options.value", null);
+            titleSelectBox.option('value', null);
 
         changedBySelectBox = false;
         dataGrid.option("toolbar.items[1].options.disabled", !data.length);
@@ -96,6 +98,10 @@
 
             dataGrid.selectRows(employeesToSelect);
         }
+    }
+
+    function selectBox_onInitialized(e) {
+        titleSelectBox = e.component;
     }
 
     function button_click() {

--- a/MVCDemos/Views/DataGrid/MultipleRecordSelectionAPI.cshtml
+++ b/MVCDemos/Views/DataGrid/MultipleRecordSelectionAPI.cshtml
@@ -79,11 +79,10 @@
     }
 
     function selectBox_valueChanged(data) {
-        var dataGrid = getDataGridInstance();
-        dataGrid.option('toolbar.items[0].options.value', data.value);
-
         if(!data.value)
             return;
+
+        var dataGrid = getDataGridInstance();
 
         changedBySelectBox = true;
         if(data.value == "All") {

--- a/NetCoreDemos/Views/DataGrid/MultipleRecordSelectionAPI.cshtml
+++ b/NetCoreDemos/Views/DataGrid/MultipleRecordSelectionAPI.cshtml
@@ -77,11 +77,10 @@
     }
 
     function selectBox_valueChanged(data) {
-        var dataGrid = getDataGridInstance();
-        dataGrid.option('toolbar.items[0].options.value', data.value);
-
         if(!data.value)
             return;
+
+        var dataGrid = getDataGridInstance();
 
         changedBySelectBox = true;
         if(data.value == "All") {

--- a/NetCoreDemos/Views/DataGrid/MultipleRecordSelectionAPI.cshtml
+++ b/NetCoreDemos/Views/DataGrid/MultipleRecordSelectionAPI.cshtml
@@ -44,6 +44,7 @@
                         .Text("Clear Selection")
                         .Disabled(true)
                         .OnClick("button_click")
+                        .OnClick("button_onInitialized")
                 );
         });
     })
@@ -56,6 +57,7 @@
 <script>
     var changedBySelectBox;
     var titleSelectBox;
+    var clearSelectionButton;
 
     function getDataGridInstance() {
         return $("#grid-container").dxDataGrid("instance");
@@ -64,18 +66,23 @@
     function selection_changed(selectedItems) {
         var dataGrid = getDataGridInstance();
         var data = selectedItems.selectedRowsData;
-        if(data.length > 0)
+
+        if(data.length > 0) {
             $("#selectedItemsContainer").text(
-            $.map(data, function(value) {
-                return value.FirstName + " " + value.LastName;
-            }).join(", "));
-        else
+                data
+                    .map((value) => `${value.FirstName} ${value.LastName}`)
+                    .join(", ")
+            );
+        } else {
             $("#selectedItemsContainer").text("Nobody has been selected");
-        if(!changedBySelectBox)
+        }
+
+        if (!changedBySelectBox) {
             titleSelectBox.option('value', null);
+        }
 
         changedBySelectBox = false;
-        dataGrid.option("toolbar.items[1].options.disabled", !data.length);
+        clearSelectionButton.option('disabled', !data.length);
     }
 
     function selectBox_valueChanged(data) {
@@ -88,7 +95,7 @@
         if(data.value == "All") {
             dataGrid.selectAll();
         } else {
-            var employeesToSelect = $.map(dataGrid.getDataSource().items(), function(item) {
+            var employeesToSelect = dataGrid.getDataSource().items().map(function(item) {
                 if(item.Prefix === data.value) {
                     return item.ID;
                 }
@@ -100,6 +107,10 @@
 
     function selectBox_onInitialized(e) {
         titleSelectBox = e.component;
+    }
+
+    function button_onInitialized(e) {
+        clearSelectionButton = e.component;
     }
 
     function button_click() {

--- a/NetCoreDemos/Views/DataGrid/MultipleRecordSelectionAPI.cshtml
+++ b/NetCoreDemos/Views/DataGrid/MultipleRecordSelectionAPI.cshtml
@@ -77,10 +77,11 @@
     }
 
     function selectBox_valueChanged(data) {
+        var dataGrid = getDataGridInstance();
+        dataGrid.option('toolbar.items[0].options.value', data.value);
+
         if(!data.value)
             return;
-
-        var dataGrid = getDataGridInstance();
 
         changedBySelectBox = true;
         if(data.value == "All") {

--- a/NetCoreDemos/Views/DataGrid/MultipleRecordSelectionAPI.cshtml
+++ b/NetCoreDemos/Views/DataGrid/MultipleRecordSelectionAPI.cshtml
@@ -34,6 +34,7 @@
                         .DataSource(new[] { "All", "Dr.", "Mr.", "Mrs.", "Ms." })
                         .Placeholder("Select title")
                         .OnValueChanged("selectBox_valueChanged")
+                        .onInitialized("selectBox_onInitialized")
                 );
 
             items.Add()
@@ -54,6 +55,7 @@
 
 <script>
     var changedBySelectBox;
+    var titleSelectBox;
 
     function getDataGridInstance() {
         return $("#grid-container").dxDataGrid("instance");
@@ -70,7 +72,7 @@
         else
             $("#selectedItemsContainer").text("Nobody has been selected");
         if(!changedBySelectBox)
-            dataGrid.option("toolbar.items[0].options.value", null);
+            titleSelectBox.option('value', null);
 
         changedBySelectBox = false;
         dataGrid.option("toolbar.items[1].options.disabled", !data.length);
@@ -94,6 +96,10 @@
 
             dataGrid.selectRows(employeesToSelect);
         }
+    }
+
+    function selectBox_onInitialized(e) {
+        titleSelectBox = e.component;
     }
 
     function button_click() {


### PR DESCRIPTION
DxDataGrid's `toolbar.items[0].options.value` option is not back-synced with SelectBox's `value`. For example, this code does not work:

```javascript
...
toolbar: { items: [{
   widget: 'dxSelectBox',
}]}
...

grid.option("toolbar.items[0].options.value", "value 1");
selectBox.option("value", "value 2");
grid.option("toolbar.items[0].options.value", "value 1");

console.log(selectBox.option("value"))
// Actual: value = 2
// Expected: value = 1
```

I changed using `grid.option("toolbar.item[0].options...")` to `selectBox.option("...")`

---

Also removed JQuery's `$.map` using