### PR TITLE
Linter - add 'no `test.only`' rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
   },
   plugins: [
     'spellcheck',
+    'no-only-tests',
   ],
   rules: {
     'spellcheck/spell-checker': (() => {
@@ -281,6 +282,7 @@ module.exports = {
     'no-use-before-define': 0,
     'prefer-destructuring': 0,
     'no-param-reassign': ['error', { 'props': false }],
+    'no-only-tests/no-only-tests': 'error',
   },
   extends: [
     'eslint:recommended',

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
                 "eslint-plugin-import": "^2.22.1",
                 "eslint-plugin-jest": "^24.1.3",
                 "eslint-plugin-jest-formatting": "^3.0.0",
+                "eslint-plugin-no-only-tests": "^2.6.0",
                 "eslint-plugin-node": "^11.1.0",
                 "eslint-plugin-promise": "^4.2.1",
                 "eslint-plugin-react": "^7.21.5",
@@ -9048,6 +9049,15 @@
             },
             "peerDependencies": {
                 "eslint": ">=0.8.0"
+            }
+        },
+        "node_modules/eslint-plugin-no-only-tests": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
+            "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=4.0.0"
             }
         },
         "node_modules/eslint-plugin-node": {
@@ -33227,6 +33237,12 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-jest-formatting/-/eslint-plugin-jest-formatting-3.0.0.tgz",
             "integrity": "sha512-XM1CHe1jX6j+t/NeppcVnm/1zgDAFqwiSLJEyLB7HDpcqBEGbbTFLSayCW2Q9y7VwcXrJbDAKRoO6vZ7jCmRFw==",
+            "dev": true
+        },
+        "eslint-plugin-no-only-tests": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
+            "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
             "dev": true
         },
         "eslint-plugin-node": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-jest": "^24.1.3",
         "eslint-plugin-jest-formatting": "^3.0.0",
+        "eslint-plugin-no-only-tests": "^2.6.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^4.2.1",
         "eslint-plugin-react": "^7.21.5",


### PR DESCRIPTION
I forgot to add `'no-only-tests/no-only-tests'` rule to demos repo.

Previous PR: https://github.com/DevExpress/DevExtreme/pull/19230