### PR TITLE
correct version of npm package globalize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,15 +28,15 @@
                 "core-js": "2.4.1",
                 "devextreme": "22.1-next",
                 "devextreme-angular": "22.1-next",
-                "devextreme-aspnet-data": "2.8.4",
-                "devextreme-aspnet-data-nojquery": "2.8.4",
+                "devextreme-aspnet-data": "2.8.6",
+                "devextreme-aspnet-data-nojquery": "2.8.6",
                 "devextreme-cldr-data": "^1.0.2",
                 "devextreme-react": "22.1-next",
                 "devextreme-vue": "22.1-next",
                 "dx-systemjs-vue-browser": "latest",
                 "exceljs": "3.8.0",
                 "file-saver-es": "2.0.5",
-                "globalize": "1.1.1",
+                "globalize": "^1.3.0",
                 "html-react-parser": "latest",
                 "jquery": "3.5.1",
                 "jspdf": "2.3.1",
@@ -8108,17 +8108,17 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/devextreme-aspnet-data": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/devextreme-aspnet-data/-/devextreme-aspnet-data-2.8.4.tgz",
-            "integrity": "sha512-s6963HJG6mcKwibz6WL6oXF/TNKyHlUqlgJiEi4h5fF8mvGpiBarufuspCnO9A0SoTYHHgpYkDP6SzyZFDK6yw==",
+            "version": "2.8.6",
+            "resolved": "https://registry.npmjs.org/devextreme-aspnet-data/-/devextreme-aspnet-data-2.8.6.tgz",
+            "integrity": "sha512-voOZP3NO/6iHFHFlRR54MNS3fzc4X1KngY6zS7dOS3lmf4V0sTjO1JDT7anj1B6BcF//pukBtJ/Y44jIdpqVzg==",
             "peerDependencies": {
                 "devextreme": ">=18.1.0"
             }
         },
         "node_modules/devextreme-aspnet-data-nojquery": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/devextreme-aspnet-data-nojquery/-/devextreme-aspnet-data-nojquery-2.8.4.tgz",
-            "integrity": "sha512-wJAeWBF0OUucVFOD1z9SzA8oPc3N9dyQT+iGk+X9dgromua1+DKdBEYZKo/4zylYdKftKlBCLDFuZxSHrgi8Cw==",
+            "version": "2.8.6",
+            "resolved": "https://registry.npmjs.org/devextreme-aspnet-data-nojquery/-/devextreme-aspnet-data-nojquery-2.8.6.tgz",
+            "integrity": "sha512-ZQHrgMQwgJWgdEF7ulSQyLs2VvK7DPuVJPIrvXA3kA0UKt1sTS69ShTJt3xKKVXlceCMS8MrtFVxustlvxByLA==",
             "peerDependencies": {
                 "devextreme": ">=18.1.0"
             }
@@ -11420,15 +11420,17 @@
             }
         },
         "node_modules/globalize": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/globalize/-/globalize-1.1.1.tgz",
-            "integrity": "sha1-uqKE04dX2TlW0QPI+hofp/kZQik=",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/globalize/-/globalize-1.7.0.tgz",
+            "integrity": "sha512-faR46vTIbFCeAemyuc9E6/d7Wrx9k2ae2L60UhakztFg6VuE42gENVJNuPFtt7Sdjrk9m2w8+py7Jj+JTNy59w==",
             "dependencies": {
-                "cldrjs": "0.4.4"
-            },
-            "peerDependencies": {
-                "cldr-data": ">=25"
+                "cldrjs": "^0.5.4"
             }
+        },
+        "node_modules/globalize/node_modules/cldrjs": {
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/cldrjs/-/cldrjs-0.5.5.tgz",
+            "integrity": "sha512-KDwzwbmLIPfCgd8JERVDpQKrUUM1U4KpFJJg2IROv89rF172lLufoJnqJ/Wea6fXL5bO6WjuLMzY8V52UWPvkA=="
         },
         "node_modules/globals": {
             "version": "11.12.0",
@@ -32886,14 +32888,14 @@
             }
         },
         "devextreme-aspnet-data": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/devextreme-aspnet-data/-/devextreme-aspnet-data-2.8.4.tgz",
-            "integrity": "sha512-s6963HJG6mcKwibz6WL6oXF/TNKyHlUqlgJiEi4h5fF8mvGpiBarufuspCnO9A0SoTYHHgpYkDP6SzyZFDK6yw=="
+            "version": "2.8.6",
+            "resolved": "https://registry.npmjs.org/devextreme-aspnet-data/-/devextreme-aspnet-data-2.8.6.tgz",
+            "integrity": "sha512-voOZP3NO/6iHFHFlRR54MNS3fzc4X1KngY6zS7dOS3lmf4V0sTjO1JDT7anj1B6BcF//pukBtJ/Y44jIdpqVzg=="
         },
         "devextreme-aspnet-data-nojquery": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/devextreme-aspnet-data-nojquery/-/devextreme-aspnet-data-nojquery-2.8.4.tgz",
-            "integrity": "sha512-wJAeWBF0OUucVFOD1z9SzA8oPc3N9dyQT+iGk+X9dgromua1+DKdBEYZKo/4zylYdKftKlBCLDFuZxSHrgi8Cw=="
+            "version": "2.8.6",
+            "resolved": "https://registry.npmjs.org/devextreme-aspnet-data-nojquery/-/devextreme-aspnet-data-nojquery-2.8.6.tgz",
+            "integrity": "sha512-ZQHrgMQwgJWgdEF7ulSQyLs2VvK7DPuVJPIrvXA3kA0UKt1sTS69ShTJt3xKKVXlceCMS8MrtFVxustlvxByLA=="
         },
         "devextreme-cldr-data": {
             "version": "1.0.3",
@@ -35504,11 +35506,18 @@
             }
         },
         "globalize": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/globalize/-/globalize-1.1.1.tgz",
-            "integrity": "sha1-uqKE04dX2TlW0QPI+hofp/kZQik=",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/globalize/-/globalize-1.7.0.tgz",
+            "integrity": "sha512-faR46vTIbFCeAemyuc9E6/d7Wrx9k2ae2L60UhakztFg6VuE42gENVJNuPFtt7Sdjrk9m2w8+py7Jj+JTNy59w==",
             "requires": {
-                "cldrjs": "0.4.4"
+                "cldrjs": "^0.5.4"
+            },
+            "dependencies": {
+                "cldrjs": {
+                    "version": "0.5.5",
+                    "resolved": "https://registry.npmjs.org/cldrjs/-/cldrjs-0.5.5.tgz",
+                    "integrity": "sha512-KDwzwbmLIPfCgd8JERVDpQKrUUM1U4KpFJJg2IROv89rF172lLufoJnqJ/Wea6fXL5bO6WjuLMzY8V52UWPvkA=="
+                }
             }
         },
         "globals": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "dx-systemjs-vue-browser": "latest",
         "exceljs": "3.8.0",
         "file-saver-es": "2.0.5",
-        "globalize": "1.1.1",
+        "globalize": "^1.3.0",
         "html-react-parser": "latest",
         "jquery": "3.5.1",
         "jspdf": "2.3.1",


### PR DESCRIPTION
In devextreme project we are using globalize version ^1.3.0. I think  it must be same In demos.