### PR TITLE
Multiline Toolbar mode: include CS files into context

### DIFF
--- a/JSDemos/menuMeta.json
+++ b/JSDemos/menuMeta.json
@@ -3940,13 +3940,13 @@
             "Badge": "New",
             "DemoType": "Web",
             "MvcAdditionalFiles": [
-              "/Controllers/ToolbarController.cs",
               "/ViewModels/ToolbarViewModel.cs",
               "/Views/Toolbar/Multiline.cshtml",
               "/Models/FontStyle.cs",
               "/Models/ListType.cs",
               "/Models/TextAlign.cs",
-              "/Models/SampleData/ToolbarData.cs"
+              "/Models/SampleData/ToolbarData.cs",
+              "/Controllers/ToolbarController.cs"
             ]
           }
         ]

--- a/MVCDemos/DevExtreme.MVC.Demos.csproj
+++ b/MVCDemos/DevExtreme.MVC.Demos.csproj
@@ -447,6 +447,7 @@
     <Compile Include="Models\SampleData\StatesData.cs" />
     <Compile Include="Models\SampleData\StochasticData.cs" />
     <Compile Include="Models\SampleData\DiagramEmployees.cs" />
+    <Compile Include="Models\SampleData\ToolbarData.cs" />
     <Compile Include="Models\SampleData\TreeViewHierarchicalDataForDragAndDrop.cs" />
     <Compile Include="Models\SampleData\TreeViewPlainDataForDragAndDrop.cs" />
     <Compile Include="Models\SimpleData.cs" />
@@ -695,6 +696,7 @@
     <Compile Include="ViewModels\SchedulerResourcesViewModel.cs" />
     <Compile Include="ViewModels\SchedulerViewModel.cs" />
     <Compile Include="ViewModels\TagBoxViewModel.cs" />
+    <Compile Include="ViewModels\ToolbarViewModel.cs" />
     <Compile Include="ViewModels\SelectBoxViewModel.cs" />
     <Compile Include="ViewModels\GalleryViewModel.cs" />
   </ItemGroup>

--- a/MVCDemos/Views/Toolbar/Multiline.cshtml
+++ b/MVCDemos/Views/Toolbar/Multiline.cshtml
@@ -1,4 +1,4 @@
-﻿@model DevExtreme.MVC.Demos.ViewModels.DropDownButtonViewModel
+﻿@model DevExtreme.MVC.Demos.ViewModels.ToolbarViewModel
 
 <div>
     <div class="widget-container">

--- a/NetCoreDemos/Views/Toolbar/Multiline.cshtml
+++ b/NetCoreDemos/Views/Toolbar/Multiline.cshtml
@@ -1,4 +1,4 @@
-﻿@model DevExtreme.NETCore.Demos.ViewModels.DropDownButtonViewModel
+﻿@model DevExtreme.NETCore.Demos.ViewModels.ToolbarViewModel
 
 <div>
     <div class="widget-container">


### PR DESCRIPTION
\Demos\WidgetsGallery\WidgetsGallery.MVC\DevExtreme.MVC.Demos\Controllers\ToolbarController.cs(27,32): error CS0103: The name 'ToolbarViewModel' does not exist in the current context [\Demos\WidgetsGallery\WidgetsGallery.MVC\DevExtreme.MVC.Demos\DevExtreme.MVC.Demos.csproj]