### PR TITLE
Fix devextreme package versions

### DIFF
--- a/NetCoreDemos/DevExtreme.NETCore.Demos.csproj
+++ b/NetCoreDemos/DevExtreme.NETCore.Demos.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.11" />
     <PackageReference Include="DevExtreme.AspNet.Data" Version="2.8.6" />
-    <PackageReference Include="DevExtreme.AspNet.Core" Version="22.1.0" />
+    <PackageReference Include="DevExtreme.AspNet.Core" Version="22.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.9" />
   </ItemGroup>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2097,16 +2097,6 @@
                 "node": ">=0.1.95"
             }
         },
-        "node_modules/@dabh/diagnostics": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
-            "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
-            "dependencies": {
-                "colorspace": "1.1.x",
-                "enabled": "2.0.x",
-                "kuler": "^2.0.0"
-            }
-        },
         "node_modules/@devexpress/error-stack-parser": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@devexpress/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
@@ -2117,9 +2107,9 @@
             }
         },
         "node_modules/@devexpress/utils": {
-            "version": "1.3.13",
-            "resolved": "https://registry.npmjs.org/@devexpress/utils/-/utils-1.3.13.tgz",
-            "integrity": "sha512-DaTNDLcyepRegwKCWrikP+6WH0cY6/gVSLC/wd6o6AhuTpn6jrXEYcJm50+DwUSwAPVyoQcp6iYRTD1BdITrBQ==",
+            "version": "1.3.16",
+            "resolved": "https://registry.npmjs.org/@devexpress/utils/-/utils-1.3.16.tgz",
+            "integrity": "sha512-4Az8FUtvesew89j6N7zmDGfZQyHicvSwVoPZMmxRPvz2u4UiLpI/LDD0zuzLYWsLa8pr+SsJ3JRIKmhlcDAsgA==",
             "dependencies": {
                 "tslib": "2.0.1"
             }
@@ -2130,18 +2120,13 @@
             "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
         },
         "node_modules/@devextreme/runtime": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@devextreme/runtime/-/runtime-3.0.4.tgz",
-            "integrity": "sha512-Jb5bScnBV8MTlCnIyqSeEVBkldoU3feNGYhztHI1CRaZGHNNj3XBRyzW5Rm7tyTwXrXup80k5Q8OG4Sb2N61ag==",
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/@devextreme/runtime/-/runtime-3.0.11.tgz",
+            "integrity": "sha512-j17t+7Uv2iji9YKSzoArw8TyYCjRBWKFRjUyQrog77Z9CVUsQnv2kI7MVNHKjmQgD/aTnHvb57dYq9UL6HesLw==",
             "dependencies": {
                 "inferno": "^7.4.6",
-                "inferno-compat": "^7.4.6",
                 "inferno-create-element": "^7.4.6",
                 "inferno-hydrate": "^7.4.6"
-            },
-            "peerDependencies": {
-                "@angular/core": "^11.0.0 || ^12.0.0 || ^13.0.0",
-                "vue": "^2.6.14"
             }
         },
         "node_modules/@eslint/eslintrc": {
@@ -4628,6 +4613,42 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/ajv-formats": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.0.tgz",
+            "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ajv-formats/node_modules/ajv": {
+            "version": "8.11.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+            "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
         "node_modules/amdefine": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -7014,6 +7035,28 @@
                 "node": ">=6"
             }
         },
+        "node_modules/cli-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+            "dependencies": {
+                "restore-cursor": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-spinners": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
+            "integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/cli-truncate": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
@@ -7278,19 +7321,11 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/color": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-            "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-            "dependencies": {
-                "color-convert": "^1.9.3",
-                "color-string": "^1.6.0"
-            }
-        },
         "node_modules/color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
             "dependencies": {
                 "color-name": "1.1.3"
             }
@@ -7304,16 +7339,8 @@
         "node_modules/color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-        },
-        "node_modules/color-string": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
-            "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
-            "dependencies": {
-                "color-name": "^1.0.0",
-                "simple-swizzle": "^0.2.2"
-            }
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
         },
         "node_modules/color-support": {
             "version": "1.1.3",
@@ -7322,23 +7349,6 @@
             "dev": true,
             "bin": {
                 "color-support": "bin.js"
-            }
-        },
-        "node_modules/colors": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-            "engines": {
-                "node": ">=0.1.90"
-            }
-        },
-        "node_modules/colorspace": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-            "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-            "dependencies": {
-                "color": "^3.1.3",
-                "text-hex": "1.0.x"
             }
         },
         "node_modules/combined-stream": {
@@ -7935,6 +7945,22 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/defaults": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+            "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+            "dependencies": {
+                "clone": "^1.0.2"
+            }
+        },
+        "node_modules/defaults/node_modules/clone": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+            "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
         "node_modules/define-lazy-prop": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -8088,33 +8114,46 @@
             }
         },
         "node_modules/devexpress-diagram": {
-            "version": "2.1.45",
-            "resolved": "https://registry.npmjs.org/devexpress-diagram/-/devexpress-diagram-2.1.45.tgz",
-            "integrity": "sha512-kOBqGM7/t2pp/M/A/7ce20Cls2OMn44PCDRgm61HxwFnRMFYI6synZZEIhW6rwQ0e2EgkuZZdr4W3LeGIaDQbQ==",
+            "version": "2.1.63",
+            "resolved": "https://registry.npmjs.org/devexpress-diagram/-/devexpress-diagram-2.1.63.tgz",
+            "integrity": "sha512-zsqt3VFJpIlkW+/N1+GXuZEP2BG1NOirCqItFnbrZZhcNPl5nxr8LnxqiNF7MtOCjgUmCD4MbU7GxShlu9J7JA==",
             "dependencies": {
-                "@devexpress/utils": "1.3.13",
+                "@devexpress/utils": "1.3.16",
                 "es6-object-assign": "^1.1.0"
             }
         },
         "node_modules/devexpress-gantt": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/devexpress-gantt/-/devexpress-gantt-4.1.6.tgz",
-            "integrity": "sha512-CLJDLrl1eMx6DT+ICwlZTIdNJA9f71KyazFWaN4DT8unTulymIlUsw1m2977EXW9SZ97FPirSXPqOFQnO7J54w==",
+            "version": "4.1.32",
+            "resolved": "https://registry.npmjs.org/devexpress-gantt/-/devexpress-gantt-4.1.32.tgz",
+            "integrity": "sha512-Zeuv1wH3K8fC30R6Azkeu6GemWhR1nhpMqEupyfMk+7rO/WHnqoa1F0oA6lfIzZUDU5RoERRvcZjV65AOzvbWg==",
             "dependencies": {
-                "@devexpress/utils": "1.3.13",
+                "@devexpress/utils": "1.3.14",
                 "tslib": "2.3.1"
             }
         },
+        "node_modules/devexpress-gantt/node_modules/@devexpress/utils": {
+            "version": "1.3.14",
+            "resolved": "https://registry.npmjs.org/@devexpress/utils/-/utils-1.3.14.tgz",
+            "integrity": "sha512-vJmUq9Rg6wqYPuZ7qvTHBsd6vkGBj5ZCMzNUJIRWIZPuQfGt576cMqDOD68EQyy/5EBqwowtoYgFdQ1a/1iVpA==",
+            "dependencies": {
+                "tslib": "2.0.1"
+            }
+        },
+        "node_modules/devexpress-gantt/node_modules/@devexpress/utils/node_modules/tslib": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+            "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+        },
         "node_modules/devextreme": {
-            "version": "22.1.1-alpha-22018-0314",
-            "resolved": "https://registry.npmjs.org/devextreme/-/devextreme-22.1.1-alpha-22018-0314.tgz",
-            "integrity": "sha512-h4iXTlzxfCqexq7dWxo3J45Z7AM5GQXyzolcpZOlsZ1AsjVA1pyBU7YXVPqHv/b9+1cQ1tVVoIUtm/bE5Nf7hg==",
+            "version": "22.2.1-alpha-22245-0308",
+            "resolved": "https://registry.npmjs.org/devextreme/-/devextreme-22.2.1-alpha-22245-0308.tgz",
+            "integrity": "sha512-WbelOy5Fl0ysHfH9Hzfg0Z2wqtCZzhJvL1hSUn5iDOCSjaHot2byHQlcR5aXa0/Qp9WyH8mXxxh3vSXqrDAU3g==",
             "dependencies": {
                 "@babel/runtime": "^7.12.1",
-                "@devextreme/runtime": "~3.0.2",
-                "devexpress-diagram": "2.1.45",
-                "devexpress-gantt": "4.1.6",
-                "devextreme-quill": "~1.5.10",
+                "@devextreme/runtime": "3.0.11",
+                "devexpress-diagram": "2.1.63",
+                "devexpress-gantt": "4.1.32",
+                "devextreme-quill": "~1.5.16",
                 "devextreme-showdown": "^1.0.1",
                 "inferno": "^7.4.9",
                 "inferno-compat": "^7.4.9",
@@ -8122,7 +8161,7 @@
                 "inferno-hydrate": "^7.4.9",
                 "jszip": "^3.7.1",
                 "rrule": "2.6.6",
-                "turndown": "~7.0.0"
+                "turndown": "~7.1.0"
             },
             "bin": {
                 "devextreme-bundler": "bin/bundler.js",
@@ -8130,26 +8169,106 @@
             }
         },
         "node_modules/devextreme-angular": {
-            "version": "22.1.1-alpha-22018-0314",
-            "resolved": "https://registry.npmjs.org/devextreme-angular/-/devextreme-angular-22.1.1-alpha-22018-0314.tgz",
-            "integrity": "sha512-V70mPc5Y8u+gtzqY/nk+/JyiAVNnL7VzV5jwGIwVIy+mPqgXNWKtlyRIzfc72+zkQOo56YmCTu2frlkldwZtqg==",
+            "version": "22.2.1-alpha-22245-0308",
+            "resolved": "https://registry.npmjs.org/devextreme-angular/-/devextreme-angular-22.2.1-alpha-22245-0308.tgz",
+            "integrity": "sha512-Vhi1nSPJCN7MWUs/b/nCl9bxuXN2ynEiVlR2As4cM++DGI20ADLGN8O7Fmpmtvvcj0VFV0Lt1+wtOtovk/kfCQ==",
             "dependencies": {
-                "@angular-devkit/schematics": "^8.0.0",
+                "@angular-devkit/schematics": "^12.2.18",
                 "devextreme-schematics": "latest",
-                "inferno-server": "7.4.4",
-                "tslib": "^1.9.0"
+                "inferno-server": "7.4.11",
+                "tslib": "^2.2.0"
             },
             "peerDependencies": {
-                "@angular/common": ">7.0.0",
-                "@angular/core": ">7.0.0",
-                "@angular/forms": ">7.0.0",
-                "devextreme": "~22.1.1-alpha-22018-0314"
+                "@angular/common": ">12.0.0",
+                "@angular/core": ">12.0.0",
+                "@angular/forms": ">12.0.0",
+                "devextreme": "~22.2.1-alpha-22245-0308"
             }
         },
-        "node_modules/devextreme-angular/node_modules/tslib": {
+        "node_modules/devextreme-angular/node_modules/@angular-devkit/core": {
+            "version": "12.2.18",
+            "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-12.2.18.tgz",
+            "integrity": "sha512-GDLHGe9HEY5SRS+NrKr14C8aHsRCiBFkBFSSbeohgLgcgSXzZHFoU84nDWrl3KZNP8oqcUSv5lHu6dLcf2fnww==",
+            "dependencies": {
+                "ajv": "8.6.2",
+                "ajv-formats": "2.1.0",
+                "fast-json-stable-stringify": "2.1.0",
+                "magic-string": "0.25.7",
+                "rxjs": "6.6.7",
+                "source-map": "0.7.3"
+            },
+            "engines": {
+                "node": "^12.14.1 || >=14.0.0",
+                "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+                "yarn": ">= 1.13.0"
+            }
+        },
+        "node_modules/devextreme-angular/node_modules/@angular-devkit/schematics": {
+            "version": "12.2.18",
+            "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-12.2.18.tgz",
+            "integrity": "sha512-bZ9NS5PgoVfetRC6WeQBHCY5FqPZ9y2TKHUo12sOB2YSL3tgWgh1oXyP8PtX34gasqsLjNULxEQsAQYEsiX/qQ==",
+            "dependencies": {
+                "@angular-devkit/core": "12.2.18",
+                "ora": "5.4.1",
+                "rxjs": "6.6.7"
+            },
+            "engines": {
+                "node": "^12.14.1 || >=14.0.0",
+                "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+                "yarn": ">= 1.13.0"
+            }
+        },
+        "node_modules/devextreme-angular/node_modules/ajv": {
+            "version": "8.6.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
+            "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/devextreme-angular/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "node_modules/devextreme-angular/node_modules/magic-string": {
+            "version": "0.25.7",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+            "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+            "dependencies": {
+                "sourcemap-codec": "^1.4.4"
+            }
+        },
+        "node_modules/devextreme-angular/node_modules/rxjs": {
+            "version": "6.6.7",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+            "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+            "dependencies": {
+                "tslib": "^1.9.0"
+            },
+            "engines": {
+                "npm": ">=2.0.0"
+            }
+        },
+        "node_modules/devextreme-angular/node_modules/rxjs/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/devextreme-angular/node_modules/source-map": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/devextreme-aspnet-data": {
             "version": "2.8.6",
@@ -8172,50 +8291,10 @@
             "resolved": "https://registry.npmjs.org/devextreme-cldr-data/-/devextreme-cldr-data-1.0.3.tgz",
             "integrity": "sha512-xd+uWv1KzEhr+ZH/MOWfDei3GFz+NAYyKUR9HgjM9BBwPel7PpMElYp4whM+PtAjziBaTssQnA//ob5c3BovTA=="
         },
-        "node_modules/devextreme-internal-tools": {
-            "version": "7.7.0",
-            "resolved": "https://registry.npmjs.org/devextreme-internal-tools/-/devextreme-internal-tools-7.7.0.tgz",
-            "integrity": "sha512-HVWnl7mH24sNMPtlzw2eQ3VHhqt6GyQk5ILdCGt6laEoHCS3z5Z9Sb7noga7/fWHHXBManZkJBt1EfSXEPE1xw==",
-            "dependencies": {
-                "prettier": "2.3.2",
-                "shelljs": "^0.8.3",
-                "typescript": "~4.1",
-                "winston": "^3.3.3"
-            },
-            "bin": {
-                "dx-tools": "index.js"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/devextreme-internal-tools/node_modules/prettier": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-            "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
-            "bin": {
-                "prettier": "bin-prettier.js"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "node_modules/devextreme-internal-tools/node_modules/typescript": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.6.tgz",
-            "integrity": "sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=4.2.0"
-            }
-        },
         "node_modules/devextreme-quill": {
-            "version": "1.5.12",
-            "resolved": "https://registry.npmjs.org/devextreme-quill/-/devextreme-quill-1.5.12.tgz",
-            "integrity": "sha512-tTgYIGMu7QI9ESil+9figY0Z+g11CgpqByIziRGir4ghqYIi4XbRJoCOH4pE3LaaTKQkrxgkrzdnmcpMCyz7Yw==",
+            "version": "1.5.18",
+            "resolved": "https://registry.npmjs.org/devextreme-quill/-/devextreme-quill-1.5.18.tgz",
+            "integrity": "sha512-qdO+8VnteqMEh/JN7q9cQogH/BZFILcPnR6FO41MiLy1fT84xEqORra7cKYQaiagf3yts934bb0ycWw8zgdFYA==",
             "dependencies": {
                 "core-js": "^3.19.1",
                 "eventemitter3": "^4.0.0",
@@ -8227,9 +8306,9 @@
             }
         },
         "node_modules/devextreme-quill/node_modules/core-js": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.0.tgz",
-            "integrity": "sha512-YUdI3fFu4TF/2WykQ2xzSiTQdldLB4KVuL9WeAy5XONZYt5Cun/fpQvctoKbCgvPhmzADeesTk/j2Rdx77AcKQ==",
+            "version": "3.25.5",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.5.tgz",
+            "integrity": "sha512-nbm6eZSjm+ZuBQxCUPQKQCoUEfFOXjUZ8dTTyikyKaWrTYmAVbykQfwsKE5dBK88u3QCkCrzsx/PPlKfhsvgpw==",
             "hasInstallScript": true,
             "funding": {
                 "type": "opencollective",
@@ -8237,17 +8316,16 @@
             }
         },
         "node_modules/devextreme-react": {
-            "version": "22.1.1-alpha-22018-0314",
-            "resolved": "https://registry.npmjs.org/devextreme-react/-/devextreme-react-22.1.1-alpha-22018-0314.tgz",
-            "integrity": "sha512-6F32iujVLvo776m2gkh0tczPTKo/mT7vB6fNpXqihfYNZ34NVMzVwhYD/1XjgtdzygQFTwROdWvsOtEy1d7ZXQ==",
+            "version": "22.2.1-alpha-22245-0308",
+            "resolved": "https://registry.npmjs.org/devextreme-react/-/devextreme-react-22.2.1-alpha-22245-0308.tgz",
+            "integrity": "sha512-89zSslTAlWxRR7+lfj1xpQnKwujH36ddbg19vMsoWsDkrrEB+oJA3M841GHw+sJ4PsdKEN29bpI1s6DFiDSm7Q==",
             "dependencies": {
-                "devextreme-internal-tools": "^7.6.0",
-                "prop-types": "^15.6.1"
+                "prop-types": "^15.8.1"
             },
             "peerDependencies": {
-                "devextreme": "~22.1.1-alpha-22018-0314",
-                "react": "^16.2.0 || ^17.0.0",
-                "react-dom": "^16.2.0 || ^17.0.0"
+                "devextreme": "~22.2.1-alpha-22245-0308",
+                "react": "^16.2.0 || ^17.0.0 || ^18.0.0",
+                "react-dom": "^16.2.0 || ^17.0.0 || ^18.0.0"
             }
         },
         "node_modules/devextreme-schematics": {
@@ -8319,11 +8397,11 @@
             }
         },
         "node_modules/devextreme-vue": {
-            "version": "22.1.1-alpha-22018-0314",
-            "resolved": "https://registry.npmjs.org/devextreme-vue/-/devextreme-vue-22.1.1-alpha-22018-0314.tgz",
-            "integrity": "sha512-Q3JWfj6KOfVqzJLjnlULHQrsjW5dWYTPyDoXmHDiJFoziwIxlW6+X2rRPNb/Q2EEixlh50gg3L6BN0wz/Q5wiQ==",
+            "version": "22.2.1-alpha-22245-0308",
+            "resolved": "https://registry.npmjs.org/devextreme-vue/-/devextreme-vue-22.2.1-alpha-22245-0308.tgz",
+            "integrity": "sha512-oByoC1zRUVJycOsg5I4HR9VWQ0f+IDpKn3R3k6Oz/tyd5eYvQsml/oVjmkkyXAMYCCp/M2UTx8SD2t3fZ4Hrqw==",
             "peerDependencies": {
-                "devextreme": "~22.1.1-alpha-22018-0314",
+                "devextreme": "~22.2.1-alpha-22245-0308",
                 "vue": "^2.5.16 || ^3.0.0"
             }
         },
@@ -8826,11 +8904,6 @@
                 "lowlight": "~1.9.0"
             }
         },
-        "node_modules/enabled": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-            "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
-        },
         "node_modules/encodeurl": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -9002,7 +9075,7 @@
         "node_modules/es6-object-assign": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-            "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
+            "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw=="
         },
         "node_modules/es6-promise": {
             "version": "4.2.8",
@@ -10617,11 +10690,6 @@
                 "bser": "2.1.1"
             }
         },
-        "node_modules/fecha": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
-            "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
-        },
         "node_modules/fflate": {
             "version": "0.4.8",
             "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
@@ -10989,11 +11057,6 @@
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
-        },
-        "node_modules/fn.name": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-            "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
         },
         "node_modules/follow-redirects": {
             "version": "1.5.10",
@@ -13026,36 +13089,15 @@
             }
         },
         "node_modules/inferno-server": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/inferno-server/-/inferno-server-7.4.4.tgz",
-            "integrity": "sha512-d8r39lumNJYT6q/N0EMnvPR48iHt5+z/gUL0hrAOsDMPQz16j8M5HJiiiXzCR+rvkcMJj01K68xD9Q2yi1ZQFw==",
+            "version": "7.4.11",
+            "resolved": "https://registry.npmjs.org/inferno-server/-/inferno-server-7.4.11.tgz",
+            "integrity": "sha512-SUnkCqZNWOIrjRVoVk/E1/70O1f1ImkCX9H2gDPbS0uc3GDxuzIeCgn0rpcc0XV9KzZJ2LTGxuBtEoQQOjUn2Q==",
             "dependencies": {
-                "inferno": "7.4.4"
+                "inferno": "7.4.11"
             },
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/inferno-server/node_modules/inferno": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/inferno/-/inferno-7.4.4.tgz",
-            "integrity": "sha512-ITPZ/Li1EvyDDNjRY7+R1MRRlPz5+fYg8wGMhgfUSMg8QcQWoeM0hP5BEYxdDz4K/aGWHfey7CgHXY6HGWylqA==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "inferno-shared": "7.4.4",
-                "inferno-vnode-flags": "7.4.4",
-                "opencollective-postinstall": "^2.0.2"
-            }
-        },
-        "node_modules/inferno-server/node_modules/inferno-shared": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/inferno-shared/-/inferno-shared-7.4.4.tgz",
-            "integrity": "sha512-HqnNCKCg30Wmt8/7MVwPr9JapIfa++dwrHvNhRWmSCcsKhF4MOJiZ1C9EunTPzSLua3n8TLrj6W3UB4gXk6kMQ=="
-        },
-        "node_modules/inferno-server/node_modules/inferno-vnode-flags": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/inferno-vnode-flags/-/inferno-vnode-flags-7.4.4.tgz",
-            "integrity": "sha512-Wyx7S/T8vKgGP4nTeqN5MYm9ryzh1xvZ1mJ4eZWXklqqnNx66kYeEUwMviqncG6uExcqnue1z8FA/rVjx/Y8yQ=="
         },
         "node_modules/inferno-shared": {
             "version": "7.4.11",
@@ -13110,6 +13152,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
             "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.10"
             }
@@ -13499,6 +13542,14 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/is-interactive": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+            "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-jquery-obj": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-jquery-obj/-/is-jquery-obj-0.1.1.tgz",
@@ -13686,6 +13737,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             },
@@ -13744,7 +13796,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
             "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -17605,11 +17656,6 @@
             "integrity": "sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw==",
             "dev": true
         },
-        "node_modules/kuler": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-            "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
-        },
         "node_modules/last-run": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
@@ -17816,7 +17862,7 @@
         "node_modules/lodash.clonedeep": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+            "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
         },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
@@ -17940,7 +17986,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
             "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-            "dev": true,
             "dependencies": {
                 "chalk": "^4.1.0",
                 "is-unicode-supported": "^0.1.0"
@@ -17956,7 +18001,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -17971,7 +18015,6 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -17987,7 +18030,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -17998,14 +18040,12 @@
         "node_modules/log-symbols/node_modules/color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "node_modules/log-symbols/node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -18014,7 +18054,6 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -18054,23 +18093,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/logform": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/logform/-/logform-2.3.2.tgz",
-            "integrity": "sha512-V6JiPThZzTsbVRspNO6TmHkR99oqYTs8fivMBYQkjZj6rxW92KxtDCPE6IkAk1DNBnYKNkjm4jYBm6JDUcyhOA==",
-            "dependencies": {
-                "colors": "1.4.0",
-                "fecha": "^4.2.0",
-                "ms": "^2.1.1",
-                "safe-stable-stringify": "^1.1.0",
-                "triple-beam": "^1.3.0"
-            }
-        },
-        "node_modules/logform/node_modules/safe-stable-stringify": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
-            "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
         },
         "node_modules/longest-streak": {
             "version": "2.0.4",
@@ -18924,7 +18946,8 @@
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "node_modules/multimatch": {
             "version": "2.1.0",
@@ -19705,19 +19728,10 @@
                 "wrappy": "1"
             }
         },
-        "node_modules/one-time": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-            "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-            "dependencies": {
-                "fn.name": "1.x.x"
-            }
-        },
         "node_modules/onetime": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
             "dependencies": {
                 "mimic-fn": "^2.1.0"
             },
@@ -19732,7 +19746,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -19798,6 +19811,92 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/ora": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+            "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+            "dependencies": {
+                "bl": "^4.1.0",
+                "chalk": "^4.1.0",
+                "cli-cursor": "^3.1.0",
+                "cli-spinners": "^2.5.0",
+                "is-interactive": "^1.0.0",
+                "is-unicode-supported": "^0.1.0",
+                "log-symbols": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "wcwidth": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ora/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/ora/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/ora/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/ora/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/ora/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ora/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/ordered-read-streams": {
@@ -21482,6 +21581,7 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+            "dev": true,
             "dependencies": {
                 "resolve": "^1.1.6"
             },
@@ -21923,7 +22023,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -22014,6 +22113,18 @@
             "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
             "deprecated": "https://github.com/lydell/resolve-url#deprecated",
             "dev": true
+        },
+        "node_modules/restore-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+            "dependencies": {
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/ret": {
             "version": "0.1.15",
@@ -22137,14 +22248,6 @@
             "dev": true,
             "dependencies": {
                 "ret": "~0.1.10"
-            }
-        },
-        "node_modules/safe-stable-stringify": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
-            "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==",
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/safer-buffer": {
@@ -22670,22 +22773,6 @@
             "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
             "dev": true
         },
-        "node_modules/shelljs": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-            "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-            "dependencies": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-            },
-            "bin": {
-                "shjs": "bin/shjs"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/shellwords": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
@@ -22716,8 +22803,7 @@
         "node_modules/signal-exit": {
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
         },
         "node_modules/signalr": {
             "version": "2.2.2",
@@ -22726,19 +22812,6 @@
             "dependencies": {
                 "jquery": ">=1.6.4"
             }
-        },
-        "node_modules/simple-swizzle": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-            "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-            "dependencies": {
-                "is-arrayish": "^0.3.1"
-            }
-        },
-        "node_modules/simple-swizzle/node_modules/is-arrayish": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-            "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         },
         "node_modules/sisteransi": {
             "version": "1.0.5",
@@ -23090,6 +23163,7 @@
             "version": "0.0.10",
             "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
             "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+            "dev": true,
             "engines": {
                 "node": "*"
             }
@@ -24927,11 +25001,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/text-hex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-            "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
-        },
         "node_modules/text-segmentation": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
@@ -25425,11 +25494,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/triple-beam": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
-            "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
-        },
         "node_modules/trough": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
@@ -25520,9 +25584,9 @@
             }
         },
         "node_modules/turndown": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.0.0.tgz",
-            "integrity": "sha512-G1FfxfR0mUNMeGjszLYl3kxtopC4O9DRRiMlMDDVHvU1jaBkGFg4qxIyjIk2aiKLHyDyZvZyu4qBO2guuYBy3Q==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.1.1.tgz",
+            "integrity": "sha512-BEkXaWH7Wh7e9bd2QumhfAXk5g34+6QUmmWx+0q6ThaVOLuLUqsnkq35HQ5SBHSaxjSfSM7US5o4lhJNH7B9MA==",
             "dependencies": {
                 "domino": "^2.1.6"
             }
@@ -26314,6 +26378,14 @@
                 "makeerror": "1.0.12"
             }
         },
+        "node_modules/wcwidth": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+            "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+            "dependencies": {
+                "defaults": "^1.0.3"
+            }
+        },
         "node_modules/webauth": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/webauth/-/webauth-1.1.0.tgz",
@@ -26476,44 +26548,6 @@
             "bin": {
                 "which": "bin/which"
             }
-        },
-        "node_modules/winston": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/winston/-/winston-3.5.1.tgz",
-            "integrity": "sha512-tbRtVy+vsSSCLcZq/8nXZaOie/S2tPXPFt4be/Q3vI/WtYwm7rrwidxVw2GRa38FIXcJ1kUM6MOZ9Jmnk3F3UA==",
-            "dependencies": {
-                "@dabh/diagnostics": "^2.0.2",
-                "async": "^3.2.3",
-                "is-stream": "^2.0.0",
-                "logform": "^2.3.2",
-                "one-time": "^1.0.0",
-                "readable-stream": "^3.4.0",
-                "safe-stable-stringify": "^2.3.1",
-                "stack-trace": "0.0.x",
-                "triple-beam": "^1.3.0",
-                "winston-transport": "^4.4.2"
-            },
-            "engines": {
-                "node": ">= 6.4.0"
-            }
-        },
-        "node_modules/winston-transport": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
-            "integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
-            "dependencies": {
-                "logform": "^2.3.2",
-                "readable-stream": "^3.6.0",
-                "triple-beam": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 6.4.0"
-            }
-        },
-        "node_modules/winston/node_modules/async": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-            "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
         },
         "node_modules/word-wrap": {
             "version": "1.2.3",
@@ -28128,16 +28162,6 @@
                 "minimist": "^1.2.0"
             }
         },
-        "@dabh/diagnostics": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
-            "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
-            "requires": {
-                "colorspace": "1.1.x",
-                "enabled": "2.0.x",
-                "kuler": "^2.0.0"
-            }
-        },
         "@devexpress/error-stack-parser": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@devexpress/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
@@ -28148,9 +28172,9 @@
             }
         },
         "@devexpress/utils": {
-            "version": "1.3.13",
-            "resolved": "https://registry.npmjs.org/@devexpress/utils/-/utils-1.3.13.tgz",
-            "integrity": "sha512-DaTNDLcyepRegwKCWrikP+6WH0cY6/gVSLC/wd6o6AhuTpn6jrXEYcJm50+DwUSwAPVyoQcp6iYRTD1BdITrBQ==",
+            "version": "1.3.16",
+            "resolved": "https://registry.npmjs.org/@devexpress/utils/-/utils-1.3.16.tgz",
+            "integrity": "sha512-4Az8FUtvesew89j6N7zmDGfZQyHicvSwVoPZMmxRPvz2u4UiLpI/LDD0zuzLYWsLa8pr+SsJ3JRIKmhlcDAsgA==",
             "requires": {
                 "tslib": "2.0.1"
             },
@@ -28163,12 +28187,11 @@
             }
         },
         "@devextreme/runtime": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@devextreme/runtime/-/runtime-3.0.4.tgz",
-            "integrity": "sha512-Jb5bScnBV8MTlCnIyqSeEVBkldoU3feNGYhztHI1CRaZGHNNj3XBRyzW5Rm7tyTwXrXup80k5Q8OG4Sb2N61ag==",
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/@devextreme/runtime/-/runtime-3.0.11.tgz",
+            "integrity": "sha512-j17t+7Uv2iji9YKSzoArw8TyYCjRBWKFRjUyQrog77Z9CVUsQnv2kI7MVNHKjmQgD/aTnHvb57dYq9UL6HesLw==",
             "requires": {
                 "inferno": "^7.4.6",
-                "inferno-compat": "^7.4.6",
                 "inferno-create-element": "^7.4.6",
                 "inferno-hydrate": "^7.4.6"
             }
@@ -30127,6 +30150,32 @@
                 "uri-js": "^4.2.2"
             }
         },
+        "ajv-formats": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.0.tgz",
+            "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
+            "requires": {
+                "ajv": "^8.0.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "8.11.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+                    "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "json-schema-traverse": "^1.0.0",
+                        "require-from-string": "^2.0.2",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                }
+            }
+        },
         "amdefine": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -32048,6 +32097,19 @@
             "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
             "dev": true
         },
+        "cli-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+            "requires": {
+                "restore-cursor": "^3.1.0"
+            }
+        },
+        "cli-spinners": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
+            "integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw=="
+        },
         "cli-truncate": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
@@ -32256,19 +32318,11 @@
                 "object-visit": "^1.0.0"
             }
         },
-        "color": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-            "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-            "requires": {
-                "color-convert": "^1.9.3",
-                "color-string": "^1.6.0"
-            }
-        },
         "color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
             "requires": {
                 "color-name": "1.1.3"
             }
@@ -32282,36 +32336,14 @@
         "color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-        },
-        "color-string": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
-            "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
-            "requires": {
-                "color-name": "^1.0.0",
-                "simple-swizzle": "^0.2.2"
-            }
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
         },
         "color-support": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
             "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
             "dev": true
-        },
-        "colors": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
-        },
-        "colorspace": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-            "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-            "requires": {
-                "color": "^3.1.3",
-                "text-hex": "1.0.x"
-            }
         },
         "combined-stream": {
             "version": "1.0.8",
@@ -32796,6 +32828,21 @@
             "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
             "dev": true
         },
+        "defaults": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+            "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+            "requires": {
+                "clone": "^1.0.2"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+                    "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="
+                }
+            }
+        },
         "define-lazy-prop": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -32914,33 +32961,50 @@
             "dev": true
         },
         "devexpress-diagram": {
-            "version": "2.1.45",
-            "resolved": "https://registry.npmjs.org/devexpress-diagram/-/devexpress-diagram-2.1.45.tgz",
-            "integrity": "sha512-kOBqGM7/t2pp/M/A/7ce20Cls2OMn44PCDRgm61HxwFnRMFYI6synZZEIhW6rwQ0e2EgkuZZdr4W3LeGIaDQbQ==",
+            "version": "2.1.63",
+            "resolved": "https://registry.npmjs.org/devexpress-diagram/-/devexpress-diagram-2.1.63.tgz",
+            "integrity": "sha512-zsqt3VFJpIlkW+/N1+GXuZEP2BG1NOirCqItFnbrZZhcNPl5nxr8LnxqiNF7MtOCjgUmCD4MbU7GxShlu9J7JA==",
             "requires": {
-                "@devexpress/utils": "1.3.13",
+                "@devexpress/utils": "1.3.16",
                 "es6-object-assign": "^1.1.0"
             }
         },
         "devexpress-gantt": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/devexpress-gantt/-/devexpress-gantt-4.1.6.tgz",
-            "integrity": "sha512-CLJDLrl1eMx6DT+ICwlZTIdNJA9f71KyazFWaN4DT8unTulymIlUsw1m2977EXW9SZ97FPirSXPqOFQnO7J54w==",
+            "version": "4.1.32",
+            "resolved": "https://registry.npmjs.org/devexpress-gantt/-/devexpress-gantt-4.1.32.tgz",
+            "integrity": "sha512-Zeuv1wH3K8fC30R6Azkeu6GemWhR1nhpMqEupyfMk+7rO/WHnqoa1F0oA6lfIzZUDU5RoERRvcZjV65AOzvbWg==",
             "requires": {
-                "@devexpress/utils": "1.3.13",
+                "@devexpress/utils": "1.3.14",
                 "tslib": "2.3.1"
+            },
+            "dependencies": {
+                "@devexpress/utils": {
+                    "version": "1.3.14",
+                    "resolved": "https://registry.npmjs.org/@devexpress/utils/-/utils-1.3.14.tgz",
+                    "integrity": "sha512-vJmUq9Rg6wqYPuZ7qvTHBsd6vkGBj5ZCMzNUJIRWIZPuQfGt576cMqDOD68EQyy/5EBqwowtoYgFdQ1a/1iVpA==",
+                    "requires": {
+                        "tslib": "2.0.1"
+                    },
+                    "dependencies": {
+                        "tslib": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+                            "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+                        }
+                    }
+                }
             }
         },
         "devextreme": {
-            "version": "22.1.1-alpha-22018-0314",
-            "resolved": "https://registry.npmjs.org/devextreme/-/devextreme-22.1.1-alpha-22018-0314.tgz",
-            "integrity": "sha512-h4iXTlzxfCqexq7dWxo3J45Z7AM5GQXyzolcpZOlsZ1AsjVA1pyBU7YXVPqHv/b9+1cQ1tVVoIUtm/bE5Nf7hg==",
+            "version": "22.2.1-alpha-22245-0308",
+            "resolved": "https://registry.npmjs.org/devextreme/-/devextreme-22.2.1-alpha-22245-0308.tgz",
+            "integrity": "sha512-WbelOy5Fl0ysHfH9Hzfg0Z2wqtCZzhJvL1hSUn5iDOCSjaHot2byHQlcR5aXa0/Qp9WyH8mXxxh3vSXqrDAU3g==",
             "requires": {
                 "@babel/runtime": "^7.12.1",
-                "@devextreme/runtime": "~3.0.2",
-                "devexpress-diagram": "2.1.45",
-                "devexpress-gantt": "4.1.6",
-                "devextreme-quill": "~1.5.10",
+                "@devextreme/runtime": "3.0.11",
+                "devexpress-diagram": "2.1.63",
+                "devexpress-gantt": "4.1.32",
+                "devextreme-quill": "~1.5.16",
                 "devextreme-showdown": "^1.0.1",
                 "inferno": "^7.4.9",
                 "inferno-compat": "^7.4.9",
@@ -32948,7 +33012,7 @@
                 "inferno-hydrate": "^7.4.9",
                 "jszip": "^3.7.1",
                 "rrule": "2.6.6",
-                "turndown": "~7.0.0"
+                "turndown": "~7.1.0"
             },
             "dependencies": {
                 "rrule": {
@@ -32968,20 +33032,82 @@
             }
         },
         "devextreme-angular": {
-            "version": "22.1.1-alpha-22018-0314",
-            "resolved": "https://registry.npmjs.org/devextreme-angular/-/devextreme-angular-22.1.1-alpha-22018-0314.tgz",
-            "integrity": "sha512-V70mPc5Y8u+gtzqY/nk+/JyiAVNnL7VzV5jwGIwVIy+mPqgXNWKtlyRIzfc72+zkQOo56YmCTu2frlkldwZtqg==",
+            "version": "22.2.1-alpha-22245-0308",
+            "resolved": "https://registry.npmjs.org/devextreme-angular/-/devextreme-angular-22.2.1-alpha-22245-0308.tgz",
+            "integrity": "sha512-Vhi1nSPJCN7MWUs/b/nCl9bxuXN2ynEiVlR2As4cM++DGI20ADLGN8O7Fmpmtvvcj0VFV0Lt1+wtOtovk/kfCQ==",
             "requires": {
-                "@angular-devkit/schematics": "^8.0.0",
+                "@angular-devkit/schematics": "^12.2.18",
                 "devextreme-schematics": "latest",
-                "inferno-server": "7.4.4",
-                "tslib": "^1.9.0"
+                "inferno-server": "7.4.11",
+                "tslib": "^2.2.0"
             },
             "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                "@angular-devkit/core": {
+                    "version": "12.2.18",
+                    "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-12.2.18.tgz",
+                    "integrity": "sha512-GDLHGe9HEY5SRS+NrKr14C8aHsRCiBFkBFSSbeohgLgcgSXzZHFoU84nDWrl3KZNP8oqcUSv5lHu6dLcf2fnww==",
+                    "requires": {
+                        "ajv": "8.6.2",
+                        "ajv-formats": "2.1.0",
+                        "fast-json-stable-stringify": "2.1.0",
+                        "magic-string": "0.25.7",
+                        "rxjs": "6.6.7",
+                        "source-map": "0.7.3"
+                    }
+                },
+                "@angular-devkit/schematics": {
+                    "version": "12.2.18",
+                    "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-12.2.18.tgz",
+                    "integrity": "sha512-bZ9NS5PgoVfetRC6WeQBHCY5FqPZ9y2TKHUo12sOB2YSL3tgWgh1oXyP8PtX34gasqsLjNULxEQsAQYEsiX/qQ==",
+                    "requires": {
+                        "@angular-devkit/core": "12.2.18",
+                        "ora": "5.4.1",
+                        "rxjs": "6.6.7"
+                    }
+                },
+                "ajv": {
+                    "version": "8.6.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
+                    "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "json-schema-traverse": "^1.0.0",
+                        "require-from-string": "^2.0.2",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                },
+                "magic-string": {
+                    "version": "0.25.7",
+                    "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+                    "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+                    "requires": {
+                        "sourcemap-codec": "^1.4.4"
+                    }
+                },
+                "rxjs": {
+                    "version": "6.6.7",
+                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+                    "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+                    "requires": {
+                        "tslib": "^1.9.0"
+                    },
+                    "dependencies": {
+                        "tslib": {
+                            "version": "1.14.1",
+                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                        }
+                    }
+                },
+                "source-map": {
+                    "version": "0.7.3",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
                 }
             }
         },
@@ -33000,33 +33126,10 @@
             "resolved": "https://registry.npmjs.org/devextreme-cldr-data/-/devextreme-cldr-data-1.0.3.tgz",
             "integrity": "sha512-xd+uWv1KzEhr+ZH/MOWfDei3GFz+NAYyKUR9HgjM9BBwPel7PpMElYp4whM+PtAjziBaTssQnA//ob5c3BovTA=="
         },
-        "devextreme-internal-tools": {
-            "version": "7.7.0",
-            "resolved": "https://registry.npmjs.org/devextreme-internal-tools/-/devextreme-internal-tools-7.7.0.tgz",
-            "integrity": "sha512-HVWnl7mH24sNMPtlzw2eQ3VHhqt6GyQk5ILdCGt6laEoHCS3z5Z9Sb7noga7/fWHHXBManZkJBt1EfSXEPE1xw==",
-            "requires": {
-                "prettier": "2.3.2",
-                "shelljs": "^0.8.3",
-                "typescript": "~4.1",
-                "winston": "^3.3.3"
-            },
-            "dependencies": {
-                "prettier": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-                    "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ=="
-                },
-                "typescript": {
-                    "version": "4.1.6",
-                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.6.tgz",
-                    "integrity": "sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow=="
-                }
-            }
-        },
         "devextreme-quill": {
-            "version": "1.5.12",
-            "resolved": "https://registry.npmjs.org/devextreme-quill/-/devextreme-quill-1.5.12.tgz",
-            "integrity": "sha512-tTgYIGMu7QI9ESil+9figY0Z+g11CgpqByIziRGir4ghqYIi4XbRJoCOH4pE3LaaTKQkrxgkrzdnmcpMCyz7Yw==",
+            "version": "1.5.18",
+            "resolved": "https://registry.npmjs.org/devextreme-quill/-/devextreme-quill-1.5.18.tgz",
+            "integrity": "sha512-qdO+8VnteqMEh/JN7q9cQogH/BZFILcPnR6FO41MiLy1fT84xEqORra7cKYQaiagf3yts934bb0ycWw8zgdFYA==",
             "requires": {
                 "core-js": "^3.19.1",
                 "eventemitter3": "^4.0.0",
@@ -33038,19 +33141,18 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.21.0",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.0.tgz",
-                    "integrity": "sha512-YUdI3fFu4TF/2WykQ2xzSiTQdldLB4KVuL9WeAy5XONZYt5Cun/fpQvctoKbCgvPhmzADeesTk/j2Rdx77AcKQ=="
+                    "version": "3.25.5",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.5.tgz",
+                    "integrity": "sha512-nbm6eZSjm+ZuBQxCUPQKQCoUEfFOXjUZ8dTTyikyKaWrTYmAVbykQfwsKE5dBK88u3QCkCrzsx/PPlKfhsvgpw=="
                 }
             }
         },
         "devextreme-react": {
-            "version": "22.1.1-alpha-22018-0314",
-            "resolved": "https://registry.npmjs.org/devextreme-react/-/devextreme-react-22.1.1-alpha-22018-0314.tgz",
-            "integrity": "sha512-6F32iujVLvo776m2gkh0tczPTKo/mT7vB6fNpXqihfYNZ34NVMzVwhYD/1XjgtdzygQFTwROdWvsOtEy1d7ZXQ==",
+            "version": "22.2.1-alpha-22245-0308",
+            "resolved": "https://registry.npmjs.org/devextreme-react/-/devextreme-react-22.2.1-alpha-22245-0308.tgz",
+            "integrity": "sha512-89zSslTAlWxRR7+lfj1xpQnKwujH36ddbg19vMsoWsDkrrEB+oJA3M841GHw+sJ4PsdKEN29bpI1s6DFiDSm7Q==",
             "requires": {
-                "devextreme-internal-tools": "^7.6.0",
-                "prop-types": "^15.6.1"
+                "prop-types": "^15.8.1"
             }
         },
         "devextreme-schematics": {
@@ -33105,9 +33207,9 @@
             }
         },
         "devextreme-vue": {
-            "version": "22.1.1-alpha-22018-0314",
-            "resolved": "https://registry.npmjs.org/devextreme-vue/-/devextreme-vue-22.1.1-alpha-22018-0314.tgz",
-            "integrity": "sha512-Q3JWfj6KOfVqzJLjnlULHQrsjW5dWYTPyDoXmHDiJFoziwIxlW6+X2rRPNb/Q2EEixlh50gg3L6BN0wz/Q5wiQ=="
+            "version": "22.2.1-alpha-22245-0308",
+            "resolved": "https://registry.npmjs.org/devextreme-vue/-/devextreme-vue-22.2.1-alpha-22245-0308.tgz",
+            "integrity": "sha512-oByoC1zRUVJycOsg5I4HR9VWQ0f+IDpKn3R3k6Oz/tyd5eYvQsml/oVjmkkyXAMYCCp/M2UTx8SD2t3fZ4Hrqw=="
         },
         "device-specs": {
             "version": "1.0.0",
@@ -33525,11 +33627,6 @@
                 "lowlight": "~1.9.0"
             }
         },
-        "enabled": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-            "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
-        },
         "encodeurl": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -33675,7 +33772,7 @@
         "es6-object-assign": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-            "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
+            "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw=="
         },
         "es6-promise": {
             "version": "4.2.8",
@@ -34912,11 +35009,6 @@
                 "bser": "2.1.1"
             }
         },
-        "fecha": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
-            "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
-        },
         "fflate": {
             "version": "0.4.8",
             "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
@@ -35225,11 +35317,6 @@
                     }
                 }
             }
-        },
-        "fn.name": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-            "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
         },
         "follow-redirects": {
             "version": "1.5.10",
@@ -36846,33 +36933,11 @@
             }
         },
         "inferno-server": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/inferno-server/-/inferno-server-7.4.4.tgz",
-            "integrity": "sha512-d8r39lumNJYT6q/N0EMnvPR48iHt5+z/gUL0hrAOsDMPQz16j8M5HJiiiXzCR+rvkcMJj01K68xD9Q2yi1ZQFw==",
+            "version": "7.4.11",
+            "resolved": "https://registry.npmjs.org/inferno-server/-/inferno-server-7.4.11.tgz",
+            "integrity": "sha512-SUnkCqZNWOIrjRVoVk/E1/70O1f1ImkCX9H2gDPbS0uc3GDxuzIeCgn0rpcc0XV9KzZJ2LTGxuBtEoQQOjUn2Q==",
             "requires": {
-                "inferno": "7.4.4"
-            },
-            "dependencies": {
-                "inferno": {
-                    "version": "7.4.4",
-                    "resolved": "https://registry.npmjs.org/inferno/-/inferno-7.4.4.tgz",
-                    "integrity": "sha512-ITPZ/Li1EvyDDNjRY7+R1MRRlPz5+fYg8wGMhgfUSMg8QcQWoeM0hP5BEYxdDz4K/aGWHfey7CgHXY6HGWylqA==",
-                    "requires": {
-                        "inferno-shared": "7.4.4",
-                        "inferno-vnode-flags": "7.4.4",
-                        "opencollective-postinstall": "^2.0.2"
-                    }
-                },
-                "inferno-shared": {
-                    "version": "7.4.4",
-                    "resolved": "https://registry.npmjs.org/inferno-shared/-/inferno-shared-7.4.4.tgz",
-                    "integrity": "sha512-HqnNCKCg30Wmt8/7MVwPr9JapIfa++dwrHvNhRWmSCcsKhF4MOJiZ1C9EunTPzSLua3n8TLrj6W3UB4gXk6kMQ=="
-                },
-                "inferno-vnode-flags": {
-                    "version": "7.4.4",
-                    "resolved": "https://registry.npmjs.org/inferno-vnode-flags/-/inferno-vnode-flags-7.4.4.tgz",
-                    "integrity": "sha512-Wyx7S/T8vKgGP4nTeqN5MYm9ryzh1xvZ1mJ4eZWXklqqnNx66kYeEUwMviqncG6uExcqnue1z8FA/rVjx/Y8yQ=="
-                }
+                "inferno": "7.4.11"
             }
         },
         "inferno-shared": {
@@ -36924,7 +36989,8 @@
         "interpret": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+            "dev": true
         },
         "invariant": {
             "version": "2.2.4",
@@ -37189,6 +37255,11 @@
             "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
             "dev": true
         },
+        "is-interactive": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+            "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="
+        },
         "is-jquery-obj": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-jquery-obj/-/is-jquery-obj-0.1.1.tgz",
@@ -37323,7 +37394,8 @@
         "is-stream": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "dev": true
         },
         "is-string": {
             "version": "1.0.7",
@@ -37360,8 +37432,7 @@
         "is-unicode-supported": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-            "dev": true
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
         },
         "is-utf8": {
             "version": "0.2.1",
@@ -40365,11 +40436,6 @@
             "integrity": "sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw==",
             "dev": true
         },
-        "kuler": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-            "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
-        },
         "last-run": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
@@ -40549,7 +40615,7 @@
         "lodash.clonedeep": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+            "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
         },
         "lodash.debounce": {
             "version": "4.0.8",
@@ -40673,7 +40739,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
             "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-            "dev": true,
             "requires": {
                 "chalk": "^4.1.0",
                 "is-unicode-supported": "^0.1.0"
@@ -40683,7 +40748,6 @@
                     "version": "4.3.0",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
                     "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "dev": true,
                     "requires": {
                         "color-convert": "^2.0.1"
                     }
@@ -40692,7 +40756,6 @@
                     "version": "4.1.2",
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
                     "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                    "dev": true,
                     "requires": {
                         "ansi-styles": "^4.1.0",
                         "supports-color": "^7.1.0"
@@ -40702,7 +40765,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
                     "requires": {
                         "color-name": "~1.1.4"
                     }
@@ -40710,20 +40772,17 @@
                 "color-name": {
                     "version": "1.1.4",
                     "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
                 },
                 "has-flag": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
                 },
                 "supports-color": {
                     "version": "7.2.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
                     "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
@@ -40756,25 +40815,6 @@
                     "requires": {
                         "mimic-fn": "^1.0.0"
                     }
-                }
-            }
-        },
-        "logform": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/logform/-/logform-2.3.2.tgz",
-            "integrity": "sha512-V6JiPThZzTsbVRspNO6TmHkR99oqYTs8fivMBYQkjZj6rxW92KxtDCPE6IkAk1DNBnYKNkjm4jYBm6JDUcyhOA==",
-            "requires": {
-                "colors": "1.4.0",
-                "fecha": "^4.2.0",
-                "ms": "^2.1.1",
-                "safe-stable-stringify": "^1.1.0",
-                "triple-beam": "^1.3.0"
-            },
-            "dependencies": {
-                "safe-stable-stringify": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
-                    "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
                 }
             }
         },
@@ -41432,7 +41472,8 @@
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "multimatch": {
             "version": "2.1.0",
@@ -42039,19 +42080,10 @@
                 "wrappy": "1"
             }
         },
-        "one-time": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-            "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-            "requires": {
-                "fn.name": "1.x.x"
-            }
-        },
         "onetime": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
             "requires": {
                 "mimic-fn": "^2.1.0"
             },
@@ -42059,8 +42091,7 @@
                 "mimic-fn": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-                    "dev": true
+                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
                 }
             }
         },
@@ -42109,6 +42140,67 @@
                 "prelude-ls": "^1.2.1",
                 "type-check": "^0.4.0",
                 "word-wrap": "^1.2.3"
+            }
+        },
+        "ora": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+            "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+            "requires": {
+                "bl": "^4.1.0",
+                "chalk": "^4.1.0",
+                "cli-cursor": "^3.1.0",
+                "cli-spinners": "^2.5.0",
+                "is-interactive": "^1.0.0",
+                "is-unicode-supported": "^0.1.0",
+                "log-symbols": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "wcwidth": "^1.0.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "ordered-read-streams": {
@@ -43434,6 +43526,7 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+            "dev": true,
             "requires": {
                 "resolve": "^1.1.6"
             }
@@ -43793,8 +43886,7 @@
         "require-from-string": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-            "dev": true
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
         },
         "require-main-filename": {
             "version": "1.0.1",
@@ -43863,6 +43955,15 @@
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
             "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
             "dev": true
+        },
+        "restore-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+            "requires": {
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
+            }
         },
         "ret": {
             "version": "0.1.15",
@@ -43951,11 +44052,6 @@
             "requires": {
                 "ret": "~0.1.10"
             }
-        },
-        "safe-stable-stringify": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
-            "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
         },
         "safer-buffer": {
             "version": "2.1.2",
@@ -44390,16 +44486,6 @@
             "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
             "dev": true
         },
-        "shelljs": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-            "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-            "requires": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-            }
-        },
         "shellwords": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
@@ -44427,8 +44513,7 @@
         "signal-exit": {
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
         },
         "signalr": {
             "version": "2.2.2",
@@ -44436,21 +44521,6 @@
             "integrity": "sha1-ugeRXrXgjPvId2UEfsaXJpTQCOI=",
             "requires": {
                 "jquery": ">=1.6.4"
-            }
-        },
-        "simple-swizzle": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-            "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-            "requires": {
-                "is-arrayish": "^0.3.1"
-            },
-            "dependencies": {
-                "is-arrayish": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-                    "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-                }
             }
         },
         "sisteransi": {
@@ -44745,7 +44815,8 @@
         "stack-trace": {
             "version": "0.0.10",
             "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+            "dev": true
         },
         "stack-utils": {
             "version": "2.0.5",
@@ -46228,11 +46299,6 @@
             "integrity": "sha512-ge1msi8RyNVyK0QrsmC79zedV7jHasKpBPeOUZd/ORpbYLeYDnprjIeOuIukw0knnTieeYsOK29/ZD+UI7/tdw==",
             "dev": true
         },
-        "text-hex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-            "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
-        },
         "text-segmentation": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
@@ -46633,11 +46699,6 @@
             "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
             "dev": true
         },
-        "triple-beam": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
-            "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
-        },
         "trough": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
@@ -46713,9 +46774,9 @@
             }
         },
         "turndown": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.0.0.tgz",
-            "integrity": "sha512-G1FfxfR0mUNMeGjszLYl3kxtopC4O9DRRiMlMDDVHvU1jaBkGFg4qxIyjIk2aiKLHyDyZvZyu4qBO2guuYBy3Q==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.1.1.tgz",
+            "integrity": "sha512-BEkXaWH7Wh7e9bd2QumhfAXk5g34+6QUmmWx+0q6ThaVOLuLUqsnkq35HQ5SBHSaxjSfSM7US5o4lhJNH7B9MA==",
             "requires": {
                 "domino": "^2.1.6"
             }
@@ -47365,6 +47426,14 @@
                 "makeerror": "1.0.12"
             }
         },
+        "wcwidth": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+            "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+            "requires": {
+                "defaults": "^1.0.3"
+            }
+        },
         "webauth": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/webauth/-/webauth-1.1.0.tgz",
@@ -47494,40 +47563,6 @@
                         "isexe": "^2.0.0"
                     }
                 }
-            }
-        },
-        "winston": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/winston/-/winston-3.5.1.tgz",
-            "integrity": "sha512-tbRtVy+vsSSCLcZq/8nXZaOie/S2tPXPFt4be/Q3vI/WtYwm7rrwidxVw2GRa38FIXcJ1kUM6MOZ9Jmnk3F3UA==",
-            "requires": {
-                "@dabh/diagnostics": "^2.0.2",
-                "async": "^3.2.3",
-                "is-stream": "^2.0.0",
-                "logform": "^2.3.2",
-                "one-time": "^1.0.0",
-                "readable-stream": "^3.4.0",
-                "safe-stable-stringify": "^2.3.1",
-                "stack-trace": "0.0.x",
-                "triple-beam": "^1.3.0",
-                "winston-transport": "^4.4.2"
-            },
-            "dependencies": {
-                "async": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-                    "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
-                }
-            }
-        },
-        "winston-transport": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
-            "integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
-            "requires": {
-                "logform": "^2.3.2",
-                "readable-stream": "^3.6.0",
-                "triple-beam": "^1.3.0"
             }
         },
         "word-wrap": {


### PR DESCRIPTION
### Problem
After package.json edits in https://github.com/DevExpress/devextreme-demos/pull/1913/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519

versions in package-lock are still old (search for `0314`)

### Changes
I had to execute
```
npm update devextreme devextreme-angular devextreme-react devextreme-vue
```
to update the lock file.

### Extra notes

Looks like we should update our 'Switch to a next major' guide 