### PR TITLE
ASP.NET Core demos maintenance after upgrade to .NET 6

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,8 @@
 *.dbf   binary
 *.shp   binary
 *.shx   binary
+
+# databases
+*.mdf    binary
+*.db     binary
+*.sqlite binary

--- a/NetCoreDemos/Controllers/ApiControllers/FileManagerAzureProviderApiController.cs
+++ b/NetCoreDemos/Controllers/ApiControllers/FileManagerAzureProviderApiController.cs
@@ -6,12 +6,12 @@ using System;
 
 namespace DevExtreme.NETCore.Demos.Controllers {
     public class FileManagerAzureProviderApiController : Controller {
-        public FileManagerAzureProviderApiController(IHostingEnvironment hostingEnvironment, AzureBlobFileProvider azureFileProvider) {
-            HostingEnvironment = hostingEnvironment;
+        public FileManagerAzureProviderApiController(IWebHostEnvironment webHostEnvironment, AzureBlobFileProvider azureFileProvider) {
+            WebHostEnvironment = webHostEnvironment;
             AzureFileProvider = azureFileProvider ?? throw new ArgumentNullException(nameof(azureFileProvider));
         }
 
-        IHostingEnvironment HostingEnvironment { get; }
+        IWebHostEnvironment WebHostEnvironment { get; }
         AzureBlobFileProvider AzureFileProvider { get; }
 
         [Route("api/file-manager-azure", Name = "FileManagerAzureProviderApi")]
@@ -30,7 +30,7 @@ namespace DevExtreme.NETCore.Demos.Controllers {
                 UploadConfiguration = new UploadConfiguration {
                     MaxFileSize = 1048576
                 },
-                TempDirectory = HostingEnvironment.ContentRootPath + "/UploadTemp"
+                TempDirectory = WebHostEnvironment.ContentRootPath + "/UploadTemp"
             };
             var processor = new FileSystemCommandProcessor(config);
             var result = processor.Execute(command, arguments);

--- a/NetCoreDemos/Controllers/ApiControllers/FileManagerImagesApiController.cs
+++ b/NetCoreDemos/Controllers/ApiControllers/FileManagerImagesApiController.cs
@@ -8,17 +8,17 @@ namespace DevExtreme.NETCore.Demos.Controllers {
     public class FileManagerImagesApiController : Controller {
         static readonly string SampleImagesRelativePath = Path.Combine("SampleData", "SampleImages");
 
-        public FileManagerImagesApiController(IHostingEnvironment hostingEnvironment) {
-            HostingEnvironment = hostingEnvironment;
+        public FileManagerImagesApiController(IWebHostEnvironment webHostEnvironment) {
+            WebHostEnvironment = webHostEnvironment;
         }
-        public IHostingEnvironment HostingEnvironment { get; }
+        public IWebHostEnvironment WebHostEnvironment { get; }
 
         [Route("api/file-manager-file-system-images", Name = "FileManagementImagesApi")]
         public object FileSystem(FileSystemCommand command, string arguments) {
             var config = new FileSystemConfiguration {
                 Request = Request,
                 FileSystemProvider = new PhysicalFileSystemProvider(
-                    Path.Combine(HostingEnvironment.WebRootPath, SampleImagesRelativePath),
+                    Path.Combine(WebHostEnvironment.WebRootPath, SampleImagesRelativePath),
                     (fileSystemItem, clientItem) => {
                         if(!clientItem.IsDirectory)
                             clientItem.CustomFields["url"] = GetFileItemUrl(fileSystemItem);
@@ -40,7 +40,7 @@ namespace DevExtreme.NETCore.Demos.Controllers {
 
         string GetFileItemUrl(FileSystemInfo fileSystemItem) {
             var relativeUrl = fileSystemItem.FullName
-                .Replace(HostingEnvironment.WebRootPath, "")
+                .Replace(WebHostEnvironment.WebRootPath, "")
                 .Replace(Path.DirectorySeparatorChar, '/');
             return $"{Request.Scheme}://{Request.Host}{Request.PathBase}{relativeUrl}";
         }

--- a/NetCoreDemos/Controllers/ApiControllers/FileManagerScriptsApiController.cs
+++ b/NetCoreDemos/Controllers/ApiControllers/FileManagerScriptsApiController.cs
@@ -4,17 +4,17 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace DevExtreme.NETCore.Demos.Controllers {
     public class FileManagerScriptsApiController : Controller {
-        IHostingEnvironment _hostingEnvironment;
+        IWebHostEnvironment _webHostEnvironment;
 
-        public FileManagerScriptsApiController(IHostingEnvironment hostingEnvironment) {
-            _hostingEnvironment = hostingEnvironment;
+        public FileManagerScriptsApiController(IWebHostEnvironment webHostEnvironment) {
+            _webHostEnvironment = webHostEnvironment;
         }
 
         [Route("api/file-manager-file-system", Name = "FileManagementFileSystemApi")]
         public object FileSystem(FileSystemCommand command, string arguments) {
             var config = new FileSystemConfiguration {
                 Request = Request,
-                FileSystemProvider = new PhysicalFileSystemProvider(_hostingEnvironment.ContentRootPath + "/wwwroot"),
+                FileSystemProvider = new PhysicalFileSystemProvider(_webHostEnvironment.ContentRootPath + "/wwwroot"),
                 //uncomment the code below to enable file/folder management
                 //AllowCopy = true,
                 //AllowCreate = true,

--- a/NetCoreDemos/Controllers/ApiControllers/TreeListDataController.cs
+++ b/NetCoreDemos/Controllers/ApiControllers/TreeListDataController.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Net.Http;
 using System.IO;
-using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Hosting;
 
@@ -10,16 +9,16 @@ namespace DevExtreme.NETCore.Demos.Controllers.ApiControllers {
 
     [Route("api/[controller]")]
     public class TreeListDataController : Controller {
-        IHostingEnvironment _hostingEnvironment;
+        IWebHostEnvironment _webHostEnvironment;
 
-        public TreeListDataController(IHostingEnvironment hostingEnvironment) {
-            _hostingEnvironment = hostingEnvironment;
+        public TreeListDataController(IWebHostEnvironment webHostEnvironment) {
+            _webHostEnvironment = webHostEnvironment;
         }
 
         [HttpGet]
         public object Get(string parentIds) {
             var parents = string.IsNullOrEmpty(parentIds) ? new[] { "" } : parentIds.Split(',');
-            var rootPath = _hostingEnvironment.ContentRootPath;
+            var rootPath = _webHostEnvironment.ContentRootPath;
 
             var childNodes = parents.SelectMany(parentId => {
                 var parentPath = String.IsNullOrEmpty(parentId) ? rootPath : Path.Combine(rootPath, parentId);

--- a/NetCoreDemos/Controllers/ApiControllers/TreeViewDataController.cs
+++ b/NetCoreDemos/Controllers/ApiControllers/TreeViewDataController.cs
@@ -11,15 +11,15 @@ namespace DevExtreme.NETCore.Demos.Controllers.ApiControllers {
     [Route("api/[controller]")]
     public class TreeViewDataController : Controller {
 
-        IHostingEnvironment _hostingEnvironment;
+        IWebHostEnvironment _webHostEnvironment;
 
-        public TreeViewDataController(IHostingEnvironment hostingEnvironment) {
-            _hostingEnvironment = hostingEnvironment;
+        public TreeViewDataController(IWebHostEnvironment webHostEnvironment) {
+            _webHostEnvironment = webHostEnvironment;
         }
 
         [HttpGet]
         public object Get(string parentId) {
-            var rootPath = _hostingEnvironment.ContentRootPath;
+            var rootPath = _webHostEnvironment.ContentRootPath;
             var parentPath = String.IsNullOrEmpty(parentId) ? rootPath : Path.Combine(rootPath, parentId);
 
             var childNodes = Directory.EnumerateFileSystemEntries(parentPath)

--- a/NetCoreDemos/Controllers/FileUploaderBaseController.cs
+++ b/NetCoreDemos/Controllers/FileUploaderBaseController.cs
@@ -6,10 +6,10 @@ using System.Linq;
 
 namespace DevExtreme.NETCore.Demos.Controllers {
     public partial class FileUploaderController : Controller {
-        IHostingEnvironment _hostingEnvironment;
+        IWebHostEnvironment _webHostEnvironment;
 
-        public FileUploaderController(IHostingEnvironment hostingEnvironment) {
-            _hostingEnvironment = hostingEnvironment;
+        public FileUploaderController(IWebHostEnvironment webHostEnvironment) {
+            _webHostEnvironment = webHostEnvironment;
         }
     }
 }

--- a/NetCoreDemos/Controllers/FileUploaderController.cs
+++ b/NetCoreDemos/Controllers/FileUploaderController.cs
@@ -22,7 +22,7 @@ namespace DevExtreme.NETCore.Demos.Controllers {
             // http://js.devexpress.com/Documentation/Guide/UI_Widgets/UI_Widgets_-_Deep_Dive/dxFileUploader/
             try {
                 var myFile = Request.Form.Files["myFile"];
-                var path = Path.Combine(_hostingEnvironment.WebRootPath, "uploads");
+                var path = Path.Combine(_webHostEnvironment.WebRootPath, "uploads");
                 // Uncomment to save the file
                 //if(!Directory.Exists(path))
                 //    Directory.CreateDirectory(path);
@@ -62,7 +62,7 @@ namespace DevExtreme.NETCore.Demos.Controllers {
 
         void SaveFile(IFormFile file) {
             try {
-                var path = Path.Combine(_hostingEnvironment.WebRootPath, "uploads");
+                var path = Path.Combine(_webHostEnvironment.WebRootPath, "uploads");
                 // Uncomment to save the file
                 //if(!Directory.Exists(path))
                 //    Directory.CreateDirectory(path);
@@ -92,7 +92,7 @@ namespace DevExtreme.NETCore.Demos.Controllers {
 
                 if(isValidExtenstion) {
                     // Uncomment to save the file
-                    //var path = Path.Combine(_hostingEnvironment.WebRootPath, "uploads");
+                    //var path = Path.Combine(_webHostEnvironment.WebRootPath, "uploads");
                     //if(!Directory.Exists(path))
                     //    Directory.CreateDirectory(path);
 
@@ -112,7 +112,7 @@ namespace DevExtreme.NETCore.Demos.Controllers {
                 var maxFileSize = 4000000;
                 if(smallFile.Length < maxFileSize) {
                     // Uncomment to save the file
-                    //var path = Path.Combine(_hostingEnvironment.WebRootPath, "uploads");
+                    //var path = Path.Combine(_webHostEnvironment.WebRootPath, "uploads");
                     //if(!Directory.Exists(path))
                     //    Directory.CreateDirectory(path);
 
@@ -145,7 +145,7 @@ namespace DevExtreme.NETCore.Demos.Controllers {
 
         [HttpPost]
         public ActionResult UploadChunk(IFormFile file, string chunkMetadata) {
-            var tempPath = Path.Combine(_hostingEnvironment.WebRootPath, "uploads");
+            var tempPath = Path.Combine(_webHostEnvironment.WebRootPath, "uploads");
             // Removes temporary files
             //RemoveTempFilesAfterDelay(tempPath, new TimeSpan(0, 5, 0));
 
@@ -191,7 +191,7 @@ namespace DevExtreme.NETCore.Demos.Controllers {
         }
         void ProcessUploadedFile(string tempFilePath, string fileName) {
             // Check if the uploaded file is a valid image
-            var path = Path.Combine(_hostingEnvironment.WebRootPath, "uploads");
+            var path = Path.Combine(_webHostEnvironment.WebRootPath, "uploads");
             System.IO.File.Copy(tempFilePath, Path.Combine(path, fileName));
         }
         void AppendContentToFile(string path, IFormFile content) {

--- a/NetCoreDemos/DevExtreme.NETCore.Demos.csproj
+++ b/NetCoreDemos/DevExtreme.NETCore.Demos.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="BuildBundlerMinifier" Version="2.8.391" />
     <PackageReference Include="CommonMark.NET" Version="0.15.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.9" />
     <PackageReference Include="DevExtreme.AspNet.Data" Version="2.8.6" />
     <PackageReference Include="DevExtreme.AspNet.Core" Version="22.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />

--- a/NetCoreDemos/Models/Northwind/NorthwindContext.cs
+++ b/NetCoreDemos/Models/Northwind/NorthwindContext.cs
@@ -20,24 +20,24 @@ namespace DevExtreme.NETCore.Demos.Models.Northwind {
         protected override void OnModelCreating(ModelBuilder modelBuilder) {
             modelBuilder.Entity<Customer>(entity => {
                 entity.HasIndex(e => e.City)
-                    .HasName("City");
+                    .HasDatabaseName("City");
 
                 entity.HasIndex(e => e.CompanyName)
-                    .HasName("CompanyName");
+                    .HasDatabaseName("CompanyName");
 
                 entity.HasIndex(e => e.PostalCode)
-                    .HasName("PostalCode");
+                    .HasDatabaseName("PostalCode");
 
                 entity.HasIndex(e => e.Region)
-                    .HasName("Region");
+                    .HasDatabaseName("Region");
             });
 
             modelBuilder.Entity<Employee>(entity => {
                 entity.HasIndex(e => e.LastName)
-                    .HasName("LastName");
+                    .HasDatabaseName("LastName");
 
                 entity.HasIndex(e => e.PostalCode)
-                    .HasName("PostalCode");
+                    .HasDatabaseName("PostalCode");
             });
 
             modelBuilder.Entity<Order_Detail>(entity => {
@@ -45,10 +45,10 @@ namespace DevExtreme.NETCore.Demos.Models.Northwind {
                     .HasName("PK_Order_Details");
 
                 entity.HasIndex(e => e.OrderID)
-                    .HasName("OrdersOrder_Details");
+                    .HasDatabaseName("OrdersOrder_Details");
 
                 entity.HasIndex(e => e.ProductID)
-                    .HasName("ProductsOrder_Details");
+                    .HasDatabaseName("ProductsOrder_Details");
 
                 entity.Property(e => e.Discount).HasDefaultValueSql("0");
 
@@ -59,40 +59,40 @@ namespace DevExtreme.NETCore.Demos.Models.Northwind {
 
             modelBuilder.Entity<Order>(entity => {
                 entity.HasIndex(e => e.CustomerID)
-                    .HasName("CustomersOrders");
+                    .HasDatabaseName("CustomersOrders");
 
                 entity.HasIndex(e => e.EmployeeID)
-                    .HasName("EmployeesOrders");
+                    .HasDatabaseName("EmployeesOrders");
 
                 entity.HasIndex(e => e.OrderDate)
-                    .HasName("OrderDate");
+                    .HasDatabaseName("OrderDate");
 
                 entity.HasIndex(e => e.ShipPostalCode)
-                    .HasName("ShipPostalCode");
+                    .HasDatabaseName("ShipPostalCode");
 
                 entity.HasIndex(e => e.ShipVia)
-                    .HasName("ShippersOrders");
+                    .HasDatabaseName("ShippersOrders");
 
                 entity.HasIndex(e => e.ShippedDate)
-                    .HasName("ShippedDate");
+                    .HasDatabaseName("ShippedDate");
 
                 entity.Property(e => e.Freight).HasDefaultValueSql("0");
             });
 
             modelBuilder.Entity<Category>(entity => {
                 entity.HasIndex(e => e.CategoryName)
-                    .HasName("CategoryName");
+                    .HasDatabaseName("CategoryName");
             });
 
             modelBuilder.Entity<Product>(entity => {
                 entity.HasIndex(e => e.CategoryID)
-                    .HasName("CategoryID");
+                    .HasDatabaseName("CategoryID");
 
                 entity.HasIndex(e => e.ProductName)
-                    .HasName("ProductName");
+                    .HasDatabaseName("ProductName");
 
                 entity.HasIndex(e => e.SupplierID)
-                    .HasName("SuppliersProducts");
+                    .HasDatabaseName("SuppliersProducts");
 
                 entity.Property(e => e.Discontinued).HasDefaultValueSql("0");
 
@@ -107,10 +107,10 @@ namespace DevExtreme.NETCore.Demos.Models.Northwind {
 
             modelBuilder.Entity<Supplier>(entity => {
                 entity.HasIndex(e => e.CompanyName)
-                    .HasName("CompanyName");
+                    .HasDatabaseName("CompanyName");
 
                 entity.HasIndex(e => e.PostalCode)
-                    .HasName("PostalCode");
+                    .HasDatabaseName("PostalCode");
             });
         }
     }

--- a/NetCoreDemos/Startup.cs
+++ b/NetCoreDemos/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json.Serialization;
 using System;
 using System.IO;
@@ -17,7 +18,7 @@ using DevExtreme.NETCore.Demos.Models.FileManagement;
 
 namespace DevExtreme.NETCore.Demos {
     public class Startup {
-        public Startup(IHostingEnvironment env) {
+        public Startup(IWebHostEnvironment env) {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
                 .AddJsonFile("appsettings.json");
@@ -93,34 +94,34 @@ namespace DevExtreme.NETCore.Demos {
         }
 
         static void ConfigureNorthwindContext(IServiceProvider serviceProvider, DbContextOptionsBuilder options) {
-            var hosting = serviceProvider.GetRequiredService<IHostingEnvironment>();
+            var env = serviceProvider.GetRequiredService<IWebHostEnvironment>();
 #if DB_LOCALDB
-            var dbPath = Path.Combine(hosting.ContentRootPath, "Northwind.mdf");
+            var dbPath = Path.Combine(env.ContentRootPath, "Northwind.mdf");
             var connectionString = $@"Data Source=(localdb)\devextreme; AttachDbFileName={dbPath}; Integrated Security=True; MultipleActiveResultSets=True; App=EntityFramework";
             options.UseSqlServer(connectionString);
 #endif
 
 #if DB_SQLITE
-            var dbPath = Path.Combine(hosting.ContentRootPath, "Northwind.sqlite");
+            var dbPath = Path.Combine(env.ContentRootPath, "Northwind.sqlite");
             options.UseSqlite("Data Source=" + dbPath);
 #endif
         }
 
         static void ConfigureFileManagementContext(IServiceProvider serviceProvider, DbContextOptionsBuilder options) {
-            var hosting = serviceProvider.GetRequiredService<IHostingEnvironment>();
-            var dbPath = Path.Combine(hosting.ContentRootPath, "FileManagement.db");
+            var env = serviceProvider.GetRequiredService<IWebHostEnvironment>();
+            var dbPath = Path.Combine(env.ContentRootPath, "FileManagement.db");
             options.UseSqlite("Data Source=" + dbPath);
         }
 
         static AzureBlobFileProvider CreateAzureBlobFileProvider(IServiceProvider serviceProvider) {
-            var hosting = serviceProvider.GetRequiredService<IHostingEnvironment>();
-            string tempDirPath = Path.Combine(hosting.ContentRootPath, "UploadTemp");
-            AzureStorageAccount account = AzureStorageAccount.FileManager;
+            var env = serviceProvider.GetRequiredService<IWebHostEnvironment>();
+            var tempDirPath = Path.Combine(env.ContentRootPath, "UploadTemp");
+            var account = AzureStorageAccount.FileManager;
             return new AzureBlobFileProvider(account.AccountName, account.AccessKey, account.ContainerName, tempDirPath);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env) {
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env) {
             if(env.IsDevelopment()) {
                 app.UseDeveloperExceptionPage();
             } else {

--- a/NetCoreDemos/Views/TabPanel/SortableClosableTabs.cshtml
+++ b/NetCoreDemos/Views/TabPanel/SortableClosableTabs.cshtml
@@ -15,7 +15,7 @@
     .ItemOrientation(Orientation.Horizontal)
     .DragDirection(DragDirection.Horizontal)
     .OnReorder("onReorder")
-    .Content(@<text>@Html.Partial("_SortableTabPanel")</text>)
+    .Content(@<text>@await Html.PartialAsync("_SortableTabPanel")</text>)
 )
 
 <script>


### PR DESCRIPTION
In this PR:
- deprecated `IHostingEnvironment` → `IWebHostEnvironment`
- deprecated `HasName` → `HasDatabaseName`
- deprecated `Html.Partial` → `Html.PartialAsync`
- add binary databases to `.gitattributes`
- fix broken `Northwind.mdf` (copied from MVC demo)
- add missing `Microsoft.EntityFrameworkCore.SqlServer` (was implicit in old NET Core)
