### PR TITLE
Remove the use of dx.common.css

### DIFF
--- a/JSDemos/Demos/Accordion/Overview/Angular/index.html
+++ b/JSDemos/Demos/Accordion/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Accordion/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/Accordion/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Accordion/Overview/Knockout/index.html
+++ b/JSDemos/Demos/Accordion/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Accordion/Overview/React/index.html
+++ b/JSDemos/Demos/Accordion/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Accordion/Overview/Vue/index.html
+++ b/JSDemos/Demos/Accordion/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Accordion/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Accordion/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/underscore/underscore.js"></script>

--- a/JSDemos/Demos/ActionSheet/Basics/Angular/index.html
+++ b/JSDemos/Demos/ActionSheet/Basics/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/ActionSheet/Basics/AngularJS/index.html
+++ b/JSDemos/Demos/ActionSheet/Basics/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/ActionSheet/Basics/Knockout/index.html
+++ b/JSDemos/Demos/ActionSheet/Basics/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/ActionSheet/Basics/React/index.html
+++ b/JSDemos/Demos/ActionSheet/Basics/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/ActionSheet/Basics/Vue/index.html
+++ b/JSDemos/Demos/ActionSheet/Basics/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/ActionSheet/Basics/jQuery/index.html
+++ b/JSDemos/Demos/ActionSheet/Basics/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/ActionSheet/PopoverMode/Angular/index.html
+++ b/JSDemos/Demos/ActionSheet/PopoverMode/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/ActionSheet/PopoverMode/AngularJS/index.html
+++ b/JSDemos/Demos/ActionSheet/PopoverMode/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/ActionSheet/PopoverMode/Knockout/index.html
+++ b/JSDemos/Demos/ActionSheet/PopoverMode/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/ActionSheet/PopoverMode/React/index.html
+++ b/JSDemos/Demos/ActionSheet/PopoverMode/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/ActionSheet/PopoverMode/Vue/index.html
+++ b/JSDemos/Demos/ActionSheet/PopoverMode/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/ActionSheet/PopoverMode/jQuery/index.html
+++ b/JSDemos/Demos/ActionSheet/PopoverMode/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Autocomplete/Overview/Angular/index.html
+++ b/JSDemos/Demos/Autocomplete/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Autocomplete/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/Autocomplete/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Autocomplete/Overview/Knockout/index.html
+++ b/JSDemos/Demos/Autocomplete/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Autocomplete/Overview/React/index.html
+++ b/JSDemos/Demos/Autocomplete/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Autocomplete/Overview/Vue/index.html
+++ b/JSDemos/Demos/Autocomplete/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Autocomplete/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Autocomplete/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Box/Overview/Angular/index.html
+++ b/JSDemos/Demos/Box/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Box/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/Box/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Box/Overview/Knockout/index.html
+++ b/JSDemos/Demos/Box/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Box/Overview/React/index.html
+++ b/JSDemos/Demos/Box/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Box/Overview/Vue/index.html
+++ b/JSDemos/Demos/Box/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Box/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Box/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Button/Icons/Angular/index.html
+++ b/JSDemos/Demos/Button/Icons/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/Button/Icons/AngularJS/index.html
+++ b/JSDemos/Demos/Button/Icons/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/Button/Icons/Knockout/index.html
+++ b/JSDemos/Demos/Button/Icons/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Button/Icons/React/index.html
+++ b/JSDemos/Demos/Button/Icons/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Button/Icons/Vue/index.html
+++ b/JSDemos/Demos/Button/Icons/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/Button/Icons/jQuery/index.html
+++ b/JSDemos/Demos/Button/Icons/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Button/PredefinedTypes/Angular/index.html
+++ b/JSDemos/Demos/Button/PredefinedTypes/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Button/PredefinedTypes/AngularJS/index.html
+++ b/JSDemos/Demos/Button/PredefinedTypes/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Button/PredefinedTypes/React/index.html
+++ b/JSDemos/Demos/Button/PredefinedTypes/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Button/PredefinedTypes/Vue/index.html
+++ b/JSDemos/Demos/Button/PredefinedTypes/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Button/PredefinedTypes/jQuery/index.html
+++ b/JSDemos/Demos/Button/PredefinedTypes/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/ButtonGroup/Overview/Angular/index.html
+++ b/JSDemos/Demos/ButtonGroup/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/ButtonGroup/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/ButtonGroup/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/ButtonGroup/Overview/Knockout/index.html
+++ b/JSDemos/Demos/ButtonGroup/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/ButtonGroup/Overview/React/index.html
+++ b/JSDemos/Demos/ButtonGroup/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/ButtonGroup/Overview/Vue/index.html
+++ b/JSDemos/Demos/ButtonGroup/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/ButtonGroup/Overview/jQuery/index.html
+++ b/JSDemos/Demos/ButtonGroup/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Calendar/Overview/Angular/index.html
+++ b/JSDemos/Demos/Calendar/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Calendar/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/Calendar/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Calendar/Overview/Knockout/index.html
+++ b/JSDemos/Demos/Calendar/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Calendar/Overview/React/index.html
+++ b/JSDemos/Demos/Calendar/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Calendar/Overview/Vue/index.html
+++ b/JSDemos/Demos/Calendar/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/Calendar/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Calendar/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Charts/APIDisplayATooltip/Angular/index.html
+++ b/JSDemos/Demos/Charts/APIDisplayATooltip/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/APIDisplayATooltip/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/APIDisplayATooltip/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/APIDisplayATooltip/Knockout/index.html
+++ b/JSDemos/Demos/Charts/APIDisplayATooltip/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/APIDisplayATooltip/React/index.html
+++ b/JSDemos/Demos/Charts/APIDisplayATooltip/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/APIDisplayATooltip/Vue/index.html
+++ b/JSDemos/Demos/Charts/APIDisplayATooltip/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/APIDisplayATooltip/jQuery/index.html
+++ b/JSDemos/Demos/Charts/APIDisplayATooltip/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/APISelectAPoint/Angular/index.html
+++ b/JSDemos/Demos/Charts/APISelectAPoint/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/APISelectAPoint/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/APISelectAPoint/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/APISelectAPoint/Knockout/index.html
+++ b/JSDemos/Demos/Charts/APISelectAPoint/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/APISelectAPoint/React/index.html
+++ b/JSDemos/Demos/Charts/APISelectAPoint/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/APISelectAPoint/Vue/index.html
+++ b/JSDemos/Demos/Charts/APISelectAPoint/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/APISelectAPoint/jQuery/index.html
+++ b/JSDemos/Demos/Charts/APISelectAPoint/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/AjaxRequest/Angular/index.html
+++ b/JSDemos/Demos/Charts/AjaxRequest/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/AjaxRequest/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/AjaxRequest/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/AjaxRequest/Knockout/index.html
+++ b/JSDemos/Demos/Charts/AjaxRequest/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Charts/AjaxRequest/React/index.html
+++ b/JSDemos/Demos/Charts/AjaxRequest/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/AjaxRequest/Vue/index.html
+++ b/JSDemos/Demos/Charts/AjaxRequest/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/AjaxRequest/jQuery/index.html
+++ b/JSDemos/Demos/Charts/AjaxRequest/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Charts/Annotation/Angular/index.html
+++ b/JSDemos/Demos/Charts/Annotation/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Annotation/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/Annotation/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/Annotation/React/index.html
+++ b/JSDemos/Demos/Charts/Annotation/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/Annotation/Vue/index.html
+++ b/JSDemos/Demos/Charts/Annotation/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Annotation/jQuery/index.html
+++ b/JSDemos/Demos/Charts/Annotation/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Area/Angular/index.html
+++ b/JSDemos/Demos/Charts/Area/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Area/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/Area/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/Area/Knockout/index.html
+++ b/JSDemos/Demos/Charts/Area/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Area/React/index.html
+++ b/JSDemos/Demos/Charts/Area/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/Area/Vue/index.html
+++ b/JSDemos/Demos/Charts/Area/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Area/jQuery/index.html
+++ b/JSDemos/Demos/Charts/Area/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/AreaSparklines/Angular/index.html
+++ b/JSDemos/Demos/Charts/AreaSparklines/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/AreaSparklines/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/AreaSparklines/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/AreaSparklines/Knockout/index.html
+++ b/JSDemos/Demos/Charts/AreaSparklines/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/AreaSparklines/React/index.html
+++ b/JSDemos/Demos/Charts/AreaSparklines/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/AreaSparklines/Vue/index.html
+++ b/JSDemos/Demos/Charts/AreaSparklines/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/AreaSparklines/jQuery/index.html
+++ b/JSDemos/Demos/Charts/AreaSparklines/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/AutoCalculatedBarWidth/Angular/index.html
+++ b/JSDemos/Demos/Charts/AutoCalculatedBarWidth/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/AutoCalculatedBarWidth/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/AutoCalculatedBarWidth/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/AutoCalculatedBarWidth/Knockout/index.html
+++ b/JSDemos/Demos/Charts/AutoCalculatedBarWidth/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/AutoCalculatedBarWidth/React/index.html
+++ b/JSDemos/Demos/Charts/AutoCalculatedBarWidth/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/AutoCalculatedBarWidth/Vue/index.html
+++ b/JSDemos/Demos/Charts/AutoCalculatedBarWidth/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/AutoCalculatedBarWidth/jQuery/index.html
+++ b/JSDemos/Demos/Charts/AutoCalculatedBarWidth/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/AxisCustomPosition/Angular/index.html
+++ b/JSDemos/Demos/Charts/AxisCustomPosition/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/AxisCustomPosition/React/index.html
+++ b/JSDemos/Demos/Charts/AxisCustomPosition/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/AxisCustomPosition/Vue/index.html
+++ b/JSDemos/Demos/Charts/AxisCustomPosition/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/AxisCustomPosition/jQuery/index.html
+++ b/JSDemos/Demos/Charts/AxisCustomPosition/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/AxisLabelsOverlapping/Angular/index.html
+++ b/JSDemos/Demos/Charts/AxisLabelsOverlapping/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/AxisLabelsOverlapping/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/AxisLabelsOverlapping/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/AxisLabelsOverlapping/Knockout/index.html
+++ b/JSDemos/Demos/Charts/AxisLabelsOverlapping/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/AxisLabelsOverlapping/React/index.html
+++ b/JSDemos/Demos/Charts/AxisLabelsOverlapping/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/AxisLabelsOverlapping/Vue/index.html
+++ b/JSDemos/Demos/Charts/AxisLabelsOverlapping/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/AxisLabelsOverlapping/jQuery/index.html
+++ b/JSDemos/Demos/Charts/AxisLabelsOverlapping/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/AxisLabelsTemplates/Angular/index.html
+++ b/JSDemos/Demos/Charts/AxisLabelsTemplates/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/AxisLabelsTemplates/React/index.html
+++ b/JSDemos/Demos/Charts/AxisLabelsTemplates/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/AxisLabelsTemplates/Vue/index.html
+++ b/JSDemos/Demos/Charts/AxisLabelsTemplates/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/AxisLabelsTemplates/jQuery/index.html
+++ b/JSDemos/Demos/Charts/AxisLabelsTemplates/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/BarSparklines/Angular/index.html
+++ b/JSDemos/Demos/Charts/BarSparklines/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/BarSparklines/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/BarSparklines/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/BarSparklines/Knockout/index.html
+++ b/JSDemos/Demos/Charts/BarSparklines/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Charts/BarSparklines/React/index.html
+++ b/JSDemos/Demos/Charts/BarSparklines/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/BarSparklines/Vue/index.html
+++ b/JSDemos/Demos/Charts/BarSparklines/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/BarSparklines/jQuery/index.html
+++ b/JSDemos/Demos/Charts/BarSparklines/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Charts/BiDirectionalBarChart/Angular/index.html
+++ b/JSDemos/Demos/Charts/BiDirectionalBarChart/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/BiDirectionalBarChart/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/BiDirectionalBarChart/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/BiDirectionalBarChart/Knockout/index.html
+++ b/JSDemos/Demos/Charts/BiDirectionalBarChart/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/BiDirectionalBarChart/React/index.html
+++ b/JSDemos/Demos/Charts/BiDirectionalBarChart/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/BiDirectionalBarChart/Vue/index.html
+++ b/JSDemos/Demos/Charts/BiDirectionalBarChart/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/BiDirectionalBarChart/jQuery/index.html
+++ b/JSDemos/Demos/Charts/BiDirectionalBarChart/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Bubble/Angular/index.html
+++ b/JSDemos/Demos/Charts/Bubble/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Bubble/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/Bubble/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/Bubble/Knockout/index.html
+++ b/JSDemos/Demos/Charts/Bubble/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Bubble/React/index.html
+++ b/JSDemos/Demos/Charts/Bubble/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/Bubble/Vue/index.html
+++ b/JSDemos/Demos/Charts/Bubble/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Bubble/jQuery/index.html
+++ b/JSDemos/Demos/Charts/Bubble/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Candlestick/Angular/index.html
+++ b/JSDemos/Demos/Charts/Candlestick/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Candlestick/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/Candlestick/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/Candlestick/Knockout/index.html
+++ b/JSDemos/Demos/Charts/Candlestick/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Candlestick/React/index.html
+++ b/JSDemos/Demos/Charts/Candlestick/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/Candlestick/Vue/index.html
+++ b/JSDemos/Demos/Charts/Candlestick/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Candlestick/jQuery/index.html
+++ b/JSDemos/Demos/Charts/Candlestick/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ChartsDrillDown/Angular/index.html
+++ b/JSDemos/Demos/Charts/ChartsDrillDown/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ChartsDrillDown/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/ChartsDrillDown/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/ChartsDrillDown/Knockout/index.html
+++ b/JSDemos/Demos/Charts/ChartsDrillDown/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ChartsDrillDown/React/index.html
+++ b/JSDemos/Demos/Charts/ChartsDrillDown/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/ChartsDrillDown/Vue/index.html
+++ b/JSDemos/Demos/Charts/ChartsDrillDown/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ChartsDrillDown/jQuery/index.html
+++ b/JSDemos/Demos/Charts/ChartsDrillDown/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ClientSideDataProcessing/Angular/index.html
+++ b/JSDemos/Demos/Charts/ClientSideDataProcessing/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ClientSideDataProcessing/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/ClientSideDataProcessing/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/ClientSideDataProcessing/Knockout/index.html
+++ b/JSDemos/Demos/Charts/ClientSideDataProcessing/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Charts/ClientSideDataProcessing/React/index.html
+++ b/JSDemos/Demos/Charts/ClientSideDataProcessing/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/ClientSideDataProcessing/Vue/index.html
+++ b/JSDemos/Demos/Charts/ClientSideDataProcessing/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ClientSideDataProcessing/jQuery/index.html
+++ b/JSDemos/Demos/Charts/ClientSideDataProcessing/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Charts/ColorEachBar/Angular/index.html
+++ b/JSDemos/Demos/Charts/ColorEachBar/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ColorEachBar/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/ColorEachBar/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/ColorEachBar/Knockout/index.html
+++ b/JSDemos/Demos/Charts/ColorEachBar/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ColorEachBar/React/index.html
+++ b/JSDemos/Demos/Charts/ColorEachBar/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/ColorEachBar/Vue/index.html
+++ b/JSDemos/Demos/Charts/ColorEachBar/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ColorEachBar/jQuery/index.html
+++ b/JSDemos/Demos/Charts/ColorEachBar/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Colorization/Angular/index.html
+++ b/JSDemos/Demos/Charts/Colorization/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Colorization/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/Colorization/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/Colorization/Knockout/index.html
+++ b/JSDemos/Demos/Charts/Colorization/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Colorization/React/index.html
+++ b/JSDemos/Demos/Charts/Colorization/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/Colorization/Vue/index.html
+++ b/JSDemos/Demos/Charts/Colorization/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Colorization/jQuery/index.html
+++ b/JSDemos/Demos/Charts/Colorization/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ContinuousData/Angular/index.html
+++ b/JSDemos/Demos/Charts/ContinuousData/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ContinuousData/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/ContinuousData/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/ContinuousData/Knockout/index.html
+++ b/JSDemos/Demos/Charts/ContinuousData/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ContinuousData/React/index.html
+++ b/JSDemos/Demos/Charts/ContinuousData/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/ContinuousData/Vue/index.html
+++ b/JSDemos/Demos/Charts/ContinuousData/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ContinuousData/jQuery/index.html
+++ b/JSDemos/Demos/Charts/ContinuousData/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Crosshair/Angular/index.html
+++ b/JSDemos/Demos/Charts/Crosshair/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Crosshair/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/Crosshair/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/Crosshair/Knockout/index.html
+++ b/JSDemos/Demos/Charts/Crosshair/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Crosshair/React/index.html
+++ b/JSDemos/Demos/Charts/Crosshair/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/Crosshair/Vue/index.html
+++ b/JSDemos/Demos/Charts/Crosshair/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Crosshair/jQuery/index.html
+++ b/JSDemos/Demos/Charts/Crosshair/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/CustomAnnotations/Angular/index.html
+++ b/JSDemos/Demos/Charts/CustomAnnotations/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/CustomAnnotations/React/index.html
+++ b/JSDemos/Demos/Charts/CustomAnnotations/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/CustomAnnotations/Vue/index.html
+++ b/JSDemos/Demos/Charts/CustomAnnotations/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/CustomAnnotations/jQuery/index.html
+++ b/JSDemos/Demos/Charts/CustomAnnotations/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/CustomBarWidth/Angular/index.html
+++ b/JSDemos/Demos/Charts/CustomBarWidth/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/CustomBarWidth/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/CustomBarWidth/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/CustomBarWidth/Knockout/index.html
+++ b/JSDemos/Demos/Charts/CustomBarWidth/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/CustomBarWidth/React/index.html
+++ b/JSDemos/Demos/Charts/CustomBarWidth/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/CustomBarWidth/Vue/index.html
+++ b/JSDemos/Demos/Charts/CustomBarWidth/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/CustomBarWidth/jQuery/index.html
+++ b/JSDemos/Demos/Charts/CustomBarWidth/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/CustomLegendMarkers/Angular/index.html
+++ b/JSDemos/Demos/Charts/CustomLegendMarkers/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/CustomLegendMarkers/React/index.html
+++ b/JSDemos/Demos/Charts/CustomLegendMarkers/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/CustomLegendMarkers/Vue/index.html
+++ b/JSDemos/Demos/Charts/CustomLegendMarkers/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/CustomLegendMarkers/jQuery/index.html
+++ b/JSDemos/Demos/Charts/CustomLegendMarkers/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/CustomizePointsAndLabels/Angular/index.html
+++ b/JSDemos/Demos/Charts/CustomizePointsAndLabels/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/CustomizePointsAndLabels/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/CustomizePointsAndLabels/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/CustomizePointsAndLabels/Knockout/index.html
+++ b/JSDemos/Demos/Charts/CustomizePointsAndLabels/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/CustomizePointsAndLabels/React/index.html
+++ b/JSDemos/Demos/Charts/CustomizePointsAndLabels/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/CustomizePointsAndLabels/Vue/index.html
+++ b/JSDemos/Demos/Charts/CustomizePointsAndLabels/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/CustomizePointsAndLabels/jQuery/index.html
+++ b/JSDemos/Demos/Charts/CustomizePointsAndLabels/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/DiscreteAggregation/Angular/index.html
+++ b/JSDemos/Demos/Charts/DiscreteAggregation/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/DiscreteAggregation/React/index.html
+++ b/JSDemos/Demos/Charts/DiscreteAggregation/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/DiscreteAggregation/Vue/index.html
+++ b/JSDemos/Demos/Charts/DiscreteAggregation/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/DiscreteAggregation/jQuery/index.html
+++ b/JSDemos/Demos/Charts/DiscreteAggregation/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/DiscreteAxisZoomingAndScrolling/Angular/index.html
+++ b/JSDemos/Demos/Charts/DiscreteAxisZoomingAndScrolling/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/DiscreteAxisZoomingAndScrolling/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/DiscreteAxisZoomingAndScrolling/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/DiscreteAxisZoomingAndScrolling/Knockout/index.html
+++ b/JSDemos/Demos/Charts/DiscreteAxisZoomingAndScrolling/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/DiscreteAxisZoomingAndScrolling/React/index.html
+++ b/JSDemos/Demos/Charts/DiscreteAxisZoomingAndScrolling/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/DiscreteAxisZoomingAndScrolling/Vue/index.html
+++ b/JSDemos/Demos/Charts/DiscreteAxisZoomingAndScrolling/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/DiscreteAxisZoomingAndScrolling/jQuery/index.html
+++ b/JSDemos/Demos/Charts/DiscreteAxisZoomingAndScrolling/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/DiscreteData/Angular/index.html
+++ b/JSDemos/Demos/Charts/DiscreteData/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/DiscreteData/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/DiscreteData/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/DiscreteData/Knockout/index.html
+++ b/JSDemos/Demos/Charts/DiscreteData/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/DiscreteData/React/index.html
+++ b/JSDemos/Demos/Charts/DiscreteData/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/DiscreteData/Vue/index.html
+++ b/JSDemos/Demos/Charts/DiscreteData/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/DiscreteData/jQuery/index.html
+++ b/JSDemos/Demos/Charts/DiscreteData/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Doughnut/Angular/index.html
+++ b/JSDemos/Demos/Charts/Doughnut/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Doughnut/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/Doughnut/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/Doughnut/Knockout/index.html
+++ b/JSDemos/Demos/Charts/Doughnut/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Doughnut/React/index.html
+++ b/JSDemos/Demos/Charts/Doughnut/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/Doughnut/Vue/index.html
+++ b/JSDemos/Demos/Charts/Doughnut/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Doughnut/jQuery/index.html
+++ b/JSDemos/Demos/Charts/Doughnut/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/DoughnutSelection/Angular/index.html
+++ b/JSDemos/Demos/Charts/DoughnutSelection/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/DoughnutSelection/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/DoughnutSelection/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/DoughnutSelection/Knockout/index.html
+++ b/JSDemos/Demos/Charts/DoughnutSelection/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/DoughnutSelection/React/index.html
+++ b/JSDemos/Demos/Charts/DoughnutSelection/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/DoughnutSelection/Vue/index.html
+++ b/JSDemos/Demos/Charts/DoughnutSelection/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/DoughnutSelection/jQuery/index.html
+++ b/JSDemos/Demos/Charts/DoughnutSelection/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/DoughnutWithCustomLabelInCenter/Angular/index.html
+++ b/JSDemos/Demos/Charts/DoughnutWithCustomLabelInCenter/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/DoughnutWithCustomLabelInCenter/React/index.html
+++ b/JSDemos/Demos/Charts/DoughnutWithCustomLabelInCenter/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/DoughnutWithCustomLabelInCenter/Vue/index.html
+++ b/JSDemos/Demos/Charts/DoughnutWithCustomLabelInCenter/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/DoughnutWithCustomLabelInCenter/jQuery/index.html
+++ b/JSDemos/Demos/Charts/DoughnutWithCustomLabelInCenter/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/DoughnutWithTopNSeries/Angular/index.html
+++ b/JSDemos/Demos/Charts/DoughnutWithTopNSeries/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/DoughnutWithTopNSeries/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/DoughnutWithTopNSeries/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/DoughnutWithTopNSeries/Knockout/index.html
+++ b/JSDemos/Demos/Charts/DoughnutWithTopNSeries/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/DoughnutWithTopNSeries/React/index.html
+++ b/JSDemos/Demos/Charts/DoughnutWithTopNSeries/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/DoughnutWithTopNSeries/Vue/index.html
+++ b/JSDemos/Demos/Charts/DoughnutWithTopNSeries/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/DoughnutWithTopNSeries/jQuery/index.html
+++ b/JSDemos/Demos/Charts/DoughnutWithTopNSeries/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/DrillDown/Angular/index.html
+++ b/JSDemos/Demos/Charts/DrillDown/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/DrillDown/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/DrillDown/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/DrillDown/Knockout/index.html
+++ b/JSDemos/Demos/Charts/DrillDown/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/DrillDown/React/index.html
+++ b/JSDemos/Demos/Charts/DrillDown/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/DrillDown/Vue/index.html
+++ b/JSDemos/Demos/Charts/DrillDown/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/DrillDown/jQuery/index.html
+++ b/JSDemos/Demos/Charts/DrillDown/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ErrorBars/Angular/index.html
+++ b/JSDemos/Demos/Charts/ErrorBars/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ErrorBars/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/ErrorBars/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/ErrorBars/Knockout/index.html
+++ b/JSDemos/Demos/Charts/ErrorBars/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ErrorBars/React/index.html
+++ b/JSDemos/Demos/Charts/ErrorBars/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/ErrorBars/Vue/index.html
+++ b/JSDemos/Demos/Charts/ErrorBars/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ErrorBars/jQuery/index.html
+++ b/JSDemos/Demos/Charts/ErrorBars/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ExportAndPrintingAPI/Angular/index.html
+++ b/JSDemos/Demos/Charts/ExportAndPrintingAPI/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ExportAndPrintingAPI/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/ExportAndPrintingAPI/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/ExportAndPrintingAPI/Knockout/index.html
+++ b/JSDemos/Demos/Charts/ExportAndPrintingAPI/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ExportAndPrintingAPI/React/index.html
+++ b/JSDemos/Demos/Charts/ExportAndPrintingAPI/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/ExportAndPrintingAPI/Vue/index.html
+++ b/JSDemos/Demos/Charts/ExportAndPrintingAPI/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ExportAndPrintingAPI/jQuery/index.html
+++ b/JSDemos/Demos/Charts/ExportAndPrintingAPI/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ExportCustomMarkup/Angular/index.html
+++ b/JSDemos/Demos/Charts/ExportCustomMarkup/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ExportCustomMarkup/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/ExportCustomMarkup/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/ExportCustomMarkup/React/index.html
+++ b/JSDemos/Demos/Charts/ExportCustomMarkup/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/ExportCustomMarkup/Vue/index.html
+++ b/JSDemos/Demos/Charts/ExportCustomMarkup/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ExportCustomMarkup/jQuery/index.html
+++ b/JSDemos/Demos/Charts/ExportCustomMarkup/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ExportSeveralCharts/Angular/index.html
+++ b/JSDemos/Demos/Charts/ExportSeveralCharts/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ExportSeveralCharts/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/ExportSeveralCharts/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/ExportSeveralCharts/Knockout/index.html
+++ b/JSDemos/Demos/Charts/ExportSeveralCharts/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ExportSeveralCharts/React/index.html
+++ b/JSDemos/Demos/Charts/ExportSeveralCharts/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/ExportSeveralCharts/Vue/index.html
+++ b/JSDemos/Demos/Charts/ExportSeveralCharts/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ExportSeveralCharts/jQuery/index.html
+++ b/JSDemos/Demos/Charts/ExportSeveralCharts/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/FlatDataStructure/Angular/index.html
+++ b/JSDemos/Demos/Charts/FlatDataStructure/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/FlatDataStructure/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/FlatDataStructure/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/FlatDataStructure/Knockout/index.html
+++ b/JSDemos/Demos/Charts/FlatDataStructure/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/FlatDataStructure/React/index.html
+++ b/JSDemos/Demos/Charts/FlatDataStructure/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/FlatDataStructure/Vue/index.html
+++ b/JSDemos/Demos/Charts/FlatDataStructure/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/FlatDataStructure/jQuery/index.html
+++ b/JSDemos/Demos/Charts/FlatDataStructure/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/FullStackedBar/Angular/index.html
+++ b/JSDemos/Demos/Charts/FullStackedBar/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/FullStackedBar/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/FullStackedBar/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/FullStackedBar/Knockout/index.html
+++ b/JSDemos/Demos/Charts/FullStackedBar/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/FullStackedBar/React/index.html
+++ b/JSDemos/Demos/Charts/FullStackedBar/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/FullStackedBar/Vue/index.html
+++ b/JSDemos/Demos/Charts/FullStackedBar/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/FullStackedBar/jQuery/index.html
+++ b/JSDemos/Demos/Charts/FullStackedBar/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/FunnelChart/Angular/index.html
+++ b/JSDemos/Demos/Charts/FunnelChart/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/FunnelChart/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/FunnelChart/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/FunnelChart/Knockout/index.html
+++ b/JSDemos/Demos/Charts/FunnelChart/Knockout/index.html
@@ -8,7 +8,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/FunnelChart/React/index.html
+++ b/JSDemos/Demos/Charts/FunnelChart/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/FunnelChart/Vue/index.html
+++ b/JSDemos/Demos/Charts/FunnelChart/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/FunnelChart/jQuery/index.html
+++ b/JSDemos/Demos/Charts/FunnelChart/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/HierarchicalDataStructure/Angular/index.html
+++ b/JSDemos/Demos/Charts/HierarchicalDataStructure/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/HierarchicalDataStructure/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/HierarchicalDataStructure/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/HierarchicalDataStructure/Knockout/index.html
+++ b/JSDemos/Demos/Charts/HierarchicalDataStructure/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/HierarchicalDataStructure/React/index.html
+++ b/JSDemos/Demos/Charts/HierarchicalDataStructure/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/HierarchicalDataStructure/Vue/index.html
+++ b/JSDemos/Demos/Charts/HierarchicalDataStructure/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/HierarchicalDataStructure/jQuery/index.html
+++ b/JSDemos/Demos/Charts/HierarchicalDataStructure/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/HoverMode/Angular/index.html
+++ b/JSDemos/Demos/Charts/HoverMode/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/HoverMode/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/HoverMode/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/HoverMode/Knockout/index.html
+++ b/JSDemos/Demos/Charts/HoverMode/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/HoverMode/React/index.html
+++ b/JSDemos/Demos/Charts/HoverMode/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/HoverMode/Vue/index.html
+++ b/JSDemos/Demos/Charts/HoverMode/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/HoverMode/jQuery/index.html
+++ b/JSDemos/Demos/Charts/HoverMode/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/InvertedChart/Angular/index.html
+++ b/JSDemos/Demos/Charts/InvertedChart/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/InvertedChart/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/InvertedChart/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/InvertedChart/Knockout/index.html
+++ b/JSDemos/Demos/Charts/InvertedChart/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/InvertedChart/React/index.html
+++ b/JSDemos/Demos/Charts/InvertedChart/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/InvertedChart/Vue/index.html
+++ b/JSDemos/Demos/Charts/InvertedChart/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/InvertedChart/jQuery/index.html
+++ b/JSDemos/Demos/Charts/InvertedChart/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Line/Angular/index.html
+++ b/JSDemos/Demos/Charts/Line/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Line/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/Line/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/Line/Knockout/index.html
+++ b/JSDemos/Demos/Charts/Line/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Line/React/index.html
+++ b/JSDemos/Demos/Charts/Line/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/Line/Vue/index.html
+++ b/JSDemos/Demos/Charts/Line/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Line/jQuery/index.html
+++ b/JSDemos/Demos/Charts/Line/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/LoadDataOnDemand/Angular/index.html
+++ b/JSDemos/Demos/Charts/LoadDataOnDemand/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/LoadDataOnDemand/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/LoadDataOnDemand/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/LoadDataOnDemand/React/index.html
+++ b/JSDemos/Demos/Charts/LoadDataOnDemand/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/LoadDataOnDemand/Vue/index.html
+++ b/JSDemos/Demos/Charts/LoadDataOnDemand/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/LoadDataOnDemand/jQuery/index.html
+++ b/JSDemos/Demos/Charts/LoadDataOnDemand/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Charts/LogarithmicAxis/Angular/index.html
+++ b/JSDemos/Demos/Charts/LogarithmicAxis/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/LogarithmicAxis/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/LogarithmicAxis/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/LogarithmicAxis/Knockout/index.html
+++ b/JSDemos/Demos/Charts/LogarithmicAxis/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/LogarithmicAxis/React/index.html
+++ b/JSDemos/Demos/Charts/LogarithmicAxis/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/LogarithmicAxis/Vue/index.html
+++ b/JSDemos/Demos/Charts/LogarithmicAxis/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/LogarithmicAxis/jQuery/index.html
+++ b/JSDemos/Demos/Charts/LogarithmicAxis/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/LogarithmicVsLinearAxes/Angular/index.html
+++ b/JSDemos/Demos/Charts/LogarithmicVsLinearAxes/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/LogarithmicVsLinearAxes/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/LogarithmicVsLinearAxes/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/LogarithmicVsLinearAxes/React/index.html
+++ b/JSDemos/Demos/Charts/LogarithmicVsLinearAxes/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/LogarithmicVsLinearAxes/Vue/index.html
+++ b/JSDemos/Demos/Charts/LogarithmicVsLinearAxes/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/LogarithmicVsLinearAxes/jQuery/index.html
+++ b/JSDemos/Demos/Charts/LogarithmicVsLinearAxes/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/MultipleAxes/Angular/index.html
+++ b/JSDemos/Demos/Charts/MultipleAxes/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/MultipleAxes/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/MultipleAxes/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/MultipleAxes/Knockout/index.html
+++ b/JSDemos/Demos/Charts/MultipleAxes/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/MultipleAxes/React/index.html
+++ b/JSDemos/Demos/Charts/MultipleAxes/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/MultipleAxes/Vue/index.html
+++ b/JSDemos/Demos/Charts/MultipleAxes/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/MultipleAxes/jQuery/index.html
+++ b/JSDemos/Demos/Charts/MultipleAxes/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/MultiplePanes/Angular/index.html
+++ b/JSDemos/Demos/Charts/MultiplePanes/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/MultiplePanes/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/MultiplePanes/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/MultiplePanes/Knockout/index.html
+++ b/JSDemos/Demos/Charts/MultiplePanes/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/MultiplePanes/React/index.html
+++ b/JSDemos/Demos/Charts/MultiplePanes/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/MultiplePanes/Vue/index.html
+++ b/JSDemos/Demos/Charts/MultiplePanes/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/MultiplePanes/jQuery/index.html
+++ b/JSDemos/Demos/Charts/MultiplePanes/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/MultiplePointSelection/Angular/index.html
+++ b/JSDemos/Demos/Charts/MultiplePointSelection/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/MultiplePointSelection/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/MultiplePointSelection/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/MultiplePointSelection/Knockout/index.html
+++ b/JSDemos/Demos/Charts/MultiplePointSelection/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/MultiplePointSelection/React/index.html
+++ b/JSDemos/Demos/Charts/MultiplePointSelection/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/MultiplePointSelection/Vue/index.html
+++ b/JSDemos/Demos/Charts/MultiplePointSelection/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/MultiplePointSelection/jQuery/index.html
+++ b/JSDemos/Demos/Charts/MultiplePointSelection/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/MultipleSeriesSelection/Angular/index.html
+++ b/JSDemos/Demos/Charts/MultipleSeriesSelection/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/MultipleSeriesSelection/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/MultipleSeriesSelection/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/MultipleSeriesSelection/Knockout/index.html
+++ b/JSDemos/Demos/Charts/MultipleSeriesSelection/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/MultipleSeriesSelection/React/index.html
+++ b/JSDemos/Demos/Charts/MultipleSeriesSelection/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/MultipleSeriesSelection/Vue/index.html
+++ b/JSDemos/Demos/Charts/MultipleSeriesSelection/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/MultipleSeriesSelection/jQuery/index.html
+++ b/JSDemos/Demos/Charts/MultipleSeriesSelection/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/NullPointSupport/Angular/index.html
+++ b/JSDemos/Demos/Charts/NullPointSupport/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/NullPointSupport/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/NullPointSupport/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/NullPointSupport/Knockout/index.html
+++ b/JSDemos/Demos/Charts/NullPointSupport/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/NullPointSupport/React/index.html
+++ b/JSDemos/Demos/Charts/NullPointSupport/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/NullPointSupport/Vue/index.html
+++ b/JSDemos/Demos/Charts/NullPointSupport/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/NullPointSupport/jQuery/index.html
+++ b/JSDemos/Demos/Charts/NullPointSupport/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Overview/Angular/index.html
+++ b/JSDemos/Demos/Charts/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/Overview/Knockout/index.html
+++ b/JSDemos/Demos/Charts/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Overview/React/index.html
+++ b/JSDemos/Demos/Charts/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/Overview/Vue/index.html
+++ b/JSDemos/Demos/Charts/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Charts/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Palette/Angular/index.html
+++ b/JSDemos/Demos/Charts/Palette/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Palette/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/Palette/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/Palette/Knockout/index.html
+++ b/JSDemos/Demos/Charts/Palette/Knockout/index.html
@@ -8,7 +8,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Palette/React/index.html
+++ b/JSDemos/Demos/Charts/Palette/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/Palette/Vue/index.html
+++ b/JSDemos/Demos/Charts/Palette/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Palette/jQuery/index.html
+++ b/JSDemos/Demos/Charts/Palette/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ParetoChart/Angular/index.html
+++ b/JSDemos/Demos/Charts/ParetoChart/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ParetoChart/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/ParetoChart/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/ParetoChart/Knockout/index.html
+++ b/JSDemos/Demos/Charts/ParetoChart/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ParetoChart/React/index.html
+++ b/JSDemos/Demos/Charts/ParetoChart/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/ParetoChart/Vue/index.html
+++ b/JSDemos/Demos/Charts/ParetoChart/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ParetoChart/jQuery/index.html
+++ b/JSDemos/Demos/Charts/ParetoChart/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PeriodicData/Angular/index.html
+++ b/JSDemos/Demos/Charts/PeriodicData/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PeriodicData/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/PeriodicData/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/PeriodicData/Knockout/index.html
+++ b/JSDemos/Demos/Charts/PeriodicData/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PeriodicData/React/index.html
+++ b/JSDemos/Demos/Charts/PeriodicData/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/PeriodicData/Vue/index.html
+++ b/JSDemos/Demos/Charts/PeriodicData/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PeriodicData/jQuery/index.html
+++ b/JSDemos/Demos/Charts/PeriodicData/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Pie/Angular/index.html
+++ b/JSDemos/Demos/Charts/Pie/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Pie/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/Pie/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/Pie/Knockout/index.html
+++ b/JSDemos/Demos/Charts/Pie/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Pie/React/index.html
+++ b/JSDemos/Demos/Charts/Pie/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/Pie/Vue/index.html
+++ b/JSDemos/Demos/Charts/Pie/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Pie/jQuery/index.html
+++ b/JSDemos/Demos/Charts/Pie/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PieWithAnnotations/Angular/index.html
+++ b/JSDemos/Demos/Charts/PieWithAnnotations/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PieWithAnnotations/React/index.html
+++ b/JSDemos/Demos/Charts/PieWithAnnotations/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/PieWithAnnotations/Vue/index.html
+++ b/JSDemos/Demos/Charts/PieWithAnnotations/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PieWithAnnotations/jQuery/index.html
+++ b/JSDemos/Demos/Charts/PieWithAnnotations/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PieWithCustomLabels/Angular/index.html
+++ b/JSDemos/Demos/Charts/PieWithCustomLabels/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PieWithCustomLabels/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/PieWithCustomLabels/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/PieWithCustomLabels/Knockout/index.html
+++ b/JSDemos/Demos/Charts/PieWithCustomLabels/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PieWithCustomLabels/React/index.html
+++ b/JSDemos/Demos/Charts/PieWithCustomLabels/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/PieWithCustomLabels/Vue/index.html
+++ b/JSDemos/Demos/Charts/PieWithCustomLabels/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PieWithCustomLabels/jQuery/index.html
+++ b/JSDemos/Demos/Charts/PieWithCustomLabels/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PieWithMultipleSeries/Angular/index.html
+++ b/JSDemos/Demos/Charts/PieWithMultipleSeries/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PieWithMultipleSeries/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/PieWithMultipleSeries/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/PieWithMultipleSeries/Knockout/index.html
+++ b/JSDemos/Demos/Charts/PieWithMultipleSeries/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PieWithMultipleSeries/React/index.html
+++ b/JSDemos/Demos/Charts/PieWithMultipleSeries/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/PieWithMultipleSeries/Vue/index.html
+++ b/JSDemos/Demos/Charts/PieWithMultipleSeries/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PieWithMultipleSeries/jQuery/index.html
+++ b/JSDemos/Demos/Charts/PieWithMultipleSeries/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PieWithResolvedLabelOverlapping/Angular/index.html
+++ b/JSDemos/Demos/Charts/PieWithResolvedLabelOverlapping/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PieWithResolvedLabelOverlapping/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/PieWithResolvedLabelOverlapping/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/PieWithResolvedLabelOverlapping/Knockout/index.html
+++ b/JSDemos/Demos/Charts/PieWithResolvedLabelOverlapping/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PieWithResolvedLabelOverlapping/React/index.html
+++ b/JSDemos/Demos/Charts/PieWithResolvedLabelOverlapping/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/PieWithResolvedLabelOverlapping/Vue/index.html
+++ b/JSDemos/Demos/Charts/PieWithResolvedLabelOverlapping/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PieWithResolvedLabelOverlapping/jQuery/index.html
+++ b/JSDemos/Demos/Charts/PieWithResolvedLabelOverlapping/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PieWithSmallValuesGrouped/Angular/index.html
+++ b/JSDemos/Demos/Charts/PieWithSmallValuesGrouped/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PieWithSmallValuesGrouped/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/PieWithSmallValuesGrouped/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/PieWithSmallValuesGrouped/Knockout/index.html
+++ b/JSDemos/Demos/Charts/PieWithSmallValuesGrouped/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PieWithSmallValuesGrouped/React/index.html
+++ b/JSDemos/Demos/Charts/PieWithSmallValuesGrouped/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/PieWithSmallValuesGrouped/Vue/index.html
+++ b/JSDemos/Demos/Charts/PieWithSmallValuesGrouped/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PieWithSmallValuesGrouped/jQuery/index.html
+++ b/JSDemos/Demos/Charts/PieWithSmallValuesGrouped/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PiesWithEqualSize/Angular/index.html
+++ b/JSDemos/Demos/Charts/PiesWithEqualSize/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PiesWithEqualSize/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/PiesWithEqualSize/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/PiesWithEqualSize/Knockout/index.html
+++ b/JSDemos/Demos/Charts/PiesWithEqualSize/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PiesWithEqualSize/React/index.html
+++ b/JSDemos/Demos/Charts/PiesWithEqualSize/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/PiesWithEqualSize/Vue/index.html
+++ b/JSDemos/Demos/Charts/PiesWithEqualSize/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PiesWithEqualSize/jQuery/index.html
+++ b/JSDemos/Demos/Charts/PiesWithEqualSize/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PointImage/Angular/index.html
+++ b/JSDemos/Demos/Charts/PointImage/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PointImage/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/PointImage/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/PointImage/Knockout/index.html
+++ b/JSDemos/Demos/Charts/PointImage/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PointImage/React/index.html
+++ b/JSDemos/Demos/Charts/PointImage/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/PointImage/Vue/index.html
+++ b/JSDemos/Demos/Charts/PointImage/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PointImage/jQuery/index.html
+++ b/JSDemos/Demos/Charts/PointImage/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PointsAggregation/Angular/index.html
+++ b/JSDemos/Demos/Charts/PointsAggregation/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PointsAggregation/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/PointsAggregation/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/PointsAggregation/Knockout/index.html
+++ b/JSDemos/Demos/Charts/PointsAggregation/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Charts/PointsAggregation/React/index.html
+++ b/JSDemos/Demos/Charts/PointsAggregation/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/PointsAggregation/Vue/index.html
+++ b/JSDemos/Demos/Charts/PointsAggregation/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PointsAggregation/jQuery/index.html
+++ b/JSDemos/Demos/Charts/PointsAggregation/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PointsAggregationFinancialChart/Angular/index.html
+++ b/JSDemos/Demos/Charts/PointsAggregationFinancialChart/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PointsAggregationFinancialChart/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/PointsAggregationFinancialChart/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/PointsAggregationFinancialChart/Knockout/index.html
+++ b/JSDemos/Demos/Charts/PointsAggregationFinancialChart/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PointsAggregationFinancialChart/React/index.html
+++ b/JSDemos/Demos/Charts/PointsAggregationFinancialChart/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/PointsAggregationFinancialChart/Vue/index.html
+++ b/JSDemos/Demos/Charts/PointsAggregationFinancialChart/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PointsAggregationFinancialChart/jQuery/index.html
+++ b/JSDemos/Demos/Charts/PointsAggregationFinancialChart/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PolarChartAnnotations/Angular/index.html
+++ b/JSDemos/Demos/Charts/PolarChartAnnotations/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PolarChartAnnotations/React/index.html
+++ b/JSDemos/Demos/Charts/PolarChartAnnotations/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/PolarChartAnnotations/Vue/index.html
+++ b/JSDemos/Demos/Charts/PolarChartAnnotations/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PolarChartAnnotations/jQuery/index.html
+++ b/JSDemos/Demos/Charts/PolarChartAnnotations/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PolarChartZoomingAndScrollingAPI/Angular/index.html
+++ b/JSDemos/Demos/Charts/PolarChartZoomingAndScrollingAPI/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PolarChartZoomingAndScrollingAPI/React/index.html
+++ b/JSDemos/Demos/Charts/PolarChartZoomingAndScrollingAPI/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/PolarChartZoomingAndScrollingAPI/Vue/index.html
+++ b/JSDemos/Demos/Charts/PolarChartZoomingAndScrollingAPI/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PolarChartZoomingAndScrollingAPI/jQuery/index.html
+++ b/JSDemos/Demos/Charts/PolarChartZoomingAndScrollingAPI/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PyramidChart/Angular/index.html
+++ b/JSDemos/Demos/Charts/PyramidChart/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PyramidChart/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/PyramidChart/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/PyramidChart/Knockout/index.html
+++ b/JSDemos/Demos/Charts/PyramidChart/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/PyramidChart/React/index.html
+++ b/JSDemos/Demos/Charts/PyramidChart/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/PyramidChart/Vue/index.html
+++ b/JSDemos/Demos/Charts/PyramidChart/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/PyramidChart/jQuery/index.html
+++ b/JSDemos/Demos/Charts/PyramidChart/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/RangeArea/Angular/index.html
+++ b/JSDemos/Demos/Charts/RangeArea/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/RangeArea/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/RangeArea/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/RangeArea/Knockout/index.html
+++ b/JSDemos/Demos/Charts/RangeArea/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/RangeArea/React/index.html
+++ b/JSDemos/Demos/Charts/RangeArea/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/RangeArea/Vue/index.html
+++ b/JSDemos/Demos/Charts/RangeArea/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/RangeArea/jQuery/index.html
+++ b/JSDemos/Demos/Charts/RangeArea/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/RangeBar/Angular/index.html
+++ b/JSDemos/Demos/Charts/RangeBar/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/RangeBar/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/RangeBar/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/RangeBar/Knockout/index.html
+++ b/JSDemos/Demos/Charts/RangeBar/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/RangeBar/React/index.html
+++ b/JSDemos/Demos/Charts/RangeBar/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/RangeBar/Vue/index.html
+++ b/JSDemos/Demos/Charts/RangeBar/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/RangeBar/jQuery/index.html
+++ b/JSDemos/Demos/Charts/RangeBar/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/SankeyChart/Angular/index.html
+++ b/JSDemos/Demos/Charts/SankeyChart/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SankeyChart/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/SankeyChart/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/SankeyChart/React/index.html
+++ b/JSDemos/Demos/Charts/SankeyChart/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/SankeyChart/Vue/index.html
+++ b/JSDemos/Demos/Charts/SankeyChart/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SankeyChart/jQuery/index.html
+++ b/JSDemos/Demos/Charts/SankeyChart/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ScaleBreaks/Angular/index.html
+++ b/JSDemos/Demos/Charts/ScaleBreaks/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ScaleBreaks/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/ScaleBreaks/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/ScaleBreaks/Knockout/index.html
+++ b/JSDemos/Demos/Charts/ScaleBreaks/Knockout/index.html
@@ -8,7 +8,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ScaleBreaks/React/index.html
+++ b/JSDemos/Demos/Charts/ScaleBreaks/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/ScaleBreaks/Vue/index.html
+++ b/JSDemos/Demos/Charts/ScaleBreaks/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ScaleBreaks/jQuery/index.html
+++ b/JSDemos/Demos/Charts/ScaleBreaks/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Scatter/Angular/index.html
+++ b/JSDemos/Demos/Charts/Scatter/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Scatter/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/Scatter/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/Scatter/Knockout/index.html
+++ b/JSDemos/Demos/Charts/Scatter/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Charts/Scatter/React/index.html
+++ b/JSDemos/Demos/Charts/Scatter/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/Scatter/Vue/index.html
+++ b/JSDemos/Demos/Charts/Scatter/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Scatter/jQuery/index.html
+++ b/JSDemos/Demos/Charts/Scatter/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Charts/Selection/Angular/index.html
+++ b/JSDemos/Demos/Charts/Selection/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Selection/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/Selection/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/Selection/Knockout/index.html
+++ b/JSDemos/Demos/Charts/Selection/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Selection/React/index.html
+++ b/JSDemos/Demos/Charts/Selection/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/Selection/Vue/index.html
+++ b/JSDemos/Demos/Charts/Selection/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Selection/jQuery/index.html
+++ b/JSDemos/Demos/Charts/Selection/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/SeriesTemplates/Angular/index.html
+++ b/JSDemos/Demos/Charts/SeriesTemplates/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SeriesTemplates/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/SeriesTemplates/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/SeriesTemplates/Knockout/index.html
+++ b/JSDemos/Demos/Charts/SeriesTemplates/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/SeriesTemplates/React/index.html
+++ b/JSDemos/Demos/Charts/SeriesTemplates/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/SeriesTemplates/Vue/index.html
+++ b/JSDemos/Demos/Charts/SeriesTemplates/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SeriesTemplates/jQuery/index.html
+++ b/JSDemos/Demos/Charts/SeriesTemplates/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ServerSideDataProcessing/Angular/index.html
+++ b/JSDemos/Demos/Charts/ServerSideDataProcessing/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ServerSideDataProcessing/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/ServerSideDataProcessing/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/ServerSideDataProcessing/Knockout/index.html
+++ b/JSDemos/Demos/Charts/ServerSideDataProcessing/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ServerSideDataProcessing/React/index.html
+++ b/JSDemos/Demos/Charts/ServerSideDataProcessing/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/ServerSideDataProcessing/Vue/index.html
+++ b/JSDemos/Demos/Charts/ServerSideDataProcessing/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ServerSideDataProcessing/jQuery/index.html
+++ b/JSDemos/Demos/Charts/ServerSideDataProcessing/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/SideBySideBar/Angular/index.html
+++ b/JSDemos/Demos/Charts/SideBySideBar/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SideBySideBar/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/SideBySideBar/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/SideBySideBar/Knockout/index.html
+++ b/JSDemos/Demos/Charts/SideBySideBar/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/SideBySideBar/React/index.html
+++ b/JSDemos/Demos/Charts/SideBySideBar/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/SideBySideBar/Vue/index.html
+++ b/JSDemos/Demos/Charts/SideBySideBar/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SideBySideBar/jQuery/index.html
+++ b/JSDemos/Demos/Charts/SideBySideBar/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/SideBySideFullStackedBar/Angular/index.html
+++ b/JSDemos/Demos/Charts/SideBySideFullStackedBar/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SideBySideFullStackedBar/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/SideBySideFullStackedBar/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/SideBySideFullStackedBar/Knockout/index.html
+++ b/JSDemos/Demos/Charts/SideBySideFullStackedBar/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/SideBySideFullStackedBar/React/index.html
+++ b/JSDemos/Demos/Charts/SideBySideFullStackedBar/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/SideBySideFullStackedBar/Vue/index.html
+++ b/JSDemos/Demos/Charts/SideBySideFullStackedBar/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SideBySideFullStackedBar/jQuery/index.html
+++ b/JSDemos/Demos/Charts/SideBySideFullStackedBar/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/SideBySideStackedBar/Angular/index.html
+++ b/JSDemos/Demos/Charts/SideBySideStackedBar/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SideBySideStackedBar/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/SideBySideStackedBar/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/SideBySideStackedBar/Knockout/index.html
+++ b/JSDemos/Demos/Charts/SideBySideStackedBar/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/SideBySideStackedBar/React/index.html
+++ b/JSDemos/Demos/Charts/SideBySideStackedBar/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/SideBySideStackedBar/Vue/index.html
+++ b/JSDemos/Demos/Charts/SideBySideStackedBar/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SideBySideStackedBar/jQuery/index.html
+++ b/JSDemos/Demos/Charts/SideBySideStackedBar/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/SignalRService/Angular/index.html
+++ b/JSDemos/Demos/Charts/SignalRService/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SignalRService/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/SignalRService/AngularJS/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/Charts/SignalRService/React/index.html
+++ b/JSDemos/Demos/Charts/SignalRService/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/SignalRService/Vue/index.html
+++ b/JSDemos/Demos/Charts/SignalRService/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SignalRService/jQuery/index.html
+++ b/JSDemos/Demos/Charts/SignalRService/jQuery/index.html
@@ -8,7 +8,6 @@
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/signalr/jquery.signalR.js"></script>
     <script src="../signalr-hub.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Charts/SimpleArray/Angular/index.html
+++ b/JSDemos/Demos/Charts/SimpleArray/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SimpleArray/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/SimpleArray/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/SimpleArray/Knockout/index.html
+++ b/JSDemos/Demos/Charts/SimpleArray/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/SimpleArray/React/index.html
+++ b/JSDemos/Demos/Charts/SimpleArray/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/SimpleArray/Vue/index.html
+++ b/JSDemos/Demos/Charts/SimpleArray/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SimpleArray/jQuery/index.html
+++ b/JSDemos/Demos/Charts/SimpleArray/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/SimpleBullets/Angular/index.html
+++ b/JSDemos/Demos/Charts/SimpleBullets/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SimpleBullets/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/SimpleBullets/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/SimpleBullets/Knockout/index.html
+++ b/JSDemos/Demos/Charts/SimpleBullets/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Charts/SimpleBullets/React/index.html
+++ b/JSDemos/Demos/Charts/SimpleBullets/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/SimpleBullets/Vue/index.html
+++ b/JSDemos/Demos/Charts/SimpleBullets/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SimpleBullets/jQuery/index.html
+++ b/JSDemos/Demos/Charts/SimpleBullets/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Charts/SimpleSparklines/Angular/index.html
+++ b/JSDemos/Demos/Charts/SimpleSparklines/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SimpleSparklines/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/SimpleSparklines/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/SimpleSparklines/Knockout/index.html
+++ b/JSDemos/Demos/Charts/SimpleSparklines/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/SimpleSparklines/React/index.html
+++ b/JSDemos/Demos/Charts/SimpleSparklines/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/SimpleSparklines/Vue/index.html
+++ b/JSDemos/Demos/Charts/SimpleSparklines/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SimpleSparklines/jQuery/index.html
+++ b/JSDemos/Demos/Charts/SimpleSparklines/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/SpiderWeb/Angular/index.html
+++ b/JSDemos/Demos/Charts/SpiderWeb/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SpiderWeb/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/SpiderWeb/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/SpiderWeb/Knockout/index.html
+++ b/JSDemos/Demos/Charts/SpiderWeb/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/SpiderWeb/React/index.html
+++ b/JSDemos/Demos/Charts/SpiderWeb/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/SpiderWeb/Vue/index.html
+++ b/JSDemos/Demos/Charts/SpiderWeb/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SpiderWeb/jQuery/index.html
+++ b/JSDemos/Demos/Charts/SpiderWeb/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Spline/Angular/index.html
+++ b/JSDemos/Demos/Charts/Spline/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Spline/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/Spline/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/Spline/Knockout/index.html
+++ b/JSDemos/Demos/Charts/Spline/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Spline/React/index.html
+++ b/JSDemos/Demos/Charts/Spline/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/Spline/Vue/index.html
+++ b/JSDemos/Demos/Charts/Spline/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Spline/jQuery/index.html
+++ b/JSDemos/Demos/Charts/Spline/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/SplineArea/Angular/index.html
+++ b/JSDemos/Demos/Charts/SplineArea/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SplineArea/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/SplineArea/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/SplineArea/Knockout/index.html
+++ b/JSDemos/Demos/Charts/SplineArea/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/SplineArea/React/index.html
+++ b/JSDemos/Demos/Charts/SplineArea/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/SplineArea/Vue/index.html
+++ b/JSDemos/Demos/Charts/SplineArea/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/SplineArea/jQuery/index.html
+++ b/JSDemos/Demos/Charts/SplineArea/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/StackedBar/Angular/index.html
+++ b/JSDemos/Demos/Charts/StackedBar/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/StackedBar/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/StackedBar/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/StackedBar/Knockout/index.html
+++ b/JSDemos/Demos/Charts/StackedBar/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/StackedBar/React/index.html
+++ b/JSDemos/Demos/Charts/StackedBar/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/StackedBar/Vue/index.html
+++ b/JSDemos/Demos/Charts/StackedBar/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/StackedBar/jQuery/index.html
+++ b/JSDemos/Demos/Charts/StackedBar/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/StandardBar/Angular/index.html
+++ b/JSDemos/Demos/Charts/StandardBar/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/StandardBar/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/StandardBar/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/StandardBar/Knockout/index.html
+++ b/JSDemos/Demos/Charts/StandardBar/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/StandardBar/React/index.html
+++ b/JSDemos/Demos/Charts/StandardBar/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/StandardBar/Vue/index.html
+++ b/JSDemos/Demos/Charts/StandardBar/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/StandardBar/jQuery/index.html
+++ b/JSDemos/Demos/Charts/StandardBar/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/StepArea/Angular/index.html
+++ b/JSDemos/Demos/Charts/StepArea/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/StepArea/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/StepArea/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/StepArea/Knockout/index.html
+++ b/JSDemos/Demos/Charts/StepArea/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/StepArea/React/index.html
+++ b/JSDemos/Demos/Charts/StepArea/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/StepArea/Vue/index.html
+++ b/JSDemos/Demos/Charts/StepArea/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/StepArea/jQuery/index.html
+++ b/JSDemos/Demos/Charts/StepArea/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/StepLine/Angular/index.html
+++ b/JSDemos/Demos/Charts/StepLine/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/StepLine/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/StepLine/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/StepLine/Knockout/index.html
+++ b/JSDemos/Demos/Charts/StepLine/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/StepLine/React/index.html
+++ b/JSDemos/Demos/Charts/StepLine/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/StepLine/Vue/index.html
+++ b/JSDemos/Demos/Charts/StepLine/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/StepLine/jQuery/index.html
+++ b/JSDemos/Demos/Charts/StepLine/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Stock/Angular/index.html
+++ b/JSDemos/Demos/Charts/Stock/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Stock/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/Stock/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/Stock/Knockout/index.html
+++ b/JSDemos/Demos/Charts/Stock/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Stock/React/index.html
+++ b/JSDemos/Demos/Charts/Stock/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/Stock/Vue/index.html
+++ b/JSDemos/Demos/Charts/Stock/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Stock/jQuery/index.html
+++ b/JSDemos/Demos/Charts/Stock/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Strips/Angular/index.html
+++ b/JSDemos/Demos/Charts/Strips/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Strips/React/index.html
+++ b/JSDemos/Demos/Charts/Strips/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/Strips/Vue/index.html
+++ b/JSDemos/Demos/Charts/Strips/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Strips/jQuery/index.html
+++ b/JSDemos/Demos/Charts/Strips/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/TilingAlgorithms/Angular/index.html
+++ b/JSDemos/Demos/Charts/TilingAlgorithms/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/TilingAlgorithms/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/TilingAlgorithms/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/TilingAlgorithms/Knockout/index.html
+++ b/JSDemos/Demos/Charts/TilingAlgorithms/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/TilingAlgorithms/React/index.html
+++ b/JSDemos/Demos/Charts/TilingAlgorithms/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/TilingAlgorithms/Vue/index.html
+++ b/JSDemos/Demos/Charts/TilingAlgorithms/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/TilingAlgorithms/jQuery/index.html
+++ b/JSDemos/Demos/Charts/TilingAlgorithms/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/Timeline/Angular/index.html
+++ b/JSDemos/Demos/Charts/Timeline/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Timeline/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/Timeline/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/Timeline/React/index.html
+++ b/JSDemos/Demos/Charts/Timeline/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/Timeline/Vue/index.html
+++ b/JSDemos/Demos/Charts/Timeline/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/Timeline/jQuery/index.html
+++ b/JSDemos/Demos/Charts/Timeline/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/TooltipHTMLSupport/Angular/index.html
+++ b/JSDemos/Demos/Charts/TooltipHTMLSupport/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/TooltipHTMLSupport/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/TooltipHTMLSupport/AngularJS/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
 
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/TooltipHTMLSupport/Knockout/index.html
+++ b/JSDemos/Demos/Charts/TooltipHTMLSupport/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/TooltipHTMLSupport/React/index.html
+++ b/JSDemos/Demos/Charts/TooltipHTMLSupport/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/TooltipHTMLSupport/Vue/index.html
+++ b/JSDemos/Demos/Charts/TooltipHTMLSupport/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/TooltipHTMLSupport/jQuery/index.html
+++ b/JSDemos/Demos/Charts/TooltipHTMLSupport/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/WindRose/Angular/index.html
+++ b/JSDemos/Demos/Charts/WindRose/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/WindRose/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/WindRose/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/WindRose/Knockout/index.html
+++ b/JSDemos/Demos/Charts/WindRose/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/WindRose/React/index.html
+++ b/JSDemos/Demos/Charts/WindRose/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/WindRose/Vue/index.html
+++ b/JSDemos/Demos/Charts/WindRose/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/WindRose/jQuery/index.html
+++ b/JSDemos/Demos/Charts/WindRose/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/WinlossSparklines/Angular/index.html
+++ b/JSDemos/Demos/Charts/WinlossSparklines/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/WinlossSparklines/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/WinlossSparklines/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/WinlossSparklines/Knockout/index.html
+++ b/JSDemos/Demos/Charts/WinlossSparklines/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/WinlossSparklines/React/index.html
+++ b/JSDemos/Demos/Charts/WinlossSparklines/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/WinlossSparklines/Vue/index.html
+++ b/JSDemos/Demos/Charts/WinlossSparklines/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/WinlossSparklines/jQuery/index.html
+++ b/JSDemos/Demos/Charts/WinlossSparklines/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ZoomingAndScrolling/Angular/index.html
+++ b/JSDemos/Demos/Charts/ZoomingAndScrolling/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ZoomingAndScrolling/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/ZoomingAndScrolling/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/ZoomingAndScrolling/Knockout/index.html
+++ b/JSDemos/Demos/Charts/ZoomingAndScrolling/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ZoomingAndScrolling/React/index.html
+++ b/JSDemos/Demos/Charts/ZoomingAndScrolling/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/ZoomingAndScrolling/Vue/index.html
+++ b/JSDemos/Demos/Charts/ZoomingAndScrolling/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ZoomingAndScrolling/jQuery/index.html
+++ b/JSDemos/Demos/Charts/ZoomingAndScrolling/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ZoomingAndScrollingAPI/Angular/index.html
+++ b/JSDemos/Demos/Charts/ZoomingAndScrollingAPI/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ZoomingAndScrollingAPI/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/ZoomingAndScrollingAPI/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/ZoomingAndScrollingAPI/Knockout/index.html
+++ b/JSDemos/Demos/Charts/ZoomingAndScrollingAPI/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ZoomingAndScrollingAPI/React/index.html
+++ b/JSDemos/Demos/Charts/ZoomingAndScrollingAPI/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ZoomingAndScrollingAPI/Vue/index.html
+++ b/JSDemos/Demos/Charts/ZoomingAndScrollingAPI/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ZoomingAndScrollingAPI/jQuery/index.html
+++ b/JSDemos/Demos/Charts/ZoomingAndScrollingAPI/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Charts/ZoomingOnAreaSelection/Angular/index.html
+++ b/JSDemos/Demos/Charts/ZoomingOnAreaSelection/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ZoomingOnAreaSelection/AngularJS/index.html
+++ b/JSDemos/Demos/Charts/ZoomingOnAreaSelection/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Charts/ZoomingOnAreaSelection/React/index.html
+++ b/JSDemos/Demos/Charts/ZoomingOnAreaSelection/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Charts/ZoomingOnAreaSelection/Vue/index.html
+++ b/JSDemos/Demos/Charts/ZoomingOnAreaSelection/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Charts/ZoomingOnAreaSelection/jQuery/index.html
+++ b/JSDemos/Demos/Charts/ZoomingOnAreaSelection/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/CheckBox/Overview/Angular/index.html
+++ b/JSDemos/Demos/CheckBox/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/CheckBox/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/CheckBox/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/CheckBox/Overview/Knockout/index.html
+++ b/JSDemos/Demos/CheckBox/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/CheckBox/Overview/React/index.html
+++ b/JSDemos/Demos/CheckBox/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/CheckBox/Overview/Vue/index.html
+++ b/JSDemos/Demos/CheckBox/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/CheckBox/Overview/jQuery/index.html
+++ b/JSDemos/Demos/CheckBox/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/ColorBox/Overview/Angular/index.html
+++ b/JSDemos/Demos/ColorBox/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/ColorBox/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/ColorBox/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/ColorBox/Overview/Knockout/index.html
+++ b/JSDemos/Demos/ColorBox/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/ColorBox/Overview/React/index.html
+++ b/JSDemos/Demos/ColorBox/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/ColorBox/Overview/Vue/index.html
+++ b/JSDemos/Demos/ColorBox/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/ColorBox/Overview/jQuery/index.html
+++ b/JSDemos/Demos/ColorBox/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Common/ActionAndListsOverview/Angular/index.html
+++ b/JSDemos/Demos/Common/ActionAndListsOverview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Common/ActionAndListsOverview/AngularJS/index.html
+++ b/JSDemos/Demos/Common/ActionAndListsOverview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Common/ActionAndListsOverview/Knockout/index.html
+++ b/JSDemos/Demos/Common/ActionAndListsOverview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Common/ActionAndListsOverview/React/index.html
+++ b/JSDemos/Demos/Common/ActionAndListsOverview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Common/ActionAndListsOverview/Vue/index.html
+++ b/JSDemos/Demos/Common/ActionAndListsOverview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Common/ActionAndListsOverview/jQuery/index.html
+++ b/JSDemos/Demos/Common/ActionAndListsOverview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/underscore/underscore.js"></script>

--- a/JSDemos/Demos/Common/CustomTextEditorButtons/Angular/index.html
+++ b/JSDemos/Demos/Common/CustomTextEditorButtons/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Common/CustomTextEditorButtons/AngularJS/index.html
+++ b/JSDemos/Demos/Common/CustomTextEditorButtons/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Common/CustomTextEditorButtons/React/index.html
+++ b/JSDemos/Demos/Common/CustomTextEditorButtons/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Common/CustomTextEditorButtons/Vue/index.html
+++ b/JSDemos/Demos/Common/CustomTextEditorButtons/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Common/CustomTextEditorButtons/jQuery/index.html
+++ b/JSDemos/Demos/Common/CustomTextEditorButtons/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Common/DialogsAndNotificationsOverview/Angular/index.html
+++ b/JSDemos/Demos/Common/DialogsAndNotificationsOverview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Common/DialogsAndNotificationsOverview/AngularJS/index.html
+++ b/JSDemos/Demos/Common/DialogsAndNotificationsOverview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Common/DialogsAndNotificationsOverview/React/index.html
+++ b/JSDemos/Demos/Common/DialogsAndNotificationsOverview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Common/DialogsAndNotificationsOverview/Vue/index.html
+++ b/JSDemos/Demos/Common/DialogsAndNotificationsOverview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Common/DialogsAndNotificationsOverview/jQuery/index.html
+++ b/JSDemos/Demos/Common/DialogsAndNotificationsOverview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/underscore/underscore.js"></script>

--- a/JSDemos/Demos/Common/EditorAppearanceVariants/Angular/index.html
+++ b/JSDemos/Demos/Common/EditorAppearanceVariants/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Common/EditorAppearanceVariants/AngularJS/index.html
+++ b/JSDemos/Demos/Common/EditorAppearanceVariants/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Common/EditorAppearanceVariants/React/index.html
+++ b/JSDemos/Demos/Common/EditorAppearanceVariants/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Common/EditorAppearanceVariants/Vue/index.html
+++ b/JSDemos/Demos/Common/EditorAppearanceVariants/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Common/EditorAppearanceVariants/jQuery/index.html
+++ b/JSDemos/Demos/Common/EditorAppearanceVariants/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Common/EditorsOverview/Angular/index.html
+++ b/JSDemos/Demos/Common/EditorsOverview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Common/EditorsOverview/AngularJS/index.html
+++ b/JSDemos/Demos/Common/EditorsOverview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Common/EditorsOverview/Knockout/index.html
+++ b/JSDemos/Demos/Common/EditorsOverview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Common/EditorsOverview/React/index.html
+++ b/JSDemos/Demos/Common/EditorsOverview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Common/EditorsOverview/Vue/index.html
+++ b/JSDemos/Demos/Common/EditorsOverview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Common/EditorsOverview/jQuery/index.html
+++ b/JSDemos/Demos/Common/EditorsOverview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Common/EditorsRightToLeftSupport/Angular/index.html
+++ b/JSDemos/Demos/Common/EditorsRightToLeftSupport/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Common/EditorsRightToLeftSupport/AngularJS/index.html
+++ b/JSDemos/Demos/Common/EditorsRightToLeftSupport/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Common/EditorsRightToLeftSupport/Knockout/index.html
+++ b/JSDemos/Demos/Common/EditorsRightToLeftSupport/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Common/EditorsRightToLeftSupport/React/index.html
+++ b/JSDemos/Demos/Common/EditorsRightToLeftSupport/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Common/EditorsRightToLeftSupport/Vue/index.html
+++ b/JSDemos/Demos/Common/EditorsRightToLeftSupport/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Common/EditorsRightToLeftSupport/jQuery/index.html
+++ b/JSDemos/Demos/Common/EditorsRightToLeftSupport/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Common/FormsAndMultiPurposeOverview/Angular/index.html
+++ b/JSDemos/Demos/Common/FormsAndMultiPurposeOverview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Common/FormsAndMultiPurposeOverview/AngularJS/index.html
+++ b/JSDemos/Demos/Common/FormsAndMultiPurposeOverview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Common/FormsAndMultiPurposeOverview/Knockout/index.html
+++ b/JSDemos/Demos/Common/FormsAndMultiPurposeOverview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Common/FormsAndMultiPurposeOverview/React/index.html
+++ b/JSDemos/Demos/Common/FormsAndMultiPurposeOverview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Common/FormsAndMultiPurposeOverview/Vue/index.html
+++ b/JSDemos/Demos/Common/FormsAndMultiPurposeOverview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Common/FormsAndMultiPurposeOverview/jQuery/index.html
+++ b/JSDemos/Demos/Common/FormsAndMultiPurposeOverview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Common/NavigationOverview/Angular/index.html
+++ b/JSDemos/Demos/Common/NavigationOverview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Common/NavigationOverview/AngularJS/index.html
+++ b/JSDemos/Demos/Common/NavigationOverview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Common/NavigationOverview/Knockout/index.html
+++ b/JSDemos/Demos/Common/NavigationOverview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Common/NavigationOverview/React/index.html
+++ b/JSDemos/Demos/Common/NavigationOverview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Common/NavigationOverview/Vue/index.html
+++ b/JSDemos/Demos/Common/NavigationOverview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Common/NavigationOverview/jQuery/index.html
+++ b/JSDemos/Demos/Common/NavigationOverview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/underscore/underscore.js"></script>

--- a/JSDemos/Demos/Common/NavigationRightToLeftSupport/Angular/index.html
+++ b/JSDemos/Demos/Common/NavigationRightToLeftSupport/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Common/NavigationRightToLeftSupport/AngularJS/index.html
+++ b/JSDemos/Demos/Common/NavigationRightToLeftSupport/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Common/NavigationRightToLeftSupport/Knockout/index.html
+++ b/JSDemos/Demos/Common/NavigationRightToLeftSupport/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Common/NavigationRightToLeftSupport/jQuery/index.html
+++ b/JSDemos/Demos/Common/NavigationRightToLeftSupport/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/underscore/underscore.js"></script>

--- a/JSDemos/Demos/ContextMenu/Basics/Angular/index.html
+++ b/JSDemos/Demos/ContextMenu/Basics/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/ContextMenu/Basics/AngularJS/index.html
+++ b/JSDemos/Demos/ContextMenu/Basics/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/ContextMenu/Basics/Knockout/index.html
+++ b/JSDemos/Demos/ContextMenu/Basics/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/ContextMenu/Basics/React/index.html
+++ b/JSDemos/Demos/ContextMenu/Basics/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/ContextMenu/Basics/Vue/index.html
+++ b/JSDemos/Demos/ContextMenu/Basics/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/ContextMenu/Basics/jQuery/index.html
+++ b/JSDemos/Demos/ContextMenu/Basics/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/ContextMenu/Templates/Angular/index.html
+++ b/JSDemos/Demos/ContextMenu/Templates/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/ContextMenu/Templates/AngularJS/index.html
+++ b/JSDemos/Demos/ContextMenu/Templates/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/ContextMenu/Templates/Knockout/index.html
+++ b/JSDemos/Demos/ContextMenu/Templates/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/ContextMenu/Templates/React/index.html
+++ b/JSDemos/Demos/ContextMenu/Templates/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/ContextMenu/Templates/Vue/index.html
+++ b/JSDemos/Demos/ContextMenu/Templates/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/ContextMenu/Templates/jQuery/index.html
+++ b/JSDemos/Demos/ContextMenu/Templates/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/React/index.html
+++ b/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/AjaxRequest/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/AjaxRequest/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/AjaxRequest/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/AjaxRequest/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/AjaxRequest/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/AjaxRequest/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="index.js"></script>

--- a/JSDemos/Demos/DataGrid/AjaxRequest/React/index.html
+++ b/JSDemos/Demos/DataGrid/AjaxRequest/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/AjaxRequest/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/AjaxRequest/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/AjaxRequest/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/AjaxRequest/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="index.js"></script>

--- a/JSDemos/Demos/DataGrid/Appearance/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/Appearance/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/Appearance/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/Appearance/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/Appearance/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/Appearance/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/Appearance/React/index.html
+++ b/JSDemos/Demos/DataGrid/Appearance/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/Appearance/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/Appearance/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/Appearance/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/Appearance/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/BatchEditing/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/BatchEditing/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/BatchEditing/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/BatchEditing/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/DataGrid/BatchEditing/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/BatchEditing/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/BatchEditing/React/index.html
+++ b/JSDemos/Demos/DataGrid/BatchEditing/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/BatchEditing/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/BatchEditing/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/BatchEditing/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/BatchEditing/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/BatchUpdateRequest/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/BatchUpdateRequest/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/BatchUpdateRequest/React/index.html
+++ b/JSDemos/Demos/DataGrid/BatchUpdateRequest/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/BatchUpdateRequest/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/BatchUpdateRequest/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/BatchUpdateRequest/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/BatchUpdateRequest/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/CRUDOperations/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/CRUDOperations/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CRUDOperations/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/CRUDOperations/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/CRUDOperations/React/index.html
+++ b/JSDemos/Demos/DataGrid/CRUDOperations/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/CRUDOperations/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/CRUDOperations/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CRUDOperations/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/CRUDOperations/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/DataGrid/CascadingLookups/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/CascadingLookups/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CascadingLookups/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/CascadingLookups/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/CascadingLookups/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/CascadingLookups/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/CascadingLookups/React/index.html
+++ b/JSDemos/Demos/DataGrid/CascadingLookups/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/CascadingLookups/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/CascadingLookups/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CascadingLookups/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/CascadingLookups/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/CellCustomization/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/CellCustomization/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CellCustomization/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/CellCustomization/AngularJS/index.html
@@ -10,7 +10,6 @@
     <script src="../../../../../node_modules/cldrjs/dist/cldr/event.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/supplemental.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/unresolved.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/CellCustomization/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/CellCustomization/Knockout/index.html
@@ -11,7 +11,6 @@
     <script src="../../../../../node_modules/cldrjs/dist/cldr/event.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/supplemental.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/unresolved.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/CellCustomization/React/index.html
+++ b/JSDemos/Demos/DataGrid/CellCustomization/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/CellCustomization/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/CellCustomization/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CellCustomization/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/CellCustomization/jQuery/index.html
@@ -10,7 +10,6 @@
     <script src="../../../../../node_modules/cldrjs/dist/cldr/event.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/supplemental.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/unresolved.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/index.html
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/CollaborativeEditing/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/CollaborativeEditing/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CollaborativeEditing/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/CollaborativeEditing/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/CollaborativeEditing/React/index.html
+++ b/JSDemos/Demos/DataGrid/CollaborativeEditing/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CollaborativeEditing/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/CollaborativeEditing/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CollaborativeEditing/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/CollaborativeEditing/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/@aspnet/signalr/dist/browser/signalr.js"></script>

--- a/JSDemos/Demos/DataGrid/Column3RdPartyEngineTemplate/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/Column3RdPartyEngineTemplate/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/underscore/underscore.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnCustomization/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnCustomization/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnCustomization/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnCustomization/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnCustomization/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnCustomization/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnCustomization/React/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnCustomization/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/ColumnCustomization/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnCustomization/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnCustomization/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnCustomization/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnResizing/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnResizing/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnResizing/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnResizing/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnResizing/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnResizing/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnResizing/React/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnResizing/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/ColumnResizing/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnResizing/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnResizing/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnResizing/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnTemplate/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnTemplate/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnTemplate/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnTemplate/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnTemplate/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnTemplate/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnTemplate/React/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnTemplate/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/ColumnTemplate/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnTemplate/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnTemplate/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnTemplate/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnsBasedOnADataSource/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnsBasedOnADataSource/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnsBasedOnADataSource/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnsBasedOnADataSource/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnsBasedOnADataSource/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnsBasedOnADataSource/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnsBasedOnADataSource/React/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnsBasedOnADataSource/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/ColumnsBasedOnADataSource/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnsBasedOnADataSource/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ColumnsBasedOnADataSource/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/ColumnsBasedOnADataSource/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/CommandColumnCustomization/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/CommandColumnCustomization/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CommandColumnCustomization/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/CommandColumnCustomization/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/CommandColumnCustomization/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/CommandColumnCustomization/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/CommandColumnCustomization/React/index.html
+++ b/JSDemos/Demos/DataGrid/CommandColumnCustomization/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/CommandColumnCustomization/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/CommandColumnCustomization/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CommandColumnCustomization/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/CommandColumnCustomization/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomDataSource/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/CustomDataSource/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomDataSource/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/CustomDataSource/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomDataSource/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/CustomDataSource/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="index.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomDataSource/React/index.html
+++ b/JSDemos/Demos/DataGrid/CustomDataSource/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomDataSource/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/CustomDataSource/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomDataSource/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/CustomDataSource/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="index.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomEditors/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/CustomEditors/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomEditors/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/CustomEditors/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomEditors/React/index.html
+++ b/JSDemos/Demos/DataGrid/CustomEditors/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/CustomEditors/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/CustomEditors/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomEditors/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/CustomEditors/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomNewRecordPosition/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/CustomNewRecordPosition/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomNewRecordPosition/React/index.html
+++ b/JSDemos/Demos/DataGrid/CustomNewRecordPosition/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/CustomNewRecordPosition/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/CustomNewRecordPosition/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomNewRecordPosition/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/CustomNewRecordPosition/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomSummaries/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/CustomSummaries/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomSummaries/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/CustomSummaries/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomSummaries/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/CustomSummaries/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomSummaries/React/index.html
+++ b/JSDemos/Demos/DataGrid/CustomSummaries/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/CustomSummaries/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/CustomSummaries/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomSummaries/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/CustomSummaries/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomizeKeyboardNavigation/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/CustomizeKeyboardNavigation/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomizeKeyboardNavigation/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/CustomizeKeyboardNavigation/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/DataGrid/CustomizeKeyboardNavigation/React/index.html
+++ b/JSDemos/Demos/DataGrid/CustomizeKeyboardNavigation/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/CustomizeKeyboardNavigation/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/CustomizeKeyboardNavigation/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/CustomizeKeyboardNavigation/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/CustomizeKeyboardNavigation/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/DataValidation/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/DataValidation/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/DataValidation/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/DataValidation/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/DataValidation/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/DataValidation/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>

--- a/JSDemos/Demos/DataGrid/DataValidation/React/index.html
+++ b/JSDemos/Demos/DataGrid/DataValidation/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/DataValidation/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/DataValidation/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/DataValidation/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/DataValidation/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>

--- a/JSDemos/Demos/DataGrid/DeferredSelection/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/DeferredSelection/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/DeferredSelection/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/DeferredSelection/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/DeferredSelection/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/DeferredSelection/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/DataGrid/DeferredSelection/React/index.html
+++ b/JSDemos/Demos/DataGrid/DeferredSelection/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/DeferredSelection/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/DeferredSelection/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/DeferredSelection/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/DeferredSelection/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/DataGrid/DnDBetweenGrids/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/DnDBetweenGrids/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/DnDBetweenGrids/React/index.html
+++ b/JSDemos/Demos/DataGrid/DnDBetweenGrids/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/DnDBetweenGrids/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/DnDBetweenGrids/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/DnDBetweenGrids/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/DnDBetweenGrids/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>

--- a/JSDemos/Demos/DataGrid/EditStateManagement/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/EditStateManagement/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/EditStateManagement/React/index.html
+++ b/JSDemos/Demos/DataGrid/EditStateManagement/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/EditStateManagement/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/EditStateManagement/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/EditStateManagement/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/EditStateManagement/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/ExcelJS/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJS/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ExcelJS/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJS/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/ExcelJS/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJS/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
 

--- a/JSDemos/Demos/DataGrid/ExcelJS/React/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJS/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/ExcelJS/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJS/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ExcelJS/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJS/jQuery/index.html
@@ -11,7 +11,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
 
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
 

--- a/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/React/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/jQuery/index.html
@@ -11,7 +11,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
 
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/DataGrid/ExcelJSExportImages/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportImages/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ExcelJSExportImages/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportImages/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/ExcelJSExportImages/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportImages/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
 

--- a/JSDemos/Demos/DataGrid/ExcelJSExportImages/React/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportImages/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/ExcelJSExportImages/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportImages/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ExcelJSExportImages/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportImages/jQuery/index.html
@@ -11,7 +11,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
 
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/DataGrid/ExcelJSExportMultipleGrids/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportMultipleGrids/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ExcelJSExportMultipleGrids/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportMultipleGrids/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/ExcelJSExportMultipleGrids/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportMultipleGrids/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
 

--- a/JSDemos/Demos/DataGrid/ExcelJSExportMultipleGrids/React/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportMultipleGrids/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/ExcelJSExportMultipleGrids/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportMultipleGrids/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ExcelJSExportMultipleGrids/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportMultipleGrids/jQuery/index.html
@@ -11,7 +11,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
 
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
 

--- a/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/React/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSHeaderAndFooter/jQuery/index.html
@@ -11,7 +11,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
 
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/DataGrid/ExcelJSOverview/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSOverview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ExcelJSOverview/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSOverview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/ExcelJSOverview/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSOverview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
 

--- a/JSDemos/Demos/DataGrid/ExcelJSOverview/React/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSOverview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/ExcelJSOverview/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSOverview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ExcelJSOverview/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSOverview/jQuery/index.html
@@ -11,7 +11,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
 
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/DataGrid/FilterPanel/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/FilterPanel/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/FilterPanel/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/FilterPanel/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/FilterPanel/React/index.html
+++ b/JSDemos/Demos/DataGrid/FilterPanel/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/FilterPanel/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/FilterPanel/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/FilterPanel/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/FilterPanel/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/Filtering/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/Filtering/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/Filtering/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/Filtering/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/Filtering/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/Filtering/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/Filtering/React/index.html
+++ b/JSDemos/Demos/DataGrid/Filtering/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/Filtering/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/Filtering/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/Filtering/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/Filtering/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/FilteringAPI/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/FilteringAPI/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/FilteringAPI/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/FilteringAPI/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/FilteringAPI/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/FilteringAPI/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/FilteringAPI/React/index.html
+++ b/JSDemos/Demos/DataGrid/FilteringAPI/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/FilteringAPI/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/FilteringAPI/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/FilteringAPI/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/FilteringAPI/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/FocusedRow/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/FocusedRow/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/FocusedRow/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/FocusedRow/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/DataGrid/FocusedRow/React/index.html
+++ b/JSDemos/Demos/DataGrid/FocusedRow/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/FocusedRow/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/FocusedRow/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/FocusedRow/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/FocusedRow/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/FormEditing/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/FormEditing/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/FormEditing/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/FormEditing/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/FormEditing/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/FormEditing/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/FormEditing/React/index.html
+++ b/JSDemos/Demos/DataGrid/FormEditing/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/FormEditing/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/FormEditing/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/FormEditing/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/FormEditing/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/React/index.html
+++ b/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/GridColumnsHidingPriority/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/GridColumnsHidingPriority/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/GridColumnsHidingPriority/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/GridColumnsHidingPriority/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/GridColumnsHidingPriority/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/GridColumnsHidingPriority/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/GridColumnsHidingPriority/React/index.html
+++ b/JSDemos/Demos/DataGrid/GridColumnsHidingPriority/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/GridColumnsHidingPriority/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/GridColumnsHidingPriority/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/GridColumnsHidingPriority/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/GridColumnsHidingPriority/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/GridSummaries/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/GridSummaries/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/GridSummaries/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/GridSummaries/AngularJS/index.html
@@ -10,7 +10,6 @@
     <script src="../../../../../node_modules/cldrjs/dist/cldr/event.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/supplemental.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/unresolved.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/GridSummaries/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/GridSummaries/Knockout/index.html
@@ -11,7 +11,6 @@
     <script src="../../../../../node_modules/cldrjs/dist/cldr/event.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/supplemental.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/unresolved.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/GridSummaries/React/index.html
+++ b/JSDemos/Demos/DataGrid/GridSummaries/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/GridSummaries/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/GridSummaries/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/GridSummaries/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/GridSummaries/jQuery/index.html
@@ -10,7 +10,6 @@
     <script src="../../../../../node_modules/cldrjs/dist/cldr/event.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/supplemental.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/unresolved.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/GroupSummaries/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/GroupSummaries/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/GroupSummaries/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/GroupSummaries/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/GroupSummaries/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/GroupSummaries/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/GroupSummaries/React/index.html
+++ b/JSDemos/Demos/DataGrid/GroupSummaries/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/GroupSummaries/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/GroupSummaries/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/GroupSummaries/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/GroupSummaries/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/HorizontalVirtualScrolling/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/HorizontalVirtualScrolling/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/HorizontalVirtualScrolling/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/HorizontalVirtualScrolling/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/HorizontalVirtualScrolling/React/index.html
+++ b/JSDemos/Demos/DataGrid/HorizontalVirtualScrolling/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/HorizontalVirtualScrolling/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/HorizontalVirtualScrolling/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/HorizontalVirtualScrolling/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/HorizontalVirtualScrolling/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/InfiniteScrolling/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/InfiniteScrolling/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/InfiniteScrolling/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/InfiniteScrolling/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/InfiniteScrolling/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/InfiniteScrolling/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/InfiniteScrolling/React/index.html
+++ b/JSDemos/Demos/DataGrid/InfiniteScrolling/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/InfiniteScrolling/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/InfiniteScrolling/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/InfiniteScrolling/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/InfiniteScrolling/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/KeyboardNavigation/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/KeyboardNavigation/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/KeyboardNavigation/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/KeyboardNavigation/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/angular-sanitize/angular-sanitize.min.js"></script>

--- a/JSDemos/Demos/DataGrid/KeyboardNavigation/React/index.html
+++ b/JSDemos/Demos/DataGrid/KeyboardNavigation/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/KeyboardNavigation/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/KeyboardNavigation/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/KeyboardNavigation/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/KeyboardNavigation/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/LocalReordering/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/LocalReordering/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/LocalReordering/React/index.html
+++ b/JSDemos/Demos/DataGrid/LocalReordering/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/LocalReordering/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/LocalReordering/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/LocalReordering/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/LocalReordering/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>

--- a/JSDemos/Demos/DataGrid/MasterDetailAPI/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/MasterDetailAPI/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/MasterDetailAPI/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/MasterDetailAPI/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/MasterDetailAPI/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/MasterDetailAPI/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/MasterDetailAPI/React/index.html
+++ b/JSDemos/Demos/DataGrid/MasterDetailAPI/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/MasterDetailAPI/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/MasterDetailAPI/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/MasterDetailAPI/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/MasterDetailAPI/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/MasterDetailView/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/MasterDetailView/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/MasterDetailView/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/MasterDetailView/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/MasterDetailView/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/MasterDetailView/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/MasterDetailView/React/index.html
+++ b/JSDemos/Demos/DataGrid/MasterDetailView/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/MasterDetailView/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/MasterDetailView/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/MasterDetailView/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/MasterDetailView/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/MultiRowHeadersBands/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/MultiRowHeadersBands/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/MultiRowHeadersBands/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/MultiRowHeadersBands/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/MultiRowHeadersBands/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/MultiRowHeadersBands/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/MultiRowHeadersBands/React/index.html
+++ b/JSDemos/Demos/DataGrid/MultiRowHeadersBands/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/MultiRowHeadersBands/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/MultiRowHeadersBands/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/MultiRowHeadersBands/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/MultiRowHeadersBands/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/React/index.html
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionModes/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionModes/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionModes/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionModes/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionModes/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionModes/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionModes/React/index.html
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionModes/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionModes/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionModes/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionModes/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionModes/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/MultipleSorting/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/MultipleSorting/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/MultipleSorting/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/MultipleSorting/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/MultipleSorting/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/MultipleSorting/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/MultipleSorting/React/index.html
+++ b/JSDemos/Demos/DataGrid/MultipleSorting/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/MultipleSorting/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/MultipleSorting/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/MultipleSorting/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/MultipleSorting/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/OdataService/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/OdataService/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/OdataService/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/OdataService/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/OdataService/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/OdataService/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="index.js"></script>

--- a/JSDemos/Demos/DataGrid/OdataService/React/index.html
+++ b/JSDemos/Demos/DataGrid/OdataService/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/OdataService/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/OdataService/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/OdataService/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/OdataService/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="index.js"></script>

--- a/JSDemos/Demos/DataGrid/Overview/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/Overview/AngularJS/index.html
@@ -10,7 +10,6 @@
     <script src="../../../../../node_modules/cldrjs/dist/cldr/event.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/supplemental.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/unresolved.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/Overview/React/index.html
+++ b/JSDemos/Demos/DataGrid/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/Overview/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/Overview/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/Overview/jQuery/index.html
@@ -10,7 +10,6 @@
     <script src="../../../../../node_modules/cldrjs/dist/cldr/event.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/supplemental.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/unresolved.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/DataGrid/PDFCellCustomization/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/PDFCellCustomization/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/PDFCellCustomization/React/index.html
+++ b/JSDemos/Demos/DataGrid/PDFCellCustomization/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/PDFCellCustomization/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/PDFCellCustomization/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/PDFCellCustomization/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/PDFCellCustomization/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/PDFExportImages/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/PDFExportImages/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/PDFExportImages/React/index.html
+++ b/JSDemos/Demos/DataGrid/PDFExportImages/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/PDFExportImages/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/PDFExportImages/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/PDFExportImages/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/PDFExportImages/jQuery/index.html
@@ -12,7 +12,6 @@
     </script>
 
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/DataGrid/PDFExportMultipleGrids/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/PDFExportMultipleGrids/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/PDFExportMultipleGrids/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/PDFExportMultipleGrids/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/PDFExportMultipleGrids/React/index.html
+++ b/JSDemos/Demos/DataGrid/PDFExportMultipleGrids/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/PDFExportMultipleGrids/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/PDFExportMultipleGrids/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/PDFExportMultipleGrids/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/PDFExportMultipleGrids/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/DataGrid/PDFHeaderAndFooter/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/PDFHeaderAndFooter/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/PDFHeaderAndFooter/React/index.html
+++ b/JSDemos/Demos/DataGrid/PDFHeaderAndFooter/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/PDFHeaderAndFooter/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/PDFHeaderAndFooter/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/PDFHeaderAndFooter/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/PDFHeaderAndFooter/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/DataGrid/PDFOverview/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/PDFOverview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/PDFOverview/React/index.html
+++ b/JSDemos/Demos/DataGrid/PDFOverview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/PDFOverview/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/PDFOverview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/PDFOverview/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/PDFOverview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/PopupEditing/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/PopupEditing/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/PopupEditing/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/PopupEditing/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/PopupEditing/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/PopupEditing/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/PopupEditing/React/index.html
+++ b/JSDemos/Demos/DataGrid/PopupEditing/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/PopupEditing/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/PopupEditing/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/PopupEditing/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/PopupEditing/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/RealTimeUpdates/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/RealTimeUpdates/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RealTimeUpdates/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/RealTimeUpdates/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/RealTimeUpdates/React/index.html
+++ b/JSDemos/Demos/DataGrid/RealTimeUpdates/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/RealTimeUpdates/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/RealTimeUpdates/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RealTimeUpdates/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/RealTimeUpdates/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/RecalculateWhileEditing/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/RecalculateWhileEditing/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RecalculateWhileEditing/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/RecalculateWhileEditing/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/RecalculateWhileEditing/React/index.html
+++ b/JSDemos/Demos/DataGrid/RecalculateWhileEditing/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/RecalculateWhileEditing/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/RecalculateWhileEditing/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RecalculateWhileEditing/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/RecalculateWhileEditing/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/RecordGrouping/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/RecordGrouping/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RecordGrouping/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/RecordGrouping/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/RecordGrouping/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/RecordGrouping/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/RecordGrouping/React/index.html
+++ b/JSDemos/Demos/DataGrid/RecordGrouping/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/RecordGrouping/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/RecordGrouping/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RecordGrouping/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/RecordGrouping/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/RecordPaging/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/RecordPaging/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RecordPaging/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/RecordPaging/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RecordPaging/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/RecordPaging/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/RecordPaging/React/index.html
+++ b/JSDemos/Demos/DataGrid/RecordPaging/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/RecordPaging/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/RecordPaging/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/RecordPaging/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/RecordPaging/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/RemoteGrouping/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/RemoteGrouping/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RemoteGrouping/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/RemoteGrouping/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/RemoteGrouping/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/RemoteGrouping/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>

--- a/JSDemos/Demos/DataGrid/RemoteGrouping/React/index.html
+++ b/JSDemos/Demos/DataGrid/RemoteGrouping/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/RemoteGrouping/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/RemoteGrouping/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RemoteGrouping/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/RemoteGrouping/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>

--- a/JSDemos/Demos/DataGrid/RemoteReordering/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/RemoteReordering/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RemoteReordering/React/index.html
+++ b/JSDemos/Demos/DataGrid/RemoteReordering/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/RemoteReordering/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/RemoteReordering/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RemoteReordering/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/RemoteReordering/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>

--- a/JSDemos/Demos/DataGrid/RemoteVirtualScrolling/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/RemoteVirtualScrolling/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RemoteVirtualScrolling/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/RemoteVirtualScrolling/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/RemoteVirtualScrolling/React/index.html
+++ b/JSDemos/Demos/DataGrid/RemoteVirtualScrolling/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RemoteVirtualScrolling/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/RemoteVirtualScrolling/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RemoteVirtualScrolling/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/RemoteVirtualScrolling/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>

--- a/JSDemos/Demos/DataGrid/RightToLeftSupport/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/RightToLeftSupport/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RightToLeftSupport/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/RightToLeftSupport/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/RightToLeftSupport/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/RightToLeftSupport/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/RightToLeftSupport/React/index.html
+++ b/JSDemos/Demos/DataGrid/RightToLeftSupport/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/RightToLeftSupport/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/RightToLeftSupport/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RightToLeftSupport/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/RightToLeftSupport/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/Row3RdPartyEngineTemplate/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/Row3RdPartyEngineTemplate/jQuery/index.html
@@ -10,7 +10,6 @@
     <script src="../../../../../node_modules/cldrjs/dist/cldr/event.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/supplemental.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/unresolved.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/underscore/underscore.js"></script>

--- a/JSDemos/Demos/DataGrid/RowEditingAndEditingEvents/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/RowEditingAndEditingEvents/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RowEditingAndEditingEvents/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/RowEditingAndEditingEvents/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/RowEditingAndEditingEvents/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/RowEditingAndEditingEvents/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/RowEditingAndEditingEvents/React/index.html
+++ b/JSDemos/Demos/DataGrid/RowEditingAndEditingEvents/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/RowEditingAndEditingEvents/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/RowEditingAndEditingEvents/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RowEditingAndEditingEvents/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/RowEditingAndEditingEvents/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/RowSelection/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/RowSelection/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RowSelection/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/RowSelection/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/RowSelection/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/RowSelection/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/RowSelection/React/index.html
+++ b/JSDemos/Demos/DataGrid/RowSelection/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/RowSelection/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/RowSelection/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RowSelection/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/RowSelection/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/RowTemplate/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/RowTemplate/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RowTemplate/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/RowTemplate/AngularJS/index.html
@@ -10,7 +10,6 @@
     <script src="../../../../../node_modules/cldrjs/dist/cldr/event.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/supplemental.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/unresolved.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/RowTemplate/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/RowTemplate/Knockout/index.html
@@ -11,7 +11,6 @@
     <script src="../../../../../node_modules/cldrjs/dist/cldr/event.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/supplemental.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/unresolved.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/RowTemplate/React/index.html
+++ b/JSDemos/Demos/DataGrid/RowTemplate/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/RowTemplate/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/RowTemplate/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/RowTemplate/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/RowTemplate/jQuery/index.html
@@ -10,7 +10,6 @@
     <script src="../../../../../node_modules/cldrjs/dist/cldr/event.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/supplemental.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/unresolved.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/SignalRService/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/SignalRService/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/SignalRService/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/SignalRService/AngularJS/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/DataGrid/SignalRService/React/index.html
+++ b/JSDemos/Demos/DataGrid/SignalRService/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/SignalRService/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/SignalRService/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/SignalRService/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/SignalRService/jQuery/index.html
@@ -8,7 +8,6 @@
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/signalr/jquery.signalR.js"></script>
     <script src="../signalr-hub.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/DataGrid/SimpleArray/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/SimpleArray/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/SimpleArray/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/SimpleArray/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/SimpleArray/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/SimpleArray/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/SimpleArray/React/index.html
+++ b/JSDemos/Demos/DataGrid/SimpleArray/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/SimpleArray/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/SimpleArray/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/SimpleArray/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/SimpleArray/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/StatePersistence/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/StatePersistence/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/StatePersistence/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/StatePersistence/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/StatePersistence/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/StatePersistence/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/StatePersistence/React/index.html
+++ b/JSDemos/Demos/DataGrid/StatePersistence/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/StatePersistence/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/StatePersistence/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/StatePersistence/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/StatePersistence/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/ToolbarCustomization/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/ToolbarCustomization/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ToolbarCustomization/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/ToolbarCustomization/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/ToolbarCustomization/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/ToolbarCustomization/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/ToolbarCustomization/React/index.html
+++ b/JSDemos/Demos/DataGrid/ToolbarCustomization/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DataGrid/ToolbarCustomization/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/ToolbarCustomization/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/ToolbarCustomization/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/ToolbarCustomization/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/VirtualScrolling/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/VirtualScrolling/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/VirtualScrolling/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/VirtualScrolling/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/VirtualScrolling/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/VirtualScrolling/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/VirtualScrolling/React/index.html
+++ b/JSDemos/Demos/DataGrid/VirtualScrolling/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/VirtualScrolling/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/VirtualScrolling/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/VirtualScrolling/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/VirtualScrolling/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DataGrid/WebAPIService/Angular/index.html
+++ b/JSDemos/Demos/DataGrid/WebAPIService/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/WebAPIService/AngularJS/index.html
+++ b/JSDemos/Demos/DataGrid/WebAPIService/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DataGrid/WebAPIService/Knockout/index.html
+++ b/JSDemos/Demos/DataGrid/WebAPIService/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>

--- a/JSDemos/Demos/DataGrid/WebAPIService/React/index.html
+++ b/JSDemos/Demos/DataGrid/WebAPIService/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/WebAPIService/Vue/index.html
+++ b/JSDemos/Demos/DataGrid/WebAPIService/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DataGrid/WebAPIService/jQuery/index.html
+++ b/JSDemos/Demos/DataGrid/WebAPIService/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>

--- a/JSDemos/Demos/DateBox/Formatting/Angular/index.html
+++ b/JSDemos/Demos/DateBox/Formatting/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DateBox/Formatting/AngularJS/index.html
+++ b/JSDemos/Demos/DateBox/Formatting/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/DateBox/Formatting/Knockout/index.html
+++ b/JSDemos/Demos/DateBox/Formatting/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DateBox/Formatting/React/index.html
+++ b/JSDemos/Demos/DateBox/Formatting/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DateBox/Formatting/Vue/index.html
+++ b/JSDemos/Demos/DateBox/Formatting/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DateBox/Formatting/jQuery/index.html
+++ b/JSDemos/Demos/DateBox/Formatting/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DateBox/Overview/Angular/index.html
+++ b/JSDemos/Demos/DateBox/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DateBox/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/DateBox/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DateBox/Overview/Knockout/index.html
+++ b/JSDemos/Demos/DateBox/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DateBox/Overview/React/index.html
+++ b/JSDemos/Demos/DateBox/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DateBox/Overview/Vue/index.html
+++ b/JSDemos/Demos/DateBox/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DateBox/Overview/jQuery/index.html
+++ b/JSDemos/Demos/DateBox/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Diagram/Adaptability/Angular/index.html
+++ b/JSDemos/Demos/Diagram/Adaptability/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
 

--- a/JSDemos/Demos/Diagram/Adaptability/React/index.html
+++ b/JSDemos/Demos/Diagram/Adaptability/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/Adaptability/Vue/index.html
+++ b/JSDemos/Demos/Diagram/Adaptability/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/Adaptability/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/Adaptability/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Diagram/AdvancedDataBinding/Angular/index.html
+++ b/JSDemos/Demos/Diagram/AdvancedDataBinding/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
 

--- a/JSDemos/Demos/Diagram/AdvancedDataBinding/React/index.html
+++ b/JSDemos/Demos/Diagram/AdvancedDataBinding/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/AdvancedDataBinding/Vue/index.html
+++ b/JSDemos/Demos/Diagram/AdvancedDataBinding/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/AdvancedDataBinding/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/AdvancedDataBinding/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Diagram/Containers/Angular/index.html
+++ b/JSDemos/Demos/Diagram/Containers/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
 

--- a/JSDemos/Demos/Diagram/Containers/React/index.html
+++ b/JSDemos/Demos/Diagram/Containers/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/Containers/Vue/index.html
+++ b/JSDemos/Demos/Diagram/Containers/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/Containers/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/Containers/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithIcons/Angular/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithIcons/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
 

--- a/JSDemos/Demos/Diagram/CustomShapesWithIcons/React/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithIcons/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/CustomShapesWithIcons/Vue/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithIcons/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/CustomShapesWithIcons/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithIcons/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplates/Angular/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplates/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
 

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplates/React/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplates/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplates/Vue/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplates/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplates/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplates/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/Angular/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
 

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/React/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/Vue/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTexts/Angular/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTexts/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
 

--- a/JSDemos/Demos/Diagram/CustomShapesWithTexts/React/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTexts/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/CustomShapesWithTexts/Vue/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTexts/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/CustomShapesWithTexts/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTexts/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Diagram/ImagesInShapes/Angular/index.html
+++ b/JSDemos/Demos/Diagram/ImagesInShapes/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
 

--- a/JSDemos/Demos/Diagram/ImagesInShapes/React/index.html
+++ b/JSDemos/Demos/Diagram/ImagesInShapes/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/ImagesInShapes/Vue/index.html
+++ b/JSDemos/Demos/Diagram/ImagesInShapes/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/ImagesInShapes/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/ImagesInShapes/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Diagram/ItemSelection/Angular/index.html
+++ b/JSDemos/Demos/Diagram/ItemSelection/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
 

--- a/JSDemos/Demos/Diagram/ItemSelection/React/index.html
+++ b/JSDemos/Demos/Diagram/ItemSelection/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/ItemSelection/Vue/index.html
+++ b/JSDemos/Demos/Diagram/ItemSelection/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/ItemSelection/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/ItemSelection/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Diagram/NodesAndEdgesArrays/Angular/index.html
+++ b/JSDemos/Demos/Diagram/NodesAndEdgesArrays/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
 

--- a/JSDemos/Demos/Diagram/NodesAndEdgesArrays/React/index.html
+++ b/JSDemos/Demos/Diagram/NodesAndEdgesArrays/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/NodesAndEdgesArrays/Vue/index.html
+++ b/JSDemos/Demos/Diagram/NodesAndEdgesArrays/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/NodesAndEdgesArrays/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/NodesAndEdgesArrays/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/Angular/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
 

--- a/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/React/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/Vue/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Diagram/NodesArrayPlainStructure/Angular/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayPlainStructure/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
 

--- a/JSDemos/Demos/Diagram/NodesArrayPlainStructure/React/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayPlainStructure/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/NodesArrayPlainStructure/Vue/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayPlainStructure/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/NodesArrayPlainStructure/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayPlainStructure/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Diagram/OperationRestrictions/Angular/index.html
+++ b/JSDemos/Demos/Diagram/OperationRestrictions/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
 

--- a/JSDemos/Demos/Diagram/OperationRestrictions/React/index.html
+++ b/JSDemos/Demos/Diagram/OperationRestrictions/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/OperationRestrictions/Vue/index.html
+++ b/JSDemos/Demos/Diagram/OperationRestrictions/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/OperationRestrictions/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/OperationRestrictions/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Diagram/Overview/Angular/index.html
+++ b/JSDemos/Demos/Diagram/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
 

--- a/JSDemos/Demos/Diagram/Overview/React/index.html
+++ b/JSDemos/Demos/Diagram/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/Overview/Vue/index.html
+++ b/JSDemos/Demos/Diagram/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/Overview/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Diagram/ReadOnly/Angular/index.html
+++ b/JSDemos/Demos/Diagram/ReadOnly/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
 

--- a/JSDemos/Demos/Diagram/ReadOnly/React/index.html
+++ b/JSDemos/Demos/Diagram/ReadOnly/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/ReadOnly/Vue/index.html
+++ b/JSDemos/Demos/Diagram/ReadOnly/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/ReadOnly/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/ReadOnly/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Diagram/SimpleView/Angular/index.html
+++ b/JSDemos/Demos/Diagram/SimpleView/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
 

--- a/JSDemos/Demos/Diagram/SimpleView/React/index.html
+++ b/JSDemos/Demos/Diagram/SimpleView/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/SimpleView/Vue/index.html
+++ b/JSDemos/Demos/Diagram/SimpleView/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/SimpleView/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/SimpleView/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Diagram/UICustomization/Angular/index.html
+++ b/JSDemos/Demos/Diagram/UICustomization/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
 

--- a/JSDemos/Demos/Diagram/UICustomization/React/index.html
+++ b/JSDemos/Demos/Diagram/UICustomization/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/UICustomization/Vue/index.html
+++ b/JSDemos/Demos/Diagram/UICustomization/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/UICustomization/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/UICustomization/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Diagram/WebAPIService/Angular/index.html
+++ b/JSDemos/Demos/Diagram/WebAPIService/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
 

--- a/JSDemos/Demos/Diagram/WebAPIService/React/index.html
+++ b/JSDemos/Demos/Diagram/WebAPIService/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/WebAPIService/Vue/index.html
+++ b/JSDemos/Demos/Diagram/WebAPIService/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />

--- a/JSDemos/Demos/Diagram/WebAPIService/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/WebAPIService/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Drawer/LeftOrRightPosition/Angular/index.html
+++ b/JSDemos/Demos/Drawer/LeftOrRightPosition/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/Drawer/LeftOrRightPosition/AngularJS/index.html
+++ b/JSDemos/Demos/Drawer/LeftOrRightPosition/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/angular-sanitize/angular-sanitize.min.js"></script>

--- a/JSDemos/Demos/Drawer/LeftOrRightPosition/React/index.html
+++ b/JSDemos/Demos/Drawer/LeftOrRightPosition/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Drawer/LeftOrRightPosition/Vue/index.html
+++ b/JSDemos/Demos/Drawer/LeftOrRightPosition/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Drawer/LeftOrRightPosition/jQuery/index.html
+++ b/JSDemos/Demos/Drawer/LeftOrRightPosition/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Drawer/TopOrBottomPosition/Angular/index.html
+++ b/JSDemos/Demos/Drawer/TopOrBottomPosition/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/Drawer/TopOrBottomPosition/AngularJS/index.html
+++ b/JSDemos/Demos/Drawer/TopOrBottomPosition/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/angular-sanitize/angular-sanitize.min.js"></script>

--- a/JSDemos/Demos/Drawer/TopOrBottomPosition/React/index.html
+++ b/JSDemos/Demos/Drawer/TopOrBottomPosition/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Drawer/TopOrBottomPosition/Vue/index.html
+++ b/JSDemos/Demos/Drawer/TopOrBottomPosition/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Drawer/TopOrBottomPosition/jQuery/index.html
+++ b/JSDemos/Demos/Drawer/TopOrBottomPosition/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/DropDownBox/MultipleSelection/Angular/index.html
+++ b/JSDemos/Demos/DropDownBox/MultipleSelection/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DropDownBox/MultipleSelection/AngularJS/index.html
+++ b/JSDemos/Demos/DropDownBox/MultipleSelection/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DropDownBox/MultipleSelection/Knockout/index.html
+++ b/JSDemos/Demos/DropDownBox/MultipleSelection/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0"/>
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css"/>
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css"/>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css"/>

--- a/JSDemos/Demos/DropDownBox/MultipleSelection/React/index.html
+++ b/JSDemos/Demos/DropDownBox/MultipleSelection/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DropDownBox/MultipleSelection/Vue/index.html
+++ b/JSDemos/Demos/DropDownBox/MultipleSelection/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DropDownBox/MultipleSelection/jQuery/index.html
+++ b/JSDemos/Demos/DropDownBox/MultipleSelection/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/DropDownBox/SingleSelection/Angular/index.html
+++ b/JSDemos/Demos/DropDownBox/SingleSelection/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DropDownBox/SingleSelection/AngularJS/index.html
+++ b/JSDemos/Demos/DropDownBox/SingleSelection/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/DropDownBox/SingleSelection/Knockout/index.html
+++ b/JSDemos/Demos/DropDownBox/SingleSelection/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0"/>
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css"/>
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css"/>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css"/>

--- a/JSDemos/Demos/DropDownBox/SingleSelection/React/index.html
+++ b/JSDemos/Demos/DropDownBox/SingleSelection/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DropDownBox/SingleSelection/Vue/index.html
+++ b/JSDemos/Demos/DropDownBox/SingleSelection/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DropDownBox/SingleSelection/jQuery/index.html
+++ b/JSDemos/Demos/DropDownBox/SingleSelection/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/DropDownButton/Overview/Angular/index.html
+++ b/JSDemos/Demos/DropDownButton/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DropDownButton/Overview/React/index.html
+++ b/JSDemos/Demos/DropDownButton/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/DropDownButton/Overview/Vue/index.html
+++ b/JSDemos/Demos/DropDownButton/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/DropDownButton/Overview/jQuery/index.html
+++ b/JSDemos/Demos/DropDownButton/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FieldSet/Overview/Angular/index.html
+++ b/JSDemos/Demos/FieldSet/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FieldSet/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/FieldSet/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/FieldSet/Overview/React/index.html
+++ b/JSDemos/Demos/FieldSet/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/FieldSet/Overview/Vue/index.html
+++ b/JSDemos/Demos/FieldSet/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FieldSet/Overview/jQuery/index.html
+++ b/JSDemos/Demos/FieldSet/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FileManager/AzureClientBinding/Angular/index.html
+++ b/JSDemos/Demos/FileManager/AzureClientBinding/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/FileManager/AzureClientBinding/React/index.html
+++ b/JSDemos/Demos/FileManager/AzureClientBinding/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-gantt.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FileManager/AzureClientBinding/Vue/index.html
+++ b/JSDemos/Demos/FileManager/AzureClientBinding/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/FileManager/AzureClientBinding/jQuery/index.html
+++ b/JSDemos/Demos/FileManager/AzureClientBinding/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../azure-file-system.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FileManager/AzureServerBinding/Angular/index.html
+++ b/JSDemos/Demos/FileManager/AzureServerBinding/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/FileManager/AzureServerBinding/React/index.html
+++ b/JSDemos/Demos/FileManager/AzureServerBinding/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FileManager/AzureServerBinding/Vue/index.html
+++ b/JSDemos/Demos/FileManager/AzureServerBinding/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/FileManager/AzureServerBinding/jQuery/index.html
+++ b/JSDemos/Demos/FileManager/AzureServerBinding/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FileManager/BindingToEF/Angular/index.html
+++ b/JSDemos/Demos/FileManager/BindingToEF/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/FileManager/BindingToEF/React/index.html
+++ b/JSDemos/Demos/FileManager/BindingToEF/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
 

--- a/JSDemos/Demos/FileManager/BindingToEF/Vue/index.html
+++ b/JSDemos/Demos/FileManager/BindingToEF/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/FileManager/BindingToEF/jQuery/index.html
+++ b/JSDemos/Demos/FileManager/BindingToEF/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="index.js"></script>

--- a/JSDemos/Demos/FileManager/BindingToFileSystem/Angular/index.html
+++ b/JSDemos/Demos/FileManager/BindingToFileSystem/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/FileManager/BindingToFileSystem/React/index.html
+++ b/JSDemos/Demos/FileManager/BindingToFileSystem/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
 

--- a/JSDemos/Demos/FileManager/BindingToFileSystem/Vue/index.html
+++ b/JSDemos/Demos/FileManager/BindingToFileSystem/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/FileManager/BindingToFileSystem/jQuery/index.html
+++ b/JSDemos/Demos/FileManager/BindingToFileSystem/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FileManager/BindingToHierarchicalStructure/Angular/index.html
+++ b/JSDemos/Demos/FileManager/BindingToHierarchicalStructure/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/FileManager/BindingToHierarchicalStructure/React/index.html
+++ b/JSDemos/Demos/FileManager/BindingToHierarchicalStructure/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
 

--- a/JSDemos/Demos/FileManager/BindingToHierarchicalStructure/Vue/index.html
+++ b/JSDemos/Demos/FileManager/BindingToHierarchicalStructure/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/FileManager/BindingToHierarchicalStructure/jQuery/index.html
+++ b/JSDemos/Demos/FileManager/BindingToHierarchicalStructure/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FileManager/CustomThumbnails/Angular/index.html
+++ b/JSDemos/Demos/FileManager/CustomThumbnails/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/FileManager/CustomThumbnails/React/index.html
+++ b/JSDemos/Demos/FileManager/CustomThumbnails/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
 

--- a/JSDemos/Demos/FileManager/CustomThumbnails/Vue/index.html
+++ b/JSDemos/Demos/FileManager/CustomThumbnails/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/FileManager/CustomThumbnails/jQuery/index.html
+++ b/JSDemos/Demos/FileManager/CustomThumbnails/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FileManager/Overview/Angular/index.html
+++ b/JSDemos/Demos/FileManager/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/FileManager/Overview/React/index.html
+++ b/JSDemos/Demos/FileManager/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FileManager/Overview/Vue/index.html
+++ b/JSDemos/Demos/FileManager/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/FileManager/Overview/jQuery/index.html
+++ b/JSDemos/Demos/FileManager/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FileManager/UICustomization/Angular/index.html
+++ b/JSDemos/Demos/FileManager/UICustomization/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FileManager/UICustomization/React/index.html
+++ b/JSDemos/Demos/FileManager/UICustomization/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FileManager/UICustomization/Vue/index.html
+++ b/JSDemos/Demos/FileManager/UICustomization/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FileManager/UICustomization/jQuery/index.html
+++ b/JSDemos/Demos/FileManager/UICustomization/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FileUploader/AzureDirectUploading/Angular/index.html
+++ b/JSDemos/Demos/FileUploader/AzureDirectUploading/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/FileUploader/AzureDirectUploading/React/index.html
+++ b/JSDemos/Demos/FileUploader/AzureDirectUploading/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FileUploader/AzureDirectUploading/Vue/index.html
+++ b/JSDemos/Demos/FileUploader/AzureDirectUploading/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/FileUploader/AzureDirectUploading/jQuery/index.html
+++ b/JSDemos/Demos/FileUploader/AzureDirectUploading/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../azure-file-system.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FileUploader/ChunkUploading/Angular/index.html
+++ b/JSDemos/Demos/FileUploader/ChunkUploading/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FileUploader/ChunkUploading/AngularJS/index.html
+++ b/JSDemos/Demos/FileUploader/ChunkUploading/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/FileUploader/ChunkUploading/React/index.html
+++ b/JSDemos/Demos/FileUploader/ChunkUploading/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/FileUploader/ChunkUploading/Vue/index.html
+++ b/JSDemos/Demos/FileUploader/ChunkUploading/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FileUploader/ChunkUploading/jQuery/index.html
+++ b/JSDemos/Demos/FileUploader/ChunkUploading/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FileUploader/CustomDropzone/Angular/index.html
+++ b/JSDemos/Demos/FileUploader/CustomDropzone/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FileUploader/CustomDropzone/React/index.html
+++ b/JSDemos/Demos/FileUploader/CustomDropzone/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/FileUploader/CustomDropzone/Vue/index.html
+++ b/JSDemos/Demos/FileUploader/CustomDropzone/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FileUploader/CustomDropzone/jQuery/index.html
+++ b/JSDemos/Demos/FileUploader/CustomDropzone/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FileUploader/FileSelection/Angular/index.html
+++ b/JSDemos/Demos/FileUploader/FileSelection/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FileUploader/FileSelection/AngularJS/index.html
+++ b/JSDemos/Demos/FileUploader/FileSelection/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/FileUploader/FileSelection/Knockout/index.html
+++ b/JSDemos/Demos/FileUploader/FileSelection/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FileUploader/FileSelection/React/index.html
+++ b/JSDemos/Demos/FileUploader/FileSelection/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/FileUploader/FileSelection/Vue/index.html
+++ b/JSDemos/Demos/FileUploader/FileSelection/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FileUploader/FileSelection/jQuery/index.html
+++ b/JSDemos/Demos/FileUploader/FileSelection/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FileUploader/FileUploading/Angular/index.html
+++ b/JSDemos/Demos/FileUploader/FileUploading/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FileUploader/FileUploading/AngularJS/index.html
+++ b/JSDemos/Demos/FileUploader/FileUploading/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/FileUploader/FileUploading/Knockout/index.html
+++ b/JSDemos/Demos/FileUploader/FileUploading/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FileUploader/FileUploading/React/index.html
+++ b/JSDemos/Demos/FileUploader/FileUploading/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/FileUploader/FileUploading/Vue/index.html
+++ b/JSDemos/Demos/FileUploader/FileUploading/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FileUploader/FileUploading/jQuery/index.html
+++ b/JSDemos/Demos/FileUploader/FileUploading/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FileUploader/Validation/Angular/index.html
+++ b/JSDemos/Demos/FileUploader/Validation/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FileUploader/Validation/AngularJS/index.html
+++ b/JSDemos/Demos/FileUploader/Validation/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/FileUploader/Validation/React/index.html
+++ b/JSDemos/Demos/FileUploader/Validation/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/FileUploader/Validation/Vue/index.html
+++ b/JSDemos/Demos/FileUploader/Validation/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FileUploader/Validation/jQuery/index.html
+++ b/JSDemos/Demos/FileUploader/Validation/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/FilterBuilder/Customization/Angular/index.html
+++ b/JSDemos/Demos/FilterBuilder/Customization/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/FilterBuilder/Customization/AngularJS/index.html
+++ b/JSDemos/Demos/FilterBuilder/Customization/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/FilterBuilder/Customization/React/index.html
+++ b/JSDemos/Demos/FilterBuilder/Customization/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/FilterBuilder/Customization/Vue/index.html
+++ b/JSDemos/Demos/FilterBuilder/Customization/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FilterBuilder/Customization/jQuery/index.html
+++ b/JSDemos/Demos/FilterBuilder/Customization/jQuery/index.html
@@ -10,7 +10,6 @@
     <script src="../../../../../node_modules/cldrjs/dist/cldr/event.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/supplemental.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/unresolved.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/FilterBuilder/WithDataGrid/Angular/index.html
+++ b/JSDemos/Demos/FilterBuilder/WithDataGrid/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/FilterBuilder/WithDataGrid/AngularJS/index.html
+++ b/JSDemos/Demos/FilterBuilder/WithDataGrid/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/FilterBuilder/WithDataGrid/Knockout/index.html
+++ b/JSDemos/Demos/FilterBuilder/WithDataGrid/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/FilterBuilder/WithDataGrid/React/index.html
+++ b/JSDemos/Demos/FilterBuilder/WithDataGrid/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/FilterBuilder/WithDataGrid/Vue/index.html
+++ b/JSDemos/Demos/FilterBuilder/WithDataGrid/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FilterBuilder/WithDataGrid/jQuery/index.html
+++ b/JSDemos/Demos/FilterBuilder/WithDataGrid/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/FilterBuilder/WithList/Angular/index.html
+++ b/JSDemos/Demos/FilterBuilder/WithList/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/FilterBuilder/WithList/AngularJS/index.html
+++ b/JSDemos/Demos/FilterBuilder/WithList/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/FilterBuilder/WithList/React/index.html
+++ b/JSDemos/Demos/FilterBuilder/WithList/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/FilterBuilder/WithList/Vue/index.html
+++ b/JSDemos/Demos/FilterBuilder/WithList/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FilterBuilder/WithList/jQuery/index.html
+++ b/JSDemos/Demos/FilterBuilder/WithList/jQuery/index.html
@@ -10,7 +10,6 @@
     <script src="../../../../../node_modules/cldrjs/dist/cldr/event.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/supplemental.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/unresolved.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/FloatingActionButton/Overview/Angular/index.html
+++ b/JSDemos/Demos/FloatingActionButton/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FloatingActionButton/Overview/React/index.html
+++ b/JSDemos/Demos/FloatingActionButton/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/FloatingActionButton/Overview/Vue/index.html
+++ b/JSDemos/Demos/FloatingActionButton/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/FloatingActionButton/Overview/jQuery/index.html
+++ b/JSDemos/Demos/FloatingActionButton/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Form/ColumnsAdaptability/Angular/index.html
+++ b/JSDemos/Demos/Form/ColumnsAdaptability/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Form/ColumnsAdaptability/AngularJS/index.html
+++ b/JSDemos/Demos/Form/ColumnsAdaptability/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Form/ColumnsAdaptability/Knockout/index.html
+++ b/JSDemos/Demos/Form/ColumnsAdaptability/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Form/ColumnsAdaptability/React/index.html
+++ b/JSDemos/Demos/Form/ColumnsAdaptability/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Form/ColumnsAdaptability/Vue/index.html
+++ b/JSDemos/Demos/Form/ColumnsAdaptability/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/Form/ColumnsAdaptability/jQuery/index.html
+++ b/JSDemos/Demos/Form/ColumnsAdaptability/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Form/CustomizeItem/Angular/index.html
+++ b/JSDemos/Demos/Form/CustomizeItem/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Form/CustomizeItem/AngularJS/index.html
+++ b/JSDemos/Demos/Form/CustomizeItem/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Form/CustomizeItem/Knockout/index.html
+++ b/JSDemos/Demos/Form/CustomizeItem/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Form/CustomizeItem/React/index.html
+++ b/JSDemos/Demos/Form/CustomizeItem/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Form/CustomizeItem/Vue/index.html
+++ b/JSDemos/Demos/Form/CustomizeItem/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/Form/CustomizeItem/jQuery/index.html
+++ b/JSDemos/Demos/Form/CustomizeItem/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Form/GroupedFields/Angular/index.html
+++ b/JSDemos/Demos/Form/GroupedFields/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Form/GroupedFields/AngularJS/index.html
+++ b/JSDemos/Demos/Form/GroupedFields/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Form/GroupedFields/Knockout/index.html
+++ b/JSDemos/Demos/Form/GroupedFields/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Form/GroupedFields/React/index.html
+++ b/JSDemos/Demos/Form/GroupedFields/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Form/GroupedFields/Vue/index.html
+++ b/JSDemos/Demos/Form/GroupedFields/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/Form/GroupedFields/jQuery/index.html
+++ b/JSDemos/Demos/Form/GroupedFields/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Form/Overview/Angular/index.html
+++ b/JSDemos/Demos/Form/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Form/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/Form/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Form/Overview/Knockout/index.html
+++ b/JSDemos/Demos/Form/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Form/Overview/React/index.html
+++ b/JSDemos/Demos/Form/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Form/Overview/Vue/index.html
+++ b/JSDemos/Demos/Form/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/Form/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Form/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Form/UpdateItemsDynamically/Angular/index.html
+++ b/JSDemos/Demos/Form/UpdateItemsDynamically/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Form/UpdateItemsDynamically/AngularJS/index.html
+++ b/JSDemos/Demos/Form/UpdateItemsDynamically/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Form/UpdateItemsDynamically/React/index.html
+++ b/JSDemos/Demos/Form/UpdateItemsDynamically/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Form/UpdateItemsDynamically/Vue/index.html
+++ b/JSDemos/Demos/Form/UpdateItemsDynamically/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/Form/UpdateItemsDynamically/jQuery/index.html
+++ b/JSDemos/Demos/Form/UpdateItemsDynamically/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Form/Validation/Angular/index.html
+++ b/JSDemos/Demos/Form/Validation/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Form/Validation/AngularJS/index.html
+++ b/JSDemos/Demos/Form/Validation/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Form/Validation/Knockout/index.html
+++ b/JSDemos/Demos/Form/Validation/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Form/Validation/React/index.html
+++ b/JSDemos/Demos/Form/Validation/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Form/Validation/Vue/index.html
+++ b/JSDemos/Demos/Form/Validation/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/Form/Validation/jQuery/index.html
+++ b/JSDemos/Demos/Form/Validation/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Gallery/Item3RdPartyEngineTemplate/jQuery/index.html
+++ b/JSDemos/Demos/Gallery/Item3RdPartyEngineTemplate/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/underscore/underscore.js"></script>

--- a/JSDemos/Demos/Gallery/ItemTemplate/Angular/index.html
+++ b/JSDemos/Demos/Gallery/ItemTemplate/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gallery/ItemTemplate/AngularJS/index.html
+++ b/JSDemos/Demos/Gallery/ItemTemplate/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gallery/ItemTemplate/Knockout/index.html
+++ b/JSDemos/Demos/Gallery/ItemTemplate/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Gallery/ItemTemplate/React/index.html
+++ b/JSDemos/Demos/Gallery/ItemTemplate/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gallery/ItemTemplate/Vue/index.html
+++ b/JSDemos/Demos/Gallery/ItemTemplate/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gallery/ItemTemplate/jQuery/index.html
+++ b/JSDemos/Demos/Gallery/ItemTemplate/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Gallery/Overview/Angular/index.html
+++ b/JSDemos/Demos/Gallery/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gallery/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/Gallery/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gallery/Overview/Knockout/index.html
+++ b/JSDemos/Demos/Gallery/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Gallery/Overview/React/index.html
+++ b/JSDemos/Demos/Gallery/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gallery/Overview/Vue/index.html
+++ b/JSDemos/Demos/Gallery/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gallery/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Gallery/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Gantt/ChartAppearance/Angular/index.html
+++ b/JSDemos/Demos/Gantt/ChartAppearance/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/ChartAppearance/React/index.html
+++ b/JSDemos/Demos/Gantt/ChartAppearance/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gantt/ChartAppearance/Vue/index.html
+++ b/JSDemos/Demos/Gantt/ChartAppearance/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/ChartAppearance/jQuery/index.html
+++ b/JSDemos/Demos/Gantt/ChartAppearance/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gantt/ContextMenu/Angular/index.html
+++ b/JSDemos/Demos/Gantt/ContextMenu/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/ContextMenu/React/index.html
+++ b/JSDemos/Demos/Gantt/ContextMenu/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gantt/ContextMenu/Vue/index.html
+++ b/JSDemos/Demos/Gantt/ContextMenu/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/ContextMenu/jQuery/index.html
+++ b/JSDemos/Demos/Gantt/ContextMenu/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gantt/DataBinding/Angular/index.html
+++ b/JSDemos/Demos/Gantt/DataBinding/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/DataBinding/React/index.html
+++ b/JSDemos/Demos/Gantt/DataBinding/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gantt/DataBinding/Vue/index.html
+++ b/JSDemos/Demos/Gantt/DataBinding/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/DataBinding/jQuery/index.html
+++ b/JSDemos/Demos/Gantt/DataBinding/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gantt/ExportToPDF/Angular/index.html
+++ b/JSDemos/Demos/Gantt/ExportToPDF/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/ExportToPDF/React/index.html
+++ b/JSDemos/Demos/Gantt/ExportToPDF/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gantt/ExportToPDF/Vue/index.html
+++ b/JSDemos/Demos/Gantt/ExportToPDF/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/ExportToPDF/jQuery/index.html
+++ b/JSDemos/Demos/Gantt/ExportToPDF/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gantt/FilterRow/Angular/index.html
+++ b/JSDemos/Demos/Gantt/FilterRow/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/FilterRow/React/index.html
+++ b/JSDemos/Demos/Gantt/FilterRow/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gantt/FilterRow/Vue/index.html
+++ b/JSDemos/Demos/Gantt/FilterRow/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/FilterRow/jQuery/index.html
+++ b/JSDemos/Demos/Gantt/FilterRow/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gantt/HeaderFilter/Angular/index.html
+++ b/JSDemos/Demos/Gantt/HeaderFilter/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/HeaderFilter/React/index.html
+++ b/JSDemos/Demos/Gantt/HeaderFilter/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gantt/HeaderFilter/Vue/index.html
+++ b/JSDemos/Demos/Gantt/HeaderFilter/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/HeaderFilter/jQuery/index.html
+++ b/JSDemos/Demos/Gantt/HeaderFilter/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gantt/Overview/Angular/index.html
+++ b/JSDemos/Demos/Gantt/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/Overview/React/index.html
+++ b/JSDemos/Demos/Gantt/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gantt/Overview/Vue/index.html
+++ b/JSDemos/Demos/Gantt/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Gantt/Overview/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gantt/Sorting/Angular/index.html
+++ b/JSDemos/Demos/Gantt/Sorting/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/Sorting/React/index.html
+++ b/JSDemos/Demos/Gantt/Sorting/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gantt/Sorting/Vue/index.html
+++ b/JSDemos/Demos/Gantt/Sorting/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/Sorting/jQuery/index.html
+++ b/JSDemos/Demos/Gantt/Sorting/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gantt/StripLines/Angular/index.html
+++ b/JSDemos/Demos/Gantt/StripLines/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/StripLines/React/index.html
+++ b/JSDemos/Demos/Gantt/StripLines/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gantt/StripLines/Vue/index.html
+++ b/JSDemos/Demos/Gantt/StripLines/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/StripLines/jQuery/index.html
+++ b/JSDemos/Demos/Gantt/StripLines/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gantt/TaskTemplate/Angular/index.html
+++ b/JSDemos/Demos/Gantt/TaskTemplate/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/TaskTemplate/React/index.html
+++ b/JSDemos/Demos/Gantt/TaskTemplate/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gantt/TaskTemplate/Vue/index.html
+++ b/JSDemos/Demos/Gantt/TaskTemplate/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/TaskTemplate/jQuery/index.html
+++ b/JSDemos/Demos/Gantt/TaskTemplate/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gantt/Toolbar/Angular/index.html
+++ b/JSDemos/Demos/Gantt/Toolbar/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/Toolbar/React/index.html
+++ b/JSDemos/Demos/Gantt/Toolbar/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gantt/Toolbar/Vue/index.html
+++ b/JSDemos/Demos/Gantt/Toolbar/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/Toolbar/jQuery/index.html
+++ b/JSDemos/Demos/Gantt/Toolbar/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gantt/Validation/Angular/index.html
+++ b/JSDemos/Demos/Gantt/Validation/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/Validation/React/index.html
+++ b/JSDemos/Demos/Gantt/Validation/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gantt/Validation/Vue/index.html
+++ b/JSDemos/Demos/Gantt/Validation/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.css" />
 

--- a/JSDemos/Demos/Gantt/Validation/jQuery/index.html
+++ b/JSDemos/Demos/Gantt/Validation/jQuery/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" href="../../../../../node_modules/devexpress-gantt/dist/dx-gantt.min.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/AnglesCustomization/Angular/index.html
+++ b/JSDemos/Demos/Gauges/AnglesCustomization/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/AnglesCustomization/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/AnglesCustomization/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/AnglesCustomization/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/AnglesCustomization/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/AnglesCustomization/React/index.html
+++ b/JSDemos/Demos/Gauges/AnglesCustomization/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/AnglesCustomization/Vue/index.html
+++ b/JSDemos/Demos/Gauges/AnglesCustomization/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/AnglesCustomization/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/AnglesCustomization/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/BaseValueForRangeBar/Angular/index.html
+++ b/JSDemos/Demos/Gauges/BaseValueForRangeBar/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/BaseValueForRangeBar/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/BaseValueForRangeBar/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/BaseValueForRangeBar/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/BaseValueForRangeBar/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/BaseValueForRangeBar/React/index.html
+++ b/JSDemos/Demos/Gauges/BaseValueForRangeBar/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/BaseValueForRangeBar/Vue/index.html
+++ b/JSDemos/Demos/Gauges/BaseValueForRangeBar/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/BaseValueForRangeBar/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/BaseValueForRangeBar/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/CustomLayout/Angular/index.html
+++ b/JSDemos/Demos/Gauges/CustomLayout/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/CustomLayout/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/CustomLayout/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/CustomLayout/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/CustomLayout/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/CustomLayout/React/index.html
+++ b/JSDemos/Demos/Gauges/CustomLayout/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/CustomLayout/Vue/index.html
+++ b/JSDemos/Demos/Gauges/CustomLayout/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/CustomLayout/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/CustomLayout/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/CustomLayoutLinearGauge/Angular/index.html
+++ b/JSDemos/Demos/Gauges/CustomLayoutLinearGauge/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/CustomLayoutLinearGauge/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/CustomLayoutLinearGauge/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/CustomLayoutLinearGauge/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/CustomLayoutLinearGauge/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/CustomLayoutLinearGauge/React/index.html
+++ b/JSDemos/Demos/Gauges/CustomLayoutLinearGauge/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/CustomLayoutLinearGauge/Vue/index.html
+++ b/JSDemos/Demos/Gauges/CustomLayoutLinearGauge/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/CustomLayoutLinearGauge/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/CustomLayoutLinearGauge/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypes/Angular/index.html
+++ b/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypes/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypes/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypes/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypes/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypes/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypes/React/index.html
+++ b/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypes/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypes/Vue/index.html
+++ b/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypes/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypes/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypes/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypesLinearGauge/Angular/index.html
+++ b/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypesLinearGauge/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypesLinearGauge/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypesLinearGauge/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypesLinearGauge/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypesLinearGauge/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypesLinearGauge/React/index.html
+++ b/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypesLinearGauge/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypesLinearGauge/Vue/index.html
+++ b/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypesLinearGauge/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypesLinearGauge/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/DifferentSubvalueIndicatorTypesLinearGauge/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/DifferentValueIndicatorTypes/Angular/index.html
+++ b/JSDemos/Demos/Gauges/DifferentValueIndicatorTypes/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/DifferentValueIndicatorTypes/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/DifferentValueIndicatorTypes/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/DifferentValueIndicatorTypes/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/DifferentValueIndicatorTypes/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/DifferentValueIndicatorTypes/React/index.html
+++ b/JSDemos/Demos/Gauges/DifferentValueIndicatorTypes/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/DifferentValueIndicatorTypes/Vue/index.html
+++ b/JSDemos/Demos/Gauges/DifferentValueIndicatorTypes/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/DifferentValueIndicatorTypes/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/DifferentValueIndicatorTypes/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/DifferentValueIndicatorTypesLinearGauge/Angular/index.html
+++ b/JSDemos/Demos/Gauges/DifferentValueIndicatorTypesLinearGauge/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/DifferentValueIndicatorTypesLinearGauge/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/DifferentValueIndicatorTypesLinearGauge/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/DifferentValueIndicatorTypesLinearGauge/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/DifferentValueIndicatorTypesLinearGauge/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/DifferentValueIndicatorTypesLinearGauge/React/index.html
+++ b/JSDemos/Demos/Gauges/DifferentValueIndicatorTypesLinearGauge/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/DifferentValueIndicatorTypesLinearGauge/Vue/index.html
+++ b/JSDemos/Demos/Gauges/DifferentValueIndicatorTypesLinearGauge/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/DifferentValueIndicatorTypesLinearGauge/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/DifferentValueIndicatorTypesLinearGauge/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/GaugeTitleCustomized/Angular/index.html
+++ b/JSDemos/Demos/Gauges/GaugeTitleCustomized/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/GaugeTitleCustomized/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/GaugeTitleCustomized/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/GaugeTitleCustomized/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/GaugeTitleCustomized/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/GaugeTitleCustomized/React/index.html
+++ b/JSDemos/Demos/Gauges/GaugeTitleCustomized/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/GaugeTitleCustomized/Vue/index.html
+++ b/JSDemos/Demos/Gauges/GaugeTitleCustomized/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/GaugeTitleCustomized/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/GaugeTitleCustomized/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/GaugeTooltip/Angular/index.html
+++ b/JSDemos/Demos/Gauges/GaugeTooltip/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/GaugeTooltip/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/GaugeTooltip/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/GaugeTooltip/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/GaugeTooltip/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/GaugeTooltip/React/index.html
+++ b/JSDemos/Demos/Gauges/GaugeTooltip/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/GaugeTooltip/Vue/index.html
+++ b/JSDemos/Demos/Gauges/GaugeTooltip/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/GaugeTooltip/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/GaugeTooltip/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/LabelsCustomization/Angular/index.html
+++ b/JSDemos/Demos/Gauges/LabelsCustomization/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/LabelsCustomization/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/LabelsCustomization/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/LabelsCustomization/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/LabelsCustomization/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/LabelsCustomization/React/index.html
+++ b/JSDemos/Demos/Gauges/LabelsCustomization/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/LabelsCustomization/Vue/index.html
+++ b/JSDemos/Demos/Gauges/LabelsCustomization/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/LabelsCustomization/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/LabelsCustomization/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/Overview/Angular/index.html
+++ b/JSDemos/Demos/Gauges/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/Overview/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/Overview/React/index.html
+++ b/JSDemos/Demos/Gauges/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/Overview/Vue/index.html
+++ b/JSDemos/Demos/Gauges/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/Palette/Angular/index.html
+++ b/JSDemos/Demos/Gauges/Palette/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/Palette/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/Palette/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/Palette/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/Palette/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/Palette/React/index.html
+++ b/JSDemos/Demos/Gauges/Palette/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/Palette/Vue/index.html
+++ b/JSDemos/Demos/Gauges/Palette/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/Palette/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/Palette/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/PaletteForRanges/Angular/index.html
+++ b/JSDemos/Demos/Gauges/PaletteForRanges/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/PaletteForRanges/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/PaletteForRanges/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/PaletteForRanges/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/PaletteForRanges/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/PaletteForRanges/React/index.html
+++ b/JSDemos/Demos/Gauges/PaletteForRanges/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/PaletteForRanges/Vue/index.html
+++ b/JSDemos/Demos/Gauges/PaletteForRanges/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/PaletteForRanges/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/PaletteForRanges/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/ScaleCustomTickInterval/Angular/index.html
+++ b/JSDemos/Demos/Gauges/ScaleCustomTickInterval/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/ScaleCustomTickInterval/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/ScaleCustomTickInterval/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/ScaleCustomTickInterval/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/ScaleCustomTickInterval/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/ScaleCustomTickInterval/React/index.html
+++ b/JSDemos/Demos/Gauges/ScaleCustomTickInterval/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/ScaleCustomTickInterval/Vue/index.html
+++ b/JSDemos/Demos/Gauges/ScaleCustomTickInterval/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/ScaleCustomTickInterval/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/ScaleCustomTickInterval/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/ScaleCustomTickValues/Angular/index.html
+++ b/JSDemos/Demos/Gauges/ScaleCustomTickValues/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/ScaleCustomTickValues/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/ScaleCustomTickValues/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/ScaleCustomTickValues/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/ScaleCustomTickValues/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/ScaleCustomTickValues/React/index.html
+++ b/JSDemos/Demos/Gauges/ScaleCustomTickValues/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/ScaleCustomTickValues/Vue/index.html
+++ b/JSDemos/Demos/Gauges/ScaleCustomTickValues/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/ScaleCustomTickValues/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/ScaleCustomTickValues/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/ScaleLabelFormatting/Angular/index.html
+++ b/JSDemos/Demos/Gauges/ScaleLabelFormatting/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/ScaleLabelFormatting/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/ScaleLabelFormatting/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/ScaleLabelFormatting/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/ScaleLabelFormatting/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/ScaleLabelFormatting/React/index.html
+++ b/JSDemos/Demos/Gauges/ScaleLabelFormatting/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/ScaleLabelFormatting/Vue/index.html
+++ b/JSDemos/Demos/Gauges/ScaleLabelFormatting/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/ScaleLabelFormatting/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/ScaleLabelFormatting/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/ScaleMinorTicks/Angular/index.html
+++ b/JSDemos/Demos/Gauges/ScaleMinorTicks/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/ScaleMinorTicks/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/ScaleMinorTicks/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/ScaleMinorTicks/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/ScaleMinorTicks/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/ScaleMinorTicks/React/index.html
+++ b/JSDemos/Demos/Gauges/ScaleMinorTicks/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/ScaleMinorTicks/Vue/index.html
+++ b/JSDemos/Demos/Gauges/ScaleMinorTicks/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/ScaleMinorTicks/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/ScaleMinorTicks/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/SubvalueIndicatorTextFormatting/Angular/index.html
+++ b/JSDemos/Demos/Gauges/SubvalueIndicatorTextFormatting/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/SubvalueIndicatorTextFormatting/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/SubvalueIndicatorTextFormatting/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/SubvalueIndicatorTextFormatting/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/SubvalueIndicatorTextFormatting/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/SubvalueIndicatorTextFormatting/React/index.html
+++ b/JSDemos/Demos/Gauges/SubvalueIndicatorTextFormatting/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/SubvalueIndicatorTextFormatting/Vue/index.html
+++ b/JSDemos/Demos/Gauges/SubvalueIndicatorTextFormatting/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/SubvalueIndicatorTextFormatting/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/SubvalueIndicatorTextFormatting/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/Tooltip/Angular/index.html
+++ b/JSDemos/Demos/Gauges/Tooltip/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/Tooltip/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/Tooltip/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/Tooltip/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/Tooltip/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/Tooltip/React/index.html
+++ b/JSDemos/Demos/Gauges/Tooltip/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/Tooltip/Vue/index.html
+++ b/JSDemos/Demos/Gauges/Tooltip/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/Tooltip/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/Tooltip/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/UpdateBarGaugeDataAtRuntime/Angular/index.html
+++ b/JSDemos/Demos/Gauges/UpdateBarGaugeDataAtRuntime/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/UpdateBarGaugeDataAtRuntime/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/UpdateBarGaugeDataAtRuntime/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/UpdateBarGaugeDataAtRuntime/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/UpdateBarGaugeDataAtRuntime/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Gauges/UpdateBarGaugeDataAtRuntime/React/index.html
+++ b/JSDemos/Demos/Gauges/UpdateBarGaugeDataAtRuntime/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/UpdateBarGaugeDataAtRuntime/Vue/index.html
+++ b/JSDemos/Demos/Gauges/UpdateBarGaugeDataAtRuntime/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/UpdateBarGaugeDataAtRuntime/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/UpdateBarGaugeDataAtRuntime/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Gauges/UpdateCircularGaugeDataAtRuntime/Angular/index.html
+++ b/JSDemos/Demos/Gauges/UpdateCircularGaugeDataAtRuntime/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/UpdateCircularGaugeDataAtRuntime/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/UpdateCircularGaugeDataAtRuntime/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/UpdateCircularGaugeDataAtRuntime/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/UpdateCircularGaugeDataAtRuntime/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Gauges/UpdateCircularGaugeDataAtRuntime/React/index.html
+++ b/JSDemos/Demos/Gauges/UpdateCircularGaugeDataAtRuntime/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/UpdateCircularGaugeDataAtRuntime/Vue/index.html
+++ b/JSDemos/Demos/Gauges/UpdateCircularGaugeDataAtRuntime/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/UpdateCircularGaugeDataAtRuntime/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/UpdateCircularGaugeDataAtRuntime/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Gauges/UpdateLinearGaugeDataAtRuntime/Angular/index.html
+++ b/JSDemos/Demos/Gauges/UpdateLinearGaugeDataAtRuntime/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/UpdateLinearGaugeDataAtRuntime/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/UpdateLinearGaugeDataAtRuntime/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/UpdateLinearGaugeDataAtRuntime/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/UpdateLinearGaugeDataAtRuntime/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Gauges/UpdateLinearGaugeDataAtRuntime/React/index.html
+++ b/JSDemos/Demos/Gauges/UpdateLinearGaugeDataAtRuntime/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/UpdateLinearGaugeDataAtRuntime/Vue/index.html
+++ b/JSDemos/Demos/Gauges/UpdateLinearGaugeDataAtRuntime/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/UpdateLinearGaugeDataAtRuntime/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/UpdateLinearGaugeDataAtRuntime/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Gauges/ValueIndicatorsAPI/Angular/index.html
+++ b/JSDemos/Demos/Gauges/ValueIndicatorsAPI/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/ValueIndicatorsAPI/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/ValueIndicatorsAPI/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/ValueIndicatorsAPI/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/ValueIndicatorsAPI/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/ValueIndicatorsAPI/React/index.html
+++ b/JSDemos/Demos/Gauges/ValueIndicatorsAPI/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/ValueIndicatorsAPI/Vue/index.html
+++ b/JSDemos/Demos/Gauges/ValueIndicatorsAPI/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/ValueIndicatorsAPI/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/ValueIndicatorsAPI/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Gauges/VariableNumberOfBars/Angular/index.html
+++ b/JSDemos/Demos/Gauges/VariableNumberOfBars/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/VariableNumberOfBars/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/VariableNumberOfBars/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/VariableNumberOfBars/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/VariableNumberOfBars/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Gauges/VariableNumberOfBars/React/index.html
+++ b/JSDemos/Demos/Gauges/VariableNumberOfBars/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/VariableNumberOfBars/Vue/index.html
+++ b/JSDemos/Demos/Gauges/VariableNumberOfBars/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/VariableNumberOfBars/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/VariableNumberOfBars/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Gauges/VariableNumberOfSubvalueIndicators/Angular/index.html
+++ b/JSDemos/Demos/Gauges/VariableNumberOfSubvalueIndicators/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/VariableNumberOfSubvalueIndicators/AngularJS/index.html
+++ b/JSDemos/Demos/Gauges/VariableNumberOfSubvalueIndicators/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Gauges/VariableNumberOfSubvalueIndicators/Knockout/index.html
+++ b/JSDemos/Demos/Gauges/VariableNumberOfSubvalueIndicators/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Gauges/VariableNumberOfSubvalueIndicators/React/index.html
+++ b/JSDemos/Demos/Gauges/VariableNumberOfSubvalueIndicators/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Gauges/VariableNumberOfSubvalueIndicators/Vue/index.html
+++ b/JSDemos/Demos/Gauges/VariableNumberOfSubvalueIndicators/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Gauges/VariableNumberOfSubvalueIndicators/jQuery/index.html
+++ b/JSDemos/Demos/Gauges/VariableNumberOfSubvalueIndicators/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/HtmlEditor/Mentions/Angular/index.html
+++ b/JSDemos/Demos/HtmlEditor/Mentions/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/HtmlEditor/Mentions/AngularJS/index.html
+++ b/JSDemos/Demos/HtmlEditor/Mentions/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme-quill/dist/dx-quill.min.js"></script>

--- a/JSDemos/Demos/HtmlEditor/Mentions/React/index.html
+++ b/JSDemos/Demos/HtmlEditor/Mentions/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/HtmlEditor/Mentions/Vue/index.html
+++ b/JSDemos/Demos/HtmlEditor/Mentions/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/HtmlEditor/Mentions/jQuery/index.html
+++ b/JSDemos/Demos/HtmlEditor/Mentions/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-quill/dist/dx-quill.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/HtmlEditor/OutputFormats/Angular/index.html
+++ b/JSDemos/Demos/HtmlEditor/OutputFormats/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/HtmlEditor/OutputFormats/AngularJS/index.html
+++ b/JSDemos/Demos/HtmlEditor/OutputFormats/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme-quill/dist/dx-quill.min.js"></script>

--- a/JSDemos/Demos/HtmlEditor/OutputFormats/Knockout/index.html
+++ b/JSDemos/Demos/HtmlEditor/OutputFormats/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-quill/dist/dx-quill.min.js"></script>
     <script src="../../../../../node_modules/turndown/dist/turndown.js"></script>

--- a/JSDemos/Demos/HtmlEditor/OutputFormats/React/index.html
+++ b/JSDemos/Demos/HtmlEditor/OutputFormats/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/HtmlEditor/OutputFormats/Vue/index.html
+++ b/JSDemos/Demos/HtmlEditor/OutputFormats/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/HtmlEditor/OutputFormats/jQuery/index.html
+++ b/JSDemos/Demos/HtmlEditor/OutputFormats/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-quill/dist/dx-quill.min.js"></script>
     <script src="../../../../../node_modules/turndown/dist/turndown.js"></script>

--- a/JSDemos/Demos/HtmlEditor/Overview/Angular/index.html
+++ b/JSDemos/Demos/HtmlEditor/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/HtmlEditor/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/HtmlEditor/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme-quill/dist/dx-quill.min.js"></script>

--- a/JSDemos/Demos/HtmlEditor/Overview/Knockout/index.html
+++ b/JSDemos/Demos/HtmlEditor/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-quill/dist/dx-quill.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/HtmlEditor/Overview/React/index.html
+++ b/JSDemos/Demos/HtmlEditor/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/HtmlEditor/Overview/Vue/index.html
+++ b/JSDemos/Demos/HtmlEditor/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/HtmlEditor/Overview/jQuery/index.html
+++ b/JSDemos/Demos/HtmlEditor/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-quill/dist/dx-quill.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/HtmlEditor/Tables/Angular/index.html
+++ b/JSDemos/Demos/HtmlEditor/Tables/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/HtmlEditor/Tables/AngularJS/index.html
+++ b/JSDemos/Demos/HtmlEditor/Tables/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme-quill/dist/dx-quill.min.js"></script>

--- a/JSDemos/Demos/HtmlEditor/Tables/React/index.html
+++ b/JSDemos/Demos/HtmlEditor/Tables/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/HtmlEditor/Tables/Vue/index.html
+++ b/JSDemos/Demos/HtmlEditor/Tables/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/HtmlEditor/Tables/jQuery/index.html
+++ b/JSDemos/Demos/HtmlEditor/Tables/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-quill/dist/dx-quill.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/HtmlEditor/ToolbarCustomization/Angular/index.html
+++ b/JSDemos/Demos/HtmlEditor/ToolbarCustomization/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/HtmlEditor/ToolbarCustomization/AngularJS/index.html
+++ b/JSDemos/Demos/HtmlEditor/ToolbarCustomization/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme-quill/dist/dx-quill.min.js"></script>

--- a/JSDemos/Demos/HtmlEditor/ToolbarCustomization/Knockout/index.html
+++ b/JSDemos/Demos/HtmlEditor/ToolbarCustomization/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-quill/dist/dx-quill.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/HtmlEditor/ToolbarCustomization/React/index.html
+++ b/JSDemos/Demos/HtmlEditor/ToolbarCustomization/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/HtmlEditor/ToolbarCustomization/Vue/index.html
+++ b/JSDemos/Demos/HtmlEditor/ToolbarCustomization/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/HtmlEditor/ToolbarCustomization/jQuery/index.html
+++ b/JSDemos/Demos/HtmlEditor/ToolbarCustomization/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-quill/dist/dx-quill.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/List/GroupedList/Angular/index.html
+++ b/JSDemos/Demos/List/GroupedList/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/List/GroupedList/AngularJS/index.html
+++ b/JSDemos/Demos/List/GroupedList/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/List/GroupedList/Knockout/index.html
+++ b/JSDemos/Demos/List/GroupedList/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/List/GroupedList/React/index.html
+++ b/JSDemos/Demos/List/GroupedList/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/List/GroupedList/Vue/index.html
+++ b/JSDemos/Demos/List/GroupedList/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/List/GroupedList/jQuery/index.html
+++ b/JSDemos/Demos/List/GroupedList/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/List/Item3RdPartyEngineTemplate/jQuery/index.html
+++ b/JSDemos/Demos/List/Item3RdPartyEngineTemplate/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/underscore/underscore.js"></script>

--- a/JSDemos/Demos/List/ItemDragging/Angular/index.html
+++ b/JSDemos/Demos/List/ItemDragging/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/List/ItemDragging/React/index.html
+++ b/JSDemos/Demos/List/ItemDragging/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/List/ItemDragging/Vue/index.html
+++ b/JSDemos/Demos/List/ItemDragging/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/List/ItemDragging/jQuery/index.html
+++ b/JSDemos/Demos/List/ItemDragging/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/List/ItemTemplate/Angular/index.html
+++ b/JSDemos/Demos/List/ItemTemplate/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/List/ItemTemplate/AngularJS/index.html
+++ b/JSDemos/Demos/List/ItemTemplate/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/List/ItemTemplate/Knockout/index.html
+++ b/JSDemos/Demos/List/ItemTemplate/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/List/ItemTemplate/React/index.html
+++ b/JSDemos/Demos/List/ItemTemplate/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/List/ItemTemplate/Vue/index.html
+++ b/JSDemos/Demos/List/ItemTemplate/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/List/ItemTemplate/jQuery/index.html
+++ b/JSDemos/Demos/List/ItemTemplate/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/List/ListEditingAndAPI/Angular/index.html
+++ b/JSDemos/Demos/List/ListEditingAndAPI/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/List/ListEditingAndAPI/AngularJS/index.html
+++ b/JSDemos/Demos/List/ListEditingAndAPI/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/List/ListEditingAndAPI/Knockout/index.html
+++ b/JSDemos/Demos/List/ListEditingAndAPI/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/List/ListEditingAndAPI/React/index.html
+++ b/JSDemos/Demos/List/ListEditingAndAPI/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/List/ListEditingAndAPI/Vue/index.html
+++ b/JSDemos/Demos/List/ListEditingAndAPI/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/List/ListEditingAndAPI/jQuery/index.html
+++ b/JSDemos/Demos/List/ListEditingAndAPI/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/List/ListSelection/Angular/index.html
+++ b/JSDemos/Demos/List/ListSelection/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/List/ListSelection/AngularJS/index.html
+++ b/JSDemos/Demos/List/ListSelection/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/List/ListSelection/Knockout/index.html
+++ b/JSDemos/Demos/List/ListSelection/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/List/ListSelection/React/index.html
+++ b/JSDemos/Demos/List/ListSelection/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/List/ListSelection/Vue/index.html
+++ b/JSDemos/Demos/List/ListSelection/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/List/ListSelection/jQuery/index.html
+++ b/JSDemos/Demos/List/ListSelection/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/List/ListWithSearchBar/Angular/index.html
+++ b/JSDemos/Demos/List/ListWithSearchBar/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/List/ListWithSearchBar/AngularJS/index.html
+++ b/JSDemos/Demos/List/ListWithSearchBar/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/List/ListWithSearchBar/Knockout/index.html
+++ b/JSDemos/Demos/List/ListWithSearchBar/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/List/ListWithSearchBar/React/index.html
+++ b/JSDemos/Demos/List/ListWithSearchBar/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/List/ListWithSearchBar/Vue/index.html
+++ b/JSDemos/Demos/List/ListWithSearchBar/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/List/ListWithSearchBar/jQuery/index.html
+++ b/JSDemos/Demos/List/ListWithSearchBar/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/List/WebAPI/Angular/index.html
+++ b/JSDemos/Demos/List/WebAPI/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/List/WebAPI/React/index.html
+++ b/JSDemos/Demos/List/WebAPI/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/List/WebAPI/Vue/index.html
+++ b/JSDemos/Demos/List/WebAPI/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/List/WebAPI/jQuery/index.html
+++ b/JSDemos/Demos/List/WebAPI/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>

--- a/JSDemos/Demos/LoadIndicator/Overview/Angular/index.html
+++ b/JSDemos/Demos/LoadIndicator/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/LoadIndicator/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/LoadIndicator/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/LoadIndicator/Overview/Knockout/index.html
+++ b/JSDemos/Demos/LoadIndicator/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/LoadIndicator/Overview/React/index.html
+++ b/JSDemos/Demos/LoadIndicator/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/LoadIndicator/Overview/Vue/index.html
+++ b/JSDemos/Demos/LoadIndicator/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/LoadIndicator/Overview/jQuery/index.html
+++ b/JSDemos/Demos/LoadIndicator/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/LoadPanel/Overview/Angular/index.html
+++ b/JSDemos/Demos/LoadPanel/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/LoadPanel/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/LoadPanel/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/LoadPanel/Overview/Knockout/index.html
+++ b/JSDemos/Demos/LoadPanel/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/LoadPanel/Overview/React/index.html
+++ b/JSDemos/Demos/LoadPanel/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/LoadPanel/Overview/Vue/index.html
+++ b/JSDemos/Demos/LoadPanel/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/LoadPanel/Overview/jQuery/index.html
+++ b/JSDemos/Demos/LoadPanel/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Localization/UsingGlobalize/Angular/index.html
+++ b/JSDemos/Demos/Localization/UsingGlobalize/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Localization/UsingGlobalize/AngularJS/index.html
+++ b/JSDemos/Demos/Localization/UsingGlobalize/AngularJS/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
 

--- a/JSDemos/Demos/Localization/UsingGlobalize/Knockout/index.html
+++ b/JSDemos/Demos/Localization/UsingGlobalize/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/cldrjs/dist/cldr.js"></script>

--- a/JSDemos/Demos/Localization/UsingGlobalize/React/index.html
+++ b/JSDemos/Demos/Localization/UsingGlobalize/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Localization/UsingGlobalize/Vue/index.html
+++ b/JSDemos/Demos/Localization/UsingGlobalize/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Localization/UsingGlobalize/jQuery/index.html
+++ b/JSDemos/Demos/Localization/UsingGlobalize/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/cldrjs/dist/cldr.js"></script>

--- a/JSDemos/Demos/Localization/UsingIntl/Angular/index.html
+++ b/JSDemos/Demos/Localization/UsingIntl/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Localization/UsingIntl/AngularJS/index.html
+++ b/JSDemos/Demos/Localization/UsingIntl/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
 

--- a/JSDemos/Demos/Localization/UsingIntl/Knockout/index.html
+++ b/JSDemos/Demos/Localization/UsingIntl/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Localization/UsingIntl/React/index.html
+++ b/JSDemos/Demos/Localization/UsingIntl/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Localization/UsingIntl/Vue/index.html
+++ b/JSDemos/Demos/Localization/UsingIntl/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Localization/UsingIntl/jQuery/index.html
+++ b/JSDemos/Demos/Localization/UsingIntl/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Lookup/Basics/Angular/index.html
+++ b/JSDemos/Demos/Lookup/Basics/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Lookup/Basics/AngularJS/index.html
+++ b/JSDemos/Demos/Lookup/Basics/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Lookup/Basics/Knockout/index.html
+++ b/JSDemos/Demos/Lookup/Basics/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Lookup/Basics/React/index.html
+++ b/JSDemos/Demos/Lookup/Basics/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Lookup/Basics/Vue/index.html
+++ b/JSDemos/Demos/Lookup/Basics/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Lookup/Basics/jQuery/index.html
+++ b/JSDemos/Demos/Lookup/Basics/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Lookup/EventHandling/Angular/index.html
+++ b/JSDemos/Demos/Lookup/EventHandling/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Lookup/EventHandling/AngularJS/index.html
+++ b/JSDemos/Demos/Lookup/EventHandling/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Lookup/EventHandling/Knockout/index.html
+++ b/JSDemos/Demos/Lookup/EventHandling/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Lookup/EventHandling/React/index.html
+++ b/JSDemos/Demos/Lookup/EventHandling/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Lookup/EventHandling/Vue/index.html
+++ b/JSDemos/Demos/Lookup/EventHandling/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Lookup/EventHandling/jQuery/index.html
+++ b/JSDemos/Demos/Lookup/EventHandling/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Lookup/Templates/Angular/index.html
+++ b/JSDemos/Demos/Lookup/Templates/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Lookup/Templates/AngularJS/index.html
+++ b/JSDemos/Demos/Lookup/Templates/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Lookup/Templates/Knockout/index.html
+++ b/JSDemos/Demos/Lookup/Templates/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Lookup/Templates/React/index.html
+++ b/JSDemos/Demos/Lookup/Templates/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Lookup/Templates/Vue/index.html
+++ b/JSDemos/Demos/Lookup/Templates/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/Lookup/Templates/jQuery/index.html
+++ b/JSDemos/Demos/Lookup/Templates/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Map/Markers/Angular/index.html
+++ b/JSDemos/Demos/Map/Markers/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Map/Markers/AngularJS/index.html
+++ b/JSDemos/Demos/Map/Markers/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Map/Markers/Knockout/index.html
+++ b/JSDemos/Demos/Map/Markers/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Map/Markers/React/index.html
+++ b/JSDemos/Demos/Map/Markers/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Map/Markers/Vue/index.html
+++ b/JSDemos/Demos/Map/Markers/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Map/Markers/jQuery/index.html
+++ b/JSDemos/Demos/Map/Markers/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Map/ProvidersAndTypes/Angular/index.html
+++ b/JSDemos/Demos/Map/ProvidersAndTypes/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Map/ProvidersAndTypes/AngularJS/index.html
+++ b/JSDemos/Demos/Map/ProvidersAndTypes/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Map/ProvidersAndTypes/Knockout/index.html
+++ b/JSDemos/Demos/Map/ProvidersAndTypes/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Map/ProvidersAndTypes/React/index.html
+++ b/JSDemos/Demos/Map/ProvidersAndTypes/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Map/ProvidersAndTypes/Vue/index.html
+++ b/JSDemos/Demos/Map/ProvidersAndTypes/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Map/ProvidersAndTypes/jQuery/index.html
+++ b/JSDemos/Demos/Map/ProvidersAndTypes/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Map/Routes/Angular/index.html
+++ b/JSDemos/Demos/Map/Routes/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Map/Routes/AngularJS/index.html
+++ b/JSDemos/Demos/Map/Routes/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Map/Routes/Knockout/index.html
+++ b/JSDemos/Demos/Map/Routes/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Map/Routes/React/index.html
+++ b/JSDemos/Demos/Map/Routes/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Map/Routes/Vue/index.html
+++ b/JSDemos/Demos/Map/Routes/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Map/Routes/jQuery/index.html
+++ b/JSDemos/Demos/Map/Routes/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Menu/Overview/Angular/index.html
+++ b/JSDemos/Demos/Menu/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Menu/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/Menu/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Menu/Overview/Knockout/index.html
+++ b/JSDemos/Demos/Menu/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Menu/Overview/React/index.html
+++ b/JSDemos/Demos/Menu/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Menu/Overview/Vue/index.html
+++ b/JSDemos/Demos/Menu/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Menu/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Menu/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/MultiView/Overview/Angular/index.html
+++ b/JSDemos/Demos/MultiView/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/MultiView/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/MultiView/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/MultiView/Overview/Knockout/index.html
+++ b/JSDemos/Demos/MultiView/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/MultiView/Overview/React/index.html
+++ b/JSDemos/Demos/MultiView/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/MultiView/Overview/Vue/index.html
+++ b/JSDemos/Demos/MultiView/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/MultiView/Overview/jQuery/index.html
+++ b/JSDemos/Demos/MultiView/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/underscore/underscore.js"></script>

--- a/JSDemos/Demos/NumberBox/Formatting/Angular/index.html
+++ b/JSDemos/Demos/NumberBox/Formatting/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/NumberBox/Formatting/AngularJS/index.html
+++ b/JSDemos/Demos/NumberBox/Formatting/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/NumberBox/Formatting/Knockout/index.html
+++ b/JSDemos/Demos/NumberBox/Formatting/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/NumberBox/Formatting/React/index.html
+++ b/JSDemos/Demos/NumberBox/Formatting/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/NumberBox/Formatting/Vue/index.html
+++ b/JSDemos/Demos/NumberBox/Formatting/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/NumberBox/Formatting/jQuery/index.html
+++ b/JSDemos/Demos/NumberBox/Formatting/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/NumberBox/Overview/Angular/index.html
+++ b/JSDemos/Demos/NumberBox/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/NumberBox/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/NumberBox/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/NumberBox/Overview/Knockout/index.html
+++ b/JSDemos/Demos/NumberBox/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="index.js"></script>

--- a/JSDemos/Demos/NumberBox/Overview/React/index.html
+++ b/JSDemos/Demos/NumberBox/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/NumberBox/Overview/Vue/index.html
+++ b/JSDemos/Demos/NumberBox/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/NumberBox/Overview/jQuery/index.html
+++ b/JSDemos/Demos/NumberBox/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="index.js"></script>

--- a/JSDemos/Demos/PivotGrid/ChartIntegration/Angular/index.html
+++ b/JSDemos/Demos/PivotGrid/ChartIntegration/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/ChartIntegration/AngularJS/index.html
+++ b/JSDemos/Demos/PivotGrid/ChartIntegration/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/PivotGrid/ChartIntegration/Knockout/index.html
+++ b/JSDemos/Demos/PivotGrid/ChartIntegration/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/ChartIntegration/React/index.html
+++ b/JSDemos/Demos/PivotGrid/ChartIntegration/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/PivotGrid/ChartIntegration/Vue/index.html
+++ b/JSDemos/Demos/PivotGrid/ChartIntegration/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/ChartIntegration/jQuery/index.html
+++ b/JSDemos/Demos/PivotGrid/ChartIntegration/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/DrillDown/Angular/index.html
+++ b/JSDemos/Demos/PivotGrid/DrillDown/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/DrillDown/AngularJS/index.html
+++ b/JSDemos/Demos/PivotGrid/DrillDown/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/PivotGrid/DrillDown/Knockout/index.html
+++ b/JSDemos/Demos/PivotGrid/DrillDown/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/DrillDown/React/index.html
+++ b/JSDemos/Demos/PivotGrid/DrillDown/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/PivotGrid/DrillDown/Vue/index.html
+++ b/JSDemos/Demos/PivotGrid/DrillDown/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/DrillDown/jQuery/index.html
+++ b/JSDemos/Demos/PivotGrid/DrillDown/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/ExcelJSCellCustomization/Angular/index.html
+++ b/JSDemos/Demos/PivotGrid/ExcelJSCellCustomization/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/ExcelJSCellCustomization/React/index.html
+++ b/JSDemos/Demos/PivotGrid/ExcelJSCellCustomization/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/systemjs/dist/system.js"></script>

--- a/JSDemos/Demos/PivotGrid/ExcelJSCellCustomization/Vue/index.html
+++ b/JSDemos/Demos/PivotGrid/ExcelJSCellCustomization/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/ExcelJSCellCustomization/jQuery/index.html
+++ b/JSDemos/Demos/PivotGrid/ExcelJSCellCustomization/jQuery/index.html
@@ -11,7 +11,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
 
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/ExcelJSOverview/Angular/index.html
+++ b/JSDemos/Demos/PivotGrid/ExcelJSOverview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/ExcelJSOverview/React/index.html
+++ b/JSDemos/Demos/PivotGrid/ExcelJSOverview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/systemjs/dist/system.js"></script>

--- a/JSDemos/Demos/PivotGrid/ExcelJSOverview/Vue/index.html
+++ b/JSDemos/Demos/PivotGrid/ExcelJSOverview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/ExcelJSOverview/jQuery/index.html
+++ b/JSDemos/Demos/PivotGrid/ExcelJSOverview/jQuery/index.html
@@ -11,7 +11,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
 
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/ExcelJsHeaderAndFooter/Angular/index.html
+++ b/JSDemos/Demos/PivotGrid/ExcelJsHeaderAndFooter/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/ExcelJsHeaderAndFooter/React/index.html
+++ b/JSDemos/Demos/PivotGrid/ExcelJsHeaderAndFooter/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/ExcelJsHeaderAndFooter/Vue/index.html
+++ b/JSDemos/Demos/PivotGrid/ExcelJsHeaderAndFooter/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/ExcelJsHeaderAndFooter/jQuery/index.html
+++ b/JSDemos/Demos/PivotGrid/ExcelJsHeaderAndFooter/jQuery/index.html
@@ -11,7 +11,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
 
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/FieldPanel/Angular/index.html
+++ b/JSDemos/Demos/PivotGrid/FieldPanel/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/FieldPanel/AngularJS/index.html
+++ b/JSDemos/Demos/PivotGrid/FieldPanel/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/PivotGrid/FieldPanel/Knockout/index.html
+++ b/JSDemos/Demos/PivotGrid/FieldPanel/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/FieldPanel/React/index.html
+++ b/JSDemos/Demos/PivotGrid/FieldPanel/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/FieldPanel/Vue/index.html
+++ b/JSDemos/Demos/PivotGrid/FieldPanel/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/FieldPanel/jQuery/index.html
+++ b/JSDemos/Demos/PivotGrid/FieldPanel/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/HeaderFilter/Angular/index.html
+++ b/JSDemos/Demos/PivotGrid/HeaderFilter/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/HeaderFilter/AngularJS/index.html
+++ b/JSDemos/Demos/PivotGrid/HeaderFilter/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/PivotGrid/HeaderFilter/React/index.html
+++ b/JSDemos/Demos/PivotGrid/HeaderFilter/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/PivotGrid/HeaderFilter/Vue/index.html
+++ b/JSDemos/Demos/PivotGrid/HeaderFilter/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/HeaderFilter/jQuery/index.html
+++ b/JSDemos/Demos/PivotGrid/HeaderFilter/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/PivotGrid/IntegratedFieldChooser/Angular/index.html
+++ b/JSDemos/Demos/PivotGrid/IntegratedFieldChooser/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/IntegratedFieldChooser/AngularJS/index.html
+++ b/JSDemos/Demos/PivotGrid/IntegratedFieldChooser/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/PivotGrid/IntegratedFieldChooser/React/index.html
+++ b/JSDemos/Demos/PivotGrid/IntegratedFieldChooser/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/PivotGrid/IntegratedFieldChooser/Vue/index.html
+++ b/JSDemos/Demos/PivotGrid/IntegratedFieldChooser/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/IntegratedFieldChooser/jQuery/index.html
+++ b/JSDemos/Demos/PivotGrid/IntegratedFieldChooser/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/PivotGrid/LayoutCustomization/Angular/index.html
+++ b/JSDemos/Demos/PivotGrid/LayoutCustomization/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/LayoutCustomization/AngularJS/index.html
+++ b/JSDemos/Demos/PivotGrid/LayoutCustomization/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/PivotGrid/LayoutCustomization/Knockout/index.html
+++ b/JSDemos/Demos/PivotGrid/LayoutCustomization/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/LayoutCustomization/React/index.html
+++ b/JSDemos/Demos/PivotGrid/LayoutCustomization/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/LayoutCustomization/Vue/index.html
+++ b/JSDemos/Demos/PivotGrid/LayoutCustomization/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/LayoutCustomization/jQuery/index.html
+++ b/JSDemos/Demos/PivotGrid/LayoutCustomization/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/OLAPDataSource/Angular/index.html
+++ b/JSDemos/Demos/PivotGrid/OLAPDataSource/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/OLAPDataSource/AngularJS/index.html
+++ b/JSDemos/Demos/PivotGrid/OLAPDataSource/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/PivotGrid/OLAPDataSource/Knockout/index.html
+++ b/JSDemos/Demos/PivotGrid/OLAPDataSource/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/PivotGrid/OLAPDataSource/React/index.html
+++ b/JSDemos/Demos/PivotGrid/OLAPDataSource/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/OLAPDataSource/Vue/index.html
+++ b/JSDemos/Demos/PivotGrid/OLAPDataSource/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/OLAPDataSource/jQuery/index.html
+++ b/JSDemos/Demos/PivotGrid/OLAPDataSource/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/PivotGrid/Overview/Angular/index.html
+++ b/JSDemos/Demos/PivotGrid/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/PivotGrid/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/PivotGrid/Overview/Knockout/index.html
+++ b/JSDemos/Demos/PivotGrid/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/Overview/React/index.html
+++ b/JSDemos/Demos/PivotGrid/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/PivotGrid/Overview/Vue/index.html
+++ b/JSDemos/Demos/PivotGrid/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/Overview/jQuery/index.html
+++ b/JSDemos/Demos/PivotGrid/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/RemoteVirtualScrolling/Angular/index.html
+++ b/JSDemos/Demos/PivotGrid/RemoteVirtualScrolling/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/RemoteVirtualScrolling/AngularJS/index.html
+++ b/JSDemos/Demos/PivotGrid/RemoteVirtualScrolling/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/PivotGrid/RemoteVirtualScrolling/React/index.html
+++ b/JSDemos/Demos/PivotGrid/RemoteVirtualScrolling/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/RemoteVirtualScrolling/Vue/index.html
+++ b/JSDemos/Demos/PivotGrid/RemoteVirtualScrolling/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/RemoteVirtualScrolling/jQuery/index.html
+++ b/JSDemos/Demos/PivotGrid/RemoteVirtualScrolling/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/PivotGrid/RunningTotals/Angular/index.html
+++ b/JSDemos/Demos/PivotGrid/RunningTotals/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/RunningTotals/AngularJS/index.html
+++ b/JSDemos/Demos/PivotGrid/RunningTotals/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/PivotGrid/RunningTotals/Knockout/index.html
+++ b/JSDemos/Demos/PivotGrid/RunningTotals/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/RunningTotals/React/index.html
+++ b/JSDemos/Demos/PivotGrid/RunningTotals/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/RunningTotals/Vue/index.html
+++ b/JSDemos/Demos/PivotGrid/RunningTotals/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/RunningTotals/jQuery/index.html
+++ b/JSDemos/Demos/PivotGrid/RunningTotals/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/SimpleArray/Angular/index.html
+++ b/JSDemos/Demos/PivotGrid/SimpleArray/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/SimpleArray/AngularJS/index.html
+++ b/JSDemos/Demos/PivotGrid/SimpleArray/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/PivotGrid/SimpleArray/Knockout/index.html
+++ b/JSDemos/Demos/PivotGrid/SimpleArray/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/SimpleArray/React/index.html
+++ b/JSDemos/Demos/PivotGrid/SimpleArray/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/SimpleArray/Vue/index.html
+++ b/JSDemos/Demos/PivotGrid/SimpleArray/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/SimpleArray/jQuery/index.html
+++ b/JSDemos/Demos/PivotGrid/SimpleArray/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/StandaloneFieldChooser/Angular/index.html
+++ b/JSDemos/Demos/PivotGrid/StandaloneFieldChooser/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/StandaloneFieldChooser/AngularJS/index.html
+++ b/JSDemos/Demos/PivotGrid/StandaloneFieldChooser/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/PivotGrid/StandaloneFieldChooser/React/index.html
+++ b/JSDemos/Demos/PivotGrid/StandaloneFieldChooser/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/PivotGrid/StandaloneFieldChooser/Vue/index.html
+++ b/JSDemos/Demos/PivotGrid/StandaloneFieldChooser/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/StandaloneFieldChooser/jQuery/index.html
+++ b/JSDemos/Demos/PivotGrid/StandaloneFieldChooser/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/StatePersistence/Angular/index.html
+++ b/JSDemos/Demos/PivotGrid/StatePersistence/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/StatePersistence/AngularJS/index.html
+++ b/JSDemos/Demos/PivotGrid/StatePersistence/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/PivotGrid/StatePersistence/Knockout/index.html
+++ b/JSDemos/Demos/PivotGrid/StatePersistence/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/StatePersistence/React/index.html
+++ b/JSDemos/Demos/PivotGrid/StatePersistence/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/StatePersistence/Vue/index.html
+++ b/JSDemos/Demos/PivotGrid/StatePersistence/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/StatePersistence/jQuery/index.html
+++ b/JSDemos/Demos/PivotGrid/StatePersistence/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/SummaryDisplayModes/Angular/index.html
+++ b/JSDemos/Demos/PivotGrid/SummaryDisplayModes/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/SummaryDisplayModes/AngularJS/index.html
+++ b/JSDemos/Demos/PivotGrid/SummaryDisplayModes/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/PivotGrid/SummaryDisplayModes/Knockout/index.html
+++ b/JSDemos/Demos/PivotGrid/SummaryDisplayModes/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/SummaryDisplayModes/React/index.html
+++ b/JSDemos/Demos/PivotGrid/SummaryDisplayModes/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/SummaryDisplayModes/Vue/index.html
+++ b/JSDemos/Demos/PivotGrid/SummaryDisplayModes/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/SummaryDisplayModes/jQuery/index.html
+++ b/JSDemos/Demos/PivotGrid/SummaryDisplayModes/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/VirtualScrolling/Angular/index.html
+++ b/JSDemos/Demos/PivotGrid/VirtualScrolling/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/VirtualScrolling/AngularJS/index.html
+++ b/JSDemos/Demos/PivotGrid/VirtualScrolling/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/PivotGrid/VirtualScrolling/Knockout/index.html
+++ b/JSDemos/Demos/PivotGrid/VirtualScrolling/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/VirtualScrolling/React/index.html
+++ b/JSDemos/Demos/PivotGrid/VirtualScrolling/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/VirtualScrolling/Vue/index.html
+++ b/JSDemos/Demos/PivotGrid/VirtualScrolling/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/VirtualScrolling/jQuery/index.html
+++ b/JSDemos/Demos/PivotGrid/VirtualScrolling/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/PivotGrid/WebAPIService/Angular/index.html
+++ b/JSDemos/Demos/PivotGrid/WebAPIService/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/WebAPIService/AngularJS/index.html
+++ b/JSDemos/Demos/PivotGrid/WebAPIService/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/PivotGrid/WebAPIService/React/index.html
+++ b/JSDemos/Demos/PivotGrid/WebAPIService/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/WebAPIService/Vue/index.html
+++ b/JSDemos/Demos/PivotGrid/WebAPIService/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/PivotGrid/WebAPIService/jQuery/index.html
+++ b/JSDemos/Demos/PivotGrid/WebAPIService/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>

--- a/JSDemos/Demos/Popover/Overview/Angular/index.html
+++ b/JSDemos/Demos/Popover/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Popover/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/Popover/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Popover/Overview/Knockout/index.html
+++ b/JSDemos/Demos/Popover/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Popover/Overview/React/index.html
+++ b/JSDemos/Demos/Popover/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Popover/Overview/Vue/index.html
+++ b/JSDemos/Demos/Popover/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Popover/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Popover/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Popup/Overview/Angular/index.html
+++ b/JSDemos/Demos/Popup/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Popup/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/Popup/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Popup/Overview/Knockout/index.html
+++ b/JSDemos/Demos/Popup/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Popup/Overview/React/index.html
+++ b/JSDemos/Demos/Popup/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Popup/Overview/Vue/index.html
+++ b/JSDemos/Demos/Popup/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Popup/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Popup/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Popup/Scrolling/Angular/index.html
+++ b/JSDemos/Demos/Popup/Scrolling/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Popup/Scrolling/AngularJS/index.html
+++ b/JSDemos/Demos/Popup/Scrolling/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/angular-sanitize/angular-sanitize.min.js"></script>

--- a/JSDemos/Demos/Popup/Scrolling/React/index.html
+++ b/JSDemos/Demos/Popup/Scrolling/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Popup/Scrolling/Vue/index.html
+++ b/JSDemos/Demos/Popup/Scrolling/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Popup/Scrolling/jQuery/index.html
+++ b/JSDemos/Demos/Popup/Scrolling/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/ProgressBar/Overview/Angular/index.html
+++ b/JSDemos/Demos/ProgressBar/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/ProgressBar/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/ProgressBar/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/ProgressBar/Overview/Knockout/index.html
+++ b/JSDemos/Demos/ProgressBar/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/ProgressBar/Overview/React/index.html
+++ b/JSDemos/Demos/ProgressBar/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/ProgressBar/Overview/Vue/index.html
+++ b/JSDemos/Demos/ProgressBar/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/ProgressBar/Overview/jQuery/index.html
+++ b/JSDemos/Demos/ProgressBar/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/RadioGroup/Overview/Angular/index.html
+++ b/JSDemos/Demos/RadioGroup/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RadioGroup/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/RadioGroup/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/RadioGroup/Overview/Knockout/index.html
+++ b/JSDemos/Demos/RadioGroup/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/RadioGroup/Overview/React/index.html
+++ b/JSDemos/Demos/RadioGroup/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/RadioGroup/Overview/Vue/index.html
+++ b/JSDemos/Demos/RadioGroup/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/RadioGroup/Overview/jQuery/index.html
+++ b/JSDemos/Demos/RadioGroup/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/RangeSelector/ChartOnBackground/Angular/index.html
+++ b/JSDemos/Demos/RangeSelector/ChartOnBackground/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/ChartOnBackground/AngularJS/index.html
+++ b/JSDemos/Demos/RangeSelector/ChartOnBackground/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/RangeSelector/ChartOnBackground/Knockout/index.html
+++ b/JSDemos/Demos/RangeSelector/ChartOnBackground/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/RangeSelector/ChartOnBackground/React/index.html
+++ b/JSDemos/Demos/RangeSelector/ChartOnBackground/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/RangeSelector/ChartOnBackground/Vue/index.html
+++ b/JSDemos/Demos/RangeSelector/ChartOnBackground/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/ChartOnBackground/jQuery/index.html
+++ b/JSDemos/Demos/RangeSelector/ChartOnBackground/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/RangeSelector/ChartOnBackgroundWithSeriesTemplate/Angular/index.html
+++ b/JSDemos/Demos/RangeSelector/ChartOnBackgroundWithSeriesTemplate/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/ChartOnBackgroundWithSeriesTemplate/AngularJS/index.html
+++ b/JSDemos/Demos/RangeSelector/ChartOnBackgroundWithSeriesTemplate/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/RangeSelector/ChartOnBackgroundWithSeriesTemplate/Knockout/index.html
+++ b/JSDemos/Demos/RangeSelector/ChartOnBackgroundWithSeriesTemplate/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/RangeSelector/ChartOnBackgroundWithSeriesTemplate/React/index.html
+++ b/JSDemos/Demos/RangeSelector/ChartOnBackgroundWithSeriesTemplate/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/RangeSelector/ChartOnBackgroundWithSeriesTemplate/Vue/index.html
+++ b/JSDemos/Demos/RangeSelector/ChartOnBackgroundWithSeriesTemplate/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/ChartOnBackgroundWithSeriesTemplate/jQuery/index.html
+++ b/JSDemos/Demos/RangeSelector/ChartOnBackgroundWithSeriesTemplate/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/RangeSelector/CustomFormatting/Angular/index.html
+++ b/JSDemos/Demos/RangeSelector/CustomFormatting/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/CustomFormatting/AngularJS/index.html
+++ b/JSDemos/Demos/RangeSelector/CustomFormatting/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/RangeSelector/CustomFormatting/Knockout/index.html
+++ b/JSDemos/Demos/RangeSelector/CustomFormatting/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/RangeSelector/CustomFormatting/React/index.html
+++ b/JSDemos/Demos/RangeSelector/CustomFormatting/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/RangeSelector/CustomFormatting/Vue/index.html
+++ b/JSDemos/Demos/RangeSelector/CustomFormatting/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/CustomFormatting/jQuery/index.html
+++ b/JSDemos/Demos/RangeSelector/CustomFormatting/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/RangeSelector/CustomizedChartOnBackground/Angular/index.html
+++ b/JSDemos/Demos/RangeSelector/CustomizedChartOnBackground/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/CustomizedChartOnBackground/AngularJS/index.html
+++ b/JSDemos/Demos/RangeSelector/CustomizedChartOnBackground/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/RangeSelector/CustomizedChartOnBackground/Knockout/index.html
+++ b/JSDemos/Demos/RangeSelector/CustomizedChartOnBackground/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/RangeSelector/CustomizedChartOnBackground/React/index.html
+++ b/JSDemos/Demos/RangeSelector/CustomizedChartOnBackground/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/RangeSelector/CustomizedChartOnBackground/Vue/index.html
+++ b/JSDemos/Demos/RangeSelector/CustomizedChartOnBackground/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/CustomizedChartOnBackground/jQuery/index.html
+++ b/JSDemos/Demos/RangeSelector/CustomizedChartOnBackground/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/RangeSelector/DateTimeScale/Angular/index.html
+++ b/JSDemos/Demos/RangeSelector/DateTimeScale/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/DateTimeScale/AngularJS/index.html
+++ b/JSDemos/Demos/RangeSelector/DateTimeScale/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/RangeSelector/DateTimeScale/Knockout/index.html
+++ b/JSDemos/Demos/RangeSelector/DateTimeScale/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/RangeSelector/DateTimeScale/React/index.html
+++ b/JSDemos/Demos/RangeSelector/DateTimeScale/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/RangeSelector/DateTimeScale/Vue/index.html
+++ b/JSDemos/Demos/RangeSelector/DateTimeScale/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/DateTimeScale/jQuery/index.html
+++ b/JSDemos/Demos/RangeSelector/DateTimeScale/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/RangeSelector/DateTimeScaleLightweight/Angular/index.html
+++ b/JSDemos/Demos/RangeSelector/DateTimeScaleLightweight/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/DateTimeScaleLightweight/AngularJS/index.html
+++ b/JSDemos/Demos/RangeSelector/DateTimeScaleLightweight/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/RangeSelector/DateTimeScaleLightweight/Knockout/index.html
+++ b/JSDemos/Demos/RangeSelector/DateTimeScaleLightweight/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/RangeSelector/DateTimeScaleLightweight/React/index.html
+++ b/JSDemos/Demos/RangeSelector/DateTimeScaleLightweight/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/RangeSelector/DateTimeScaleLightweight/Vue/index.html
+++ b/JSDemos/Demos/RangeSelector/DateTimeScaleLightweight/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/DateTimeScaleLightweight/jQuery/index.html
+++ b/JSDemos/Demos/RangeSelector/DateTimeScaleLightweight/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/RangeSelector/DiscreteScale/Angular/index.html
+++ b/JSDemos/Demos/RangeSelector/DiscreteScale/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/DiscreteScale/AngularJS/index.html
+++ b/JSDemos/Demos/RangeSelector/DiscreteScale/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/RangeSelector/DiscreteScale/Knockout/index.html
+++ b/JSDemos/Demos/RangeSelector/DiscreteScale/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/RangeSelector/DiscreteScale/React/index.html
+++ b/JSDemos/Demos/RangeSelector/DiscreteScale/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/RangeSelector/DiscreteScale/Vue/index.html
+++ b/JSDemos/Demos/RangeSelector/DiscreteScale/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/DiscreteScale/jQuery/index.html
+++ b/JSDemos/Demos/RangeSelector/DiscreteScale/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/RangeSelector/ImageOnBackground/Angular/index.html
+++ b/JSDemos/Demos/RangeSelector/ImageOnBackground/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/ImageOnBackground/AngularJS/index.html
+++ b/JSDemos/Demos/RangeSelector/ImageOnBackground/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/RangeSelector/ImageOnBackground/Knockout/index.html
+++ b/JSDemos/Demos/RangeSelector/ImageOnBackground/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/RangeSelector/ImageOnBackground/React/index.html
+++ b/JSDemos/Demos/RangeSelector/ImageOnBackground/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/RangeSelector/ImageOnBackground/Vue/index.html
+++ b/JSDemos/Demos/RangeSelector/ImageOnBackground/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/ImageOnBackground/jQuery/index.html
+++ b/JSDemos/Demos/RangeSelector/ImageOnBackground/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/RangeSelector/LogarithmicScale/Angular/index.html
+++ b/JSDemos/Demos/RangeSelector/LogarithmicScale/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/LogarithmicScale/AngularJS/index.html
+++ b/JSDemos/Demos/RangeSelector/LogarithmicScale/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/RangeSelector/LogarithmicScale/Knockout/index.html
+++ b/JSDemos/Demos/RangeSelector/LogarithmicScale/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/RangeSelector/LogarithmicScale/React/index.html
+++ b/JSDemos/Demos/RangeSelector/LogarithmicScale/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/RangeSelector/LogarithmicScale/Vue/index.html
+++ b/JSDemos/Demos/RangeSelector/LogarithmicScale/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/LogarithmicScale/jQuery/index.html
+++ b/JSDemos/Demos/RangeSelector/LogarithmicScale/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/RangeSelector/NumericScale/Angular/index.html
+++ b/JSDemos/Demos/RangeSelector/NumericScale/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/NumericScale/AngularJS/index.html
+++ b/JSDemos/Demos/RangeSelector/NumericScale/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/RangeSelector/NumericScale/Knockout/index.html
+++ b/JSDemos/Demos/RangeSelector/NumericScale/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/RangeSelector/NumericScale/React/index.html
+++ b/JSDemos/Demos/RangeSelector/NumericScale/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/RangeSelector/NumericScale/Vue/index.html
+++ b/JSDemos/Demos/RangeSelector/NumericScale/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/NumericScale/jQuery/index.html
+++ b/JSDemos/Demos/RangeSelector/NumericScale/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/RangeSelector/NumericScaleLightweight/Angular/index.html
+++ b/JSDemos/Demos/RangeSelector/NumericScaleLightweight/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/NumericScaleLightweight/AngularJS/index.html
+++ b/JSDemos/Demos/RangeSelector/NumericScaleLightweight/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/RangeSelector/NumericScaleLightweight/Knockout/index.html
+++ b/JSDemos/Demos/RangeSelector/NumericScaleLightweight/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/RangeSelector/NumericScaleLightweight/React/index.html
+++ b/JSDemos/Demos/RangeSelector/NumericScaleLightweight/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/RangeSelector/NumericScaleLightweight/Vue/index.html
+++ b/JSDemos/Demos/RangeSelector/NumericScaleLightweight/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/NumericScaleLightweight/jQuery/index.html
+++ b/JSDemos/Demos/RangeSelector/NumericScaleLightweight/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/RangeSelector/UseRangeSelectionForCalculation/Angular/index.html
+++ b/JSDemos/Demos/RangeSelector/UseRangeSelectionForCalculation/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/UseRangeSelectionForCalculation/AngularJS/index.html
+++ b/JSDemos/Demos/RangeSelector/UseRangeSelectionForCalculation/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/RangeSelector/UseRangeSelectionForCalculation/Knockout/index.html
+++ b/JSDemos/Demos/RangeSelector/UseRangeSelectionForCalculation/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/RangeSelector/UseRangeSelectionForCalculation/React/index.html
+++ b/JSDemos/Demos/RangeSelector/UseRangeSelectionForCalculation/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/RangeSelector/UseRangeSelectionForCalculation/Vue/index.html
+++ b/JSDemos/Demos/RangeSelector/UseRangeSelectionForCalculation/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="dx-theme" data-theme="generic.light" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/UseRangeSelectionForCalculation/jQuery/index.html
+++ b/JSDemos/Demos/RangeSelector/UseRangeSelectionForCalculation/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/RangeSelector/UseRangeSelectionForFiltering/Angular/index.html
+++ b/JSDemos/Demos/RangeSelector/UseRangeSelectionForFiltering/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/UseRangeSelectionForFiltering/AngularJS/index.html
+++ b/JSDemos/Demos/RangeSelector/UseRangeSelectionForFiltering/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/RangeSelector/UseRangeSelectionForFiltering/Knockout/index.html
+++ b/JSDemos/Demos/RangeSelector/UseRangeSelectionForFiltering/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/RangeSelector/UseRangeSelectionForFiltering/React/index.html
+++ b/JSDemos/Demos/RangeSelector/UseRangeSelectionForFiltering/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/RangeSelector/UseRangeSelectionForFiltering/Vue/index.html
+++ b/JSDemos/Demos/RangeSelector/UseRangeSelectionForFiltering/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSelector/UseRangeSelectionForFiltering/jQuery/index.html
+++ b/JSDemos/Demos/RangeSelector/UseRangeSelectionForFiltering/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/RangeSlider/Overview/Angular/index.html
+++ b/JSDemos/Demos/RangeSlider/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSlider/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/RangeSlider/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/RangeSlider/Overview/Knockout/index.html
+++ b/JSDemos/Demos/RangeSlider/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/RangeSlider/Overview/React/index.html
+++ b/JSDemos/Demos/RangeSlider/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/RangeSlider/Overview/Vue/index.html
+++ b/JSDemos/Demos/RangeSlider/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/RangeSlider/Overview/jQuery/index.html
+++ b/JSDemos/Demos/RangeSlider/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Resizable/Overview/Angular/index.html
+++ b/JSDemos/Demos/Resizable/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Resizable/Overview/React/index.html
+++ b/JSDemos/Demos/Resizable/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Resizable/Overview/Vue/index.html
+++ b/JSDemos/Demos/Resizable/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Resizable/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Resizable/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/ResponsiveBox/Overview/Angular/index.html
+++ b/JSDemos/Demos/ResponsiveBox/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/ResponsiveBox/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/ResponsiveBox/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/ResponsiveBox/Overview/Knockout/index.html
+++ b/JSDemos/Demos/ResponsiveBox/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/ResponsiveBox/Overview/React/index.html
+++ b/JSDemos/Demos/ResponsiveBox/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/ResponsiveBox/Overview/Vue/index.html
+++ b/JSDemos/Demos/ResponsiveBox/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/ResponsiveBox/Overview/jQuery/index.html
+++ b/JSDemos/Demos/ResponsiveBox/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Scheduler/Adaptability/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/Adaptability/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/Adaptability/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/Adaptability/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/Scheduler/Adaptability/React/index.html
+++ b/JSDemos/Demos/Scheduler/Adaptability/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/Adaptability/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/Adaptability/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/Adaptability/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/Adaptability/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/Agenda/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/Agenda/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/Agenda/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/Agenda/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/Agenda/Knockout/index.html
+++ b/JSDemos/Demos/Scheduler/Agenda/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/Agenda/React/index.html
+++ b/JSDemos/Demos/Scheduler/Agenda/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/Agenda/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/Agenda/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/Agenda/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/Agenda/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/AllDayPanelMode/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/AllDayPanelMode/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/AllDayPanelMode/React/index.html
+++ b/JSDemos/Demos/Scheduler/AllDayPanelMode/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/AllDayPanelMode/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/AllDayPanelMode/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/AllDayPanelMode/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/AllDayPanelMode/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/BasicViews/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/BasicViews/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/BasicViews/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/BasicViews/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/BasicViews/Knockout/index.html
+++ b/JSDemos/Demos/Scheduler/BasicViews/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/BasicViews/React/index.html
+++ b/JSDemos/Demos/Scheduler/BasicViews/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/BasicViews/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/BasicViews/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/BasicViews/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/BasicViews/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/CellTemplates/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/CellTemplates/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/CellTemplates/React/index.html
+++ b/JSDemos/Demos/Scheduler/CellTemplates/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/CellTemplates/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/CellTemplates/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/CellTemplates/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/CellTemplates/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/ContextMenuIntegration/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/ContextMenuIntegration/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/ContextMenuIntegration/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/ContextMenuIntegration/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/ContextMenuIntegration/React/index.html
+++ b/JSDemos/Demos/Scheduler/ContextMenuIntegration/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/ContextMenuIntegration/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/ContextMenuIntegration/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/ContextMenuIntegration/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/ContextMenuIntegration/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/CurrentTimeIndicator/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/CurrentTimeIndicator/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/CurrentTimeIndicator/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/CurrentTimeIndicator/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/CurrentTimeIndicator/Knockout/index.html
+++ b/JSDemos/Demos/Scheduler/CurrentTimeIndicator/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/CurrentTimeIndicator/React/index.html
+++ b/JSDemos/Demos/Scheduler/CurrentTimeIndicator/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/CurrentTimeIndicator/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/CurrentTimeIndicator/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/CurrentTimeIndicator/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/CurrentTimeIndicator/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/CustomDragAndDrop/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/CustomDragAndDrop/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/CustomDragAndDrop/React/index.html
+++ b/JSDemos/Demos/Scheduler/CustomDragAndDrop/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/CustomDragAndDrop/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/CustomDragAndDrop/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/CustomDragAndDrop/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/CustomDragAndDrop/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/CustomTemplates/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/CustomTemplates/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/CustomTemplates/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/CustomTemplates/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/CustomTemplates/React/index.html
+++ b/JSDemos/Demos/Scheduler/CustomTemplates/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/CustomTemplates/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/CustomTemplates/Vue/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/CustomTemplates/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/CustomTemplates/jQuery/index.html
@@ -10,7 +10,6 @@
     <script src="../../../../../node_modules/cldrjs/dist/cldr/event.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/supplemental.js"></script>
     <script src="../../../../../node_modules/cldrjs/dist/cldr/unresolved.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/CustomizeIndividualViews/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/CustomizeIndividualViews/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/CustomizeIndividualViews/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/CustomizeIndividualViews/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/CustomizeIndividualViews/React/index.html
+++ b/JSDemos/Demos/Scheduler/CustomizeIndividualViews/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/CustomizeIndividualViews/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/CustomizeIndividualViews/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/CustomizeIndividualViews/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/CustomizeIndividualViews/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/Editing/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/Editing/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/Editing/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/Editing/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/Editing/Knockout/index.html
+++ b/JSDemos/Demos/Scheduler/Editing/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/Editing/React/index.html
+++ b/JSDemos/Demos/Scheduler/Editing/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/Editing/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/Editing/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/Editing/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/Editing/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/GoogleCalendarIntegration/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/GoogleCalendarIntegration/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/GoogleCalendarIntegration/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/GoogleCalendarIntegration/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/GoogleCalendarIntegration/Knockout/index.html
+++ b/JSDemos/Demos/Scheduler/GoogleCalendarIntegration/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/GoogleCalendarIntegration/React/index.html
+++ b/JSDemos/Demos/Scheduler/GoogleCalendarIntegration/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/GoogleCalendarIntegration/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/GoogleCalendarIntegration/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/GoogleCalendarIntegration/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/GoogleCalendarIntegration/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/GroupByDate/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/GroupByDate/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/GroupByDate/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/GroupByDate/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/GroupByDate/React/index.html
+++ b/JSDemos/Demos/Scheduler/GroupByDate/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/GroupByDate/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/GroupByDate/Vue/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/GroupByDate/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/GroupByDate/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/GroupOrientation/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/GroupOrientation/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/GroupOrientation/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/GroupOrientation/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/GroupOrientation/React/index.html
+++ b/JSDemos/Demos/Scheduler/GroupOrientation/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/GroupOrientation/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/GroupOrientation/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/GroupOrientation/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/GroupOrientation/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/IncreaseViewDuration/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/IncreaseViewDuration/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/IncreaseViewDuration/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/IncreaseViewDuration/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/IncreaseViewDuration/Knockout/index.html
+++ b/JSDemos/Demos/Scheduler/IncreaseViewDuration/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/IncreaseViewDuration/React/index.html
+++ b/JSDemos/Demos/Scheduler/IncreaseViewDuration/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/IncreaseViewDuration/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/IncreaseViewDuration/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/IncreaseViewDuration/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/IncreaseViewDuration/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/LimitAppointmentCountPerCell/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/LimitAppointmentCountPerCell/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/LimitAppointmentCountPerCell/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/LimitAppointmentCountPerCell/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/LimitAppointmentCountPerCell/React/index.html
+++ b/JSDemos/Demos/Scheduler/LimitAppointmentCountPerCell/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/LimitAppointmentCountPerCell/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/LimitAppointmentCountPerCell/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/LimitAppointmentCountPerCell/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/LimitAppointmentCountPerCell/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/Overview/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/Overview/React/index.html
+++ b/JSDemos/Demos/Scheduler/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/Overview/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/RecurringAppointments/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/RecurringAppointments/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/RecurringAppointments/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/RecurringAppointments/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/RecurringAppointments/Knockout/index.html
+++ b/JSDemos/Demos/Scheduler/RecurringAppointments/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/RecurringAppointments/React/index.html
+++ b/JSDemos/Demos/Scheduler/RecurringAppointments/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/RecurringAppointments/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/RecurringAppointments/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/RecurringAppointments/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/RecurringAppointments/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/Resources/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/Resources/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/Resources/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/Resources/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/Resources/Knockout/index.html
+++ b/JSDemos/Demos/Scheduler/Resources/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/Resources/React/index.html
+++ b/JSDemos/Demos/Scheduler/Resources/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/Resources/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/Resources/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/Resources/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/Resources/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/SignalRService/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/SignalRService/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../signalr-session-id.js"></script>
 

--- a/JSDemos/Demos/Scheduler/SignalRService/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/SignalRService/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/SignalRService/React/index.html
+++ b/JSDemos/Demos/Scheduler/SignalRService/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../signalr-session-id.js"></script>
 

--- a/JSDemos/Demos/Scheduler/SignalRService/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/SignalRService/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../signalr-session-id.js"></script>
 

--- a/JSDemos/Demos/Scheduler/SignalRService/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/SignalRService/jQuery/index.html
@@ -8,7 +8,6 @@
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../signalr-session-id.js"></script>
     <script src="../../../../../node_modules/@aspnet/signalr/dist/browser/signalr.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>

--- a/JSDemos/Demos/Scheduler/SimpleArray/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/SimpleArray/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/SimpleArray/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/SimpleArray/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/SimpleArray/Knockout/index.html
+++ b/JSDemos/Demos/Scheduler/SimpleArray/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/SimpleArray/React/index.html
+++ b/JSDemos/Demos/Scheduler/SimpleArray/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/SimpleArray/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/SimpleArray/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/SimpleArray/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/SimpleArray/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/TimeZonesSupport/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/TimeZonesSupport/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/TimeZonesSupport/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/TimeZonesSupport/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/TimeZonesSupport/Knockout/index.html
+++ b/JSDemos/Demos/Scheduler/TimeZonesSupport/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/TimeZonesSupport/React/index.html
+++ b/JSDemos/Demos/Scheduler/TimeZonesSupport/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/TimeZonesSupport/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/TimeZonesSupport/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/TimeZonesSupport/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/TimeZonesSupport/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/Timelines/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/Timelines/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/Timelines/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/Timelines/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/Timelines/Knockout/index.html
+++ b/JSDemos/Demos/Scheduler/Timelines/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/Timelines/React/index.html
+++ b/JSDemos/Demos/Scheduler/Timelines/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/Timelines/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/Timelines/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/Timelines/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/Timelines/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Scheduler/VirtualScrolling/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/VirtualScrolling/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/VirtualScrolling/React/index.html
+++ b/JSDemos/Demos/Scheduler/VirtualScrolling/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/VirtualScrolling/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/VirtualScrolling/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/VirtualScrolling/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/VirtualScrolling/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Scheduler/WebAPIService/Angular/index.html
+++ b/JSDemos/Demos/Scheduler/WebAPIService/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/WebAPIService/AngularJS/index.html
+++ b/JSDemos/Demos/Scheduler/WebAPIService/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Scheduler/WebAPIService/Knockout/index.html
+++ b/JSDemos/Demos/Scheduler/WebAPIService/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>

--- a/JSDemos/Demos/Scheduler/WebAPIService/React/index.html
+++ b/JSDemos/Demos/Scheduler/WebAPIService/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/WebAPIService/Vue/index.html
+++ b/JSDemos/Demos/Scheduler/WebAPIService/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Scheduler/WebAPIService/jQuery/index.html
+++ b/JSDemos/Demos/Scheduler/WebAPIService/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>

--- a/JSDemos/Demos/ScrollView/Overview/Angular/index.html
+++ b/JSDemos/Demos/ScrollView/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/ScrollView/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/ScrollView/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/ScrollView/Overview/Knockout/index.html
+++ b/JSDemos/Demos/ScrollView/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/ScrollView/Overview/React/index.html
+++ b/JSDemos/Demos/ScrollView/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/ScrollView/Overview/Vue/index.html
+++ b/JSDemos/Demos/ScrollView/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/ScrollView/Overview/jQuery/index.html
+++ b/JSDemos/Demos/ScrollView/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/SelectBox/CustomizeDropDownButton/Angular/index.html
+++ b/JSDemos/Demos/SelectBox/CustomizeDropDownButton/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/SelectBox/CustomizeDropDownButton/AngularJS/index.html
+++ b/JSDemos/Demos/SelectBox/CustomizeDropDownButton/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/SelectBox/CustomizeDropDownButton/Knockout/index.html
+++ b/JSDemos/Demos/SelectBox/CustomizeDropDownButton/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/SelectBox/CustomizeDropDownButton/React/index.html
+++ b/JSDemos/Demos/SelectBox/CustomizeDropDownButton/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/SelectBox/CustomizeDropDownButton/Vue/index.html
+++ b/JSDemos/Demos/SelectBox/CustomizeDropDownButton/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/SelectBox/CustomizeDropDownButton/jQuery/index.html
+++ b/JSDemos/Demos/SelectBox/CustomizeDropDownButton/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/SelectBox/GroupedItems/Angular/index.html
+++ b/JSDemos/Demos/SelectBox/GroupedItems/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/SelectBox/GroupedItems/AngularJS/index.html
+++ b/JSDemos/Demos/SelectBox/GroupedItems/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/SelectBox/GroupedItems/Knockout/index.html
+++ b/JSDemos/Demos/SelectBox/GroupedItems/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/SelectBox/GroupedItems/React/index.html
+++ b/JSDemos/Demos/SelectBox/GroupedItems/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/SelectBox/GroupedItems/Vue/index.html
+++ b/JSDemos/Demos/SelectBox/GroupedItems/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/SelectBox/GroupedItems/jQuery/index.html
+++ b/JSDemos/Demos/SelectBox/GroupedItems/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/SelectBox/Overview/Angular/index.html
+++ b/JSDemos/Demos/SelectBox/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/SelectBox/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/SelectBox/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/SelectBox/Overview/Knockout/index.html
+++ b/JSDemos/Demos/SelectBox/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/SelectBox/Overview/React/index.html
+++ b/JSDemos/Demos/SelectBox/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/SelectBox/Overview/Vue/index.html
+++ b/JSDemos/Demos/SelectBox/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/SelectBox/Overview/jQuery/index.html
+++ b/JSDemos/Demos/SelectBox/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/SelectBox/SearchAndEditing/Angular/index.html
+++ b/JSDemos/Demos/SelectBox/SearchAndEditing/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/SelectBox/SearchAndEditing/AngularJS/index.html
+++ b/JSDemos/Demos/SelectBox/SearchAndEditing/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/SelectBox/SearchAndEditing/Knockout/index.html
+++ b/JSDemos/Demos/SelectBox/SearchAndEditing/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/SelectBox/SearchAndEditing/React/index.html
+++ b/JSDemos/Demos/SelectBox/SearchAndEditing/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/SelectBox/SearchAndEditing/Vue/index.html
+++ b/JSDemos/Demos/SelectBox/SearchAndEditing/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/SelectBox/SearchAndEditing/jQuery/index.html
+++ b/JSDemos/Demos/SelectBox/SearchAndEditing/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Slider/Overview/Angular/index.html
+++ b/JSDemos/Demos/Slider/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Slider/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/Slider/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Slider/Overview/Knockout/index.html
+++ b/JSDemos/Demos/Slider/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Slider/Overview/React/index.html
+++ b/JSDemos/Demos/Slider/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Slider/Overview/Vue/index.html
+++ b/JSDemos/Demos/Slider/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/Slider/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Slider/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Sortable/Customization/Angular/index.html
+++ b/JSDemos/Demos/Sortable/Customization/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Sortable/Customization/React/index.html
+++ b/JSDemos/Demos/Sortable/Customization/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Sortable/Customization/Vue/index.html
+++ b/JSDemos/Demos/Sortable/Customization/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/Sortable/Customization/jQuery/index.html
+++ b/JSDemos/Demos/Sortable/Customization/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Sortable/Kanban/Angular/index.html
+++ b/JSDemos/Demos/Sortable/Kanban/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Sortable/Kanban/React/index.html
+++ b/JSDemos/Demos/Sortable/Kanban/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Sortable/Kanban/Vue/index.html
+++ b/JSDemos/Demos/Sortable/Kanban/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Sortable/Kanban/jQuery/index.html
+++ b/JSDemos/Demos/Sortable/Kanban/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Switch/Overview/Angular/index.html
+++ b/JSDemos/Demos/Switch/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Switch/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/Switch/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Switch/Overview/Knockout/index.html
+++ b/JSDemos/Demos/Switch/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Switch/Overview/React/index.html
+++ b/JSDemos/Demos/Switch/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Switch/Overview/Vue/index.html
+++ b/JSDemos/Demos/Switch/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Switch/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Switch/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/TabPanel/Overview/Angular/index.html
+++ b/JSDemos/Demos/TabPanel/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TabPanel/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/TabPanel/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TabPanel/Overview/Knockout/index.html
+++ b/JSDemos/Demos/TabPanel/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TabPanel/Overview/React/index.html
+++ b/JSDemos/Demos/TabPanel/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TabPanel/Overview/Vue/index.html
+++ b/JSDemos/Demos/TabPanel/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TabPanel/Overview/jQuery/index.html
+++ b/JSDemos/Demos/TabPanel/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/underscore/underscore.js"></script>

--- a/JSDemos/Demos/TabPanel/SortableClosableTabs/Angular/index.html
+++ b/JSDemos/Demos/TabPanel/SortableClosableTabs/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TabPanel/SortableClosableTabs/React/index.html
+++ b/JSDemos/Demos/TabPanel/SortableClosableTabs/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TabPanel/SortableClosableTabs/Vue/index.html
+++ b/JSDemos/Demos/TabPanel/SortableClosableTabs/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TabPanel/SortableClosableTabs/jQuery/index.html
+++ b/JSDemos/Demos/TabPanel/SortableClosableTabs/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/underscore/underscore.js"></script>

--- a/JSDemos/Demos/Tabs/Overview/Angular/index.html
+++ b/JSDemos/Demos/Tabs/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Tabs/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/Tabs/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Tabs/Overview/Knockout/index.html
+++ b/JSDemos/Demos/Tabs/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Tabs/Overview/React/index.html
+++ b/JSDemos/Demos/Tabs/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Tabs/Overview/Vue/index.html
+++ b/JSDemos/Demos/Tabs/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Tabs/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Tabs/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TagBox/GroupedItems/Angular/index.html
+++ b/JSDemos/Demos/TagBox/GroupedItems/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TagBox/GroupedItems/AngularJS/index.html
+++ b/JSDemos/Demos/TagBox/GroupedItems/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TagBox/GroupedItems/Knockout/index.html
+++ b/JSDemos/Demos/TagBox/GroupedItems/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TagBox/GroupedItems/React/index.html
+++ b/JSDemos/Demos/TagBox/GroupedItems/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/TagBox/GroupedItems/Vue/index.html
+++ b/JSDemos/Demos/TagBox/GroupedItems/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 

--- a/JSDemos/Demos/TagBox/GroupedItems/jQuery/index.html
+++ b/JSDemos/Demos/TagBox/GroupedItems/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TagBox/Overview/Angular/index.html
+++ b/JSDemos/Demos/TagBox/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TagBox/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/TagBox/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TagBox/Overview/Knockout/index.html
+++ b/JSDemos/Demos/TagBox/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TagBox/Overview/React/index.html
+++ b/JSDemos/Demos/TagBox/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TagBox/Overview/Vue/index.html
+++ b/JSDemos/Demos/TagBox/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TagBox/Overview/jQuery/index.html
+++ b/JSDemos/Demos/TagBox/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TagBox/TagCountLimitation/Angular/index.html
+++ b/JSDemos/Demos/TagBox/TagCountLimitation/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TagBox/TagCountLimitation/AngularJS/index.html
+++ b/JSDemos/Demos/TagBox/TagCountLimitation/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TagBox/TagCountLimitation/Knockout/index.html
+++ b/JSDemos/Demos/TagBox/TagCountLimitation/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TagBox/TagCountLimitation/React/index.html
+++ b/JSDemos/Demos/TagBox/TagCountLimitation/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TagBox/TagCountLimitation/Vue/index.html
+++ b/JSDemos/Demos/TagBox/TagCountLimitation/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TagBox/TagCountLimitation/jQuery/index.html
+++ b/JSDemos/Demos/TagBox/TagCountLimitation/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TextArea/Overview/Angular/index.html
+++ b/JSDemos/Demos/TextArea/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TextArea/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/TextArea/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TextArea/Overview/Knockout/index.html
+++ b/JSDemos/Demos/TextArea/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TextArea/Overview/React/index.html
+++ b/JSDemos/Demos/TextArea/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TextArea/Overview/Vue/index.html
+++ b/JSDemos/Demos/TextArea/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TextArea/Overview/jQuery/index.html
+++ b/JSDemos/Demos/TextArea/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TextBox/Overview/Angular/index.html
+++ b/JSDemos/Demos/TextBox/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TextBox/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/TextBox/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TextBox/Overview/Knockout/index.html
+++ b/JSDemos/Demos/TextBox/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="index.js"></script>

--- a/JSDemos/Demos/TextBox/Overview/React/index.html
+++ b/JSDemos/Demos/TextBox/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TextBox/Overview/Vue/index.html
+++ b/JSDemos/Demos/TextBox/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TextBox/Overview/jQuery/index.html
+++ b/JSDemos/Demos/TextBox/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="index.js"></script>

--- a/JSDemos/Demos/TileView/Basics/Angular/index.html
+++ b/JSDemos/Demos/TileView/Basics/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TileView/Basics/AngularJS/index.html
+++ b/JSDemos/Demos/TileView/Basics/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TileView/Basics/Knockout/index.html
+++ b/JSDemos/Demos/TileView/Basics/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TileView/Basics/React/index.html
+++ b/JSDemos/Demos/TileView/Basics/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TileView/Basics/Vue/index.html
+++ b/JSDemos/Demos/TileView/Basics/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TileView/Basics/jQuery/index.html
+++ b/JSDemos/Demos/TileView/Basics/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TileView/Directions/Angular/index.html
+++ b/JSDemos/Demos/TileView/Directions/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TileView/Directions/AngularJS/index.html
+++ b/JSDemos/Demos/TileView/Directions/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TileView/Directions/Knockout/index.html
+++ b/JSDemos/Demos/TileView/Directions/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TileView/Directions/React/index.html
+++ b/JSDemos/Demos/TileView/Directions/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TileView/Directions/Vue/index.html
+++ b/JSDemos/Demos/TileView/Directions/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TileView/Directions/jQuery/index.html
+++ b/JSDemos/Demos/TileView/Directions/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TileView/Item3RdPartyEngineTemplate/jQuery/index.html
+++ b/JSDemos/Demos/TileView/Item3RdPartyEngineTemplate/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/underscore/underscore.js"></script>

--- a/JSDemos/Demos/TileView/ItemTemplate/Angular/index.html
+++ b/JSDemos/Demos/TileView/ItemTemplate/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TileView/ItemTemplate/AngularJS/index.html
+++ b/JSDemos/Demos/TileView/ItemTemplate/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TileView/ItemTemplate/Knockout/index.html
+++ b/JSDemos/Demos/TileView/ItemTemplate/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/underscore/underscore.js"></script>

--- a/JSDemos/Demos/TileView/ItemTemplate/React/index.html
+++ b/JSDemos/Demos/TileView/ItemTemplate/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TileView/ItemTemplate/Vue/index.html
+++ b/JSDemos/Demos/TileView/ItemTemplate/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TileView/ItemTemplate/jQuery/index.html
+++ b/JSDemos/Demos/TileView/ItemTemplate/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Toast/Overview/Angular/index.html
+++ b/JSDemos/Demos/Toast/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Toast/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/Toast/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Toast/Overview/Knockout/index.html
+++ b/JSDemos/Demos/Toast/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Toast/Overview/React/index.html
+++ b/JSDemos/Demos/Toast/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Toast/Overview/Vue/index.html
+++ b/JSDemos/Demos/Toast/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Toast/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Toast/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Toast/Stack/Angular/index.html
+++ b/JSDemos/Demos/Toast/Stack/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Toast/Stack/React/index.html
+++ b/JSDemos/Demos/Toast/Stack/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Toast/Stack/Vue/index.html
+++ b/JSDemos/Demos/Toast/Stack/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Toast/Stack/jQuery/index.html
+++ b/JSDemos/Demos/Toast/Stack/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Toolbar/Adaptability/Angular/index.html
+++ b/JSDemos/Demos/Toolbar/Adaptability/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Toolbar/Adaptability/React/index.html
+++ b/JSDemos/Demos/Toolbar/Adaptability/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Toolbar/Adaptability/Vue/index.html
+++ b/JSDemos/Demos/Toolbar/Adaptability/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Toolbar/Adaptability/jQuery/index.html
+++ b/JSDemos/Demos/Toolbar/Adaptability/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Toolbar/Overview/Angular/index.html
+++ b/JSDemos/Demos/Toolbar/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Toolbar/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/Toolbar/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Toolbar/Overview/Knockout/index.html
+++ b/JSDemos/Demos/Toolbar/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Toolbar/Overview/React/index.html
+++ b/JSDemos/Demos/Toolbar/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Toolbar/Overview/Vue/index.html
+++ b/JSDemos/Demos/Toolbar/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Toolbar/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Toolbar/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Tooltip/Overview/Angular/index.html
+++ b/JSDemos/Demos/Tooltip/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Tooltip/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/Tooltip/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Tooltip/Overview/Knockout/index.html
+++ b/JSDemos/Demos/Tooltip/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Tooltip/Overview/React/index.html
+++ b/JSDemos/Demos/Tooltip/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Tooltip/Overview/Vue/index.html
+++ b/JSDemos/Demos/Tooltip/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Tooltip/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Tooltip/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/TreeList/Adaptability/Angular/index.html
+++ b/JSDemos/Demos/TreeList/Adaptability/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/Adaptability/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/Adaptability/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/TreeList/Adaptability/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/Adaptability/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/Adaptability/React/index.html
+++ b/JSDemos/Demos/TreeList/Adaptability/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/Adaptability/Vue/index.html
+++ b/JSDemos/Demos/TreeList/Adaptability/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/Adaptability/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/Adaptability/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/BatchEditing/Angular/index.html
+++ b/JSDemos/Demos/TreeList/BatchEditing/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/BatchEditing/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/BatchEditing/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/BatchEditing/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/BatchEditing/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/BatchEditing/React/index.html
+++ b/JSDemos/Demos/TreeList/BatchEditing/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/BatchEditing/Vue/index.html
+++ b/JSDemos/Demos/TreeList/BatchEditing/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/BatchEditing/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/BatchEditing/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/CellEditing/Angular/index.html
+++ b/JSDemos/Demos/TreeList/CellEditing/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/CellEditing/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/CellEditing/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/CellEditing/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/CellEditing/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/CellEditing/React/index.html
+++ b/JSDemos/Demos/TreeList/CellEditing/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/CellEditing/Vue/index.html
+++ b/JSDemos/Demos/TreeList/CellEditing/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/CellEditing/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/CellEditing/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/ColumnChooser/Angular/index.html
+++ b/JSDemos/Demos/TreeList/ColumnChooser/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/ColumnChooser/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/ColumnChooser/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/TreeList/ColumnChooser/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/ColumnChooser/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/ColumnChooser/React/index.html
+++ b/JSDemos/Demos/TreeList/ColumnChooser/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/ColumnChooser/Vue/index.html
+++ b/JSDemos/Demos/TreeList/ColumnChooser/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/ColumnChooser/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/ColumnChooser/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/ColumnFixing/Angular/index.html
+++ b/JSDemos/Demos/TreeList/ColumnFixing/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/ColumnFixing/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/ColumnFixing/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/TreeList/ColumnFixing/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/ColumnFixing/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/ColumnFixing/React/index.html
+++ b/JSDemos/Demos/TreeList/ColumnFixing/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/ColumnFixing/Vue/index.html
+++ b/JSDemos/Demos/TreeList/ColumnFixing/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/ColumnFixing/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/ColumnFixing/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/CustomizeKeyboardNavigation/Angular/index.html
+++ b/JSDemos/Demos/TreeList/CustomizeKeyboardNavigation/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/CustomizeKeyboardNavigation/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/CustomizeKeyboardNavigation/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/TreeList/CustomizeKeyboardNavigation/React/index.html
+++ b/JSDemos/Demos/TreeList/CustomizeKeyboardNavigation/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/CustomizeKeyboardNavigation/Vue/index.html
+++ b/JSDemos/Demos/TreeList/CustomizeKeyboardNavigation/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/CustomizeKeyboardNavigation/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/CustomizeKeyboardNavigation/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/FilterModes/Angular/index.html
+++ b/JSDemos/Demos/TreeList/FilterModes/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/FilterModes/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/FilterModes/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/TreeList/FilterModes/React/index.html
+++ b/JSDemos/Demos/TreeList/FilterModes/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/FilterModes/Vue/index.html
+++ b/JSDemos/Demos/TreeList/FilterModes/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/FilterModes/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/FilterModes/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/FilterPanel/Angular/index.html
+++ b/JSDemos/Demos/TreeList/FilterPanel/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/FilterPanel/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/FilterPanel/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/FilterPanel/React/index.html
+++ b/JSDemos/Demos/TreeList/FilterPanel/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/FilterPanel/Vue/index.html
+++ b/JSDemos/Demos/TreeList/FilterPanel/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/FilterPanel/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/FilterPanel/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/FocusedRow/Angular/index.html
+++ b/JSDemos/Demos/TreeList/FocusedRow/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/FocusedRow/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/FocusedRow/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/TreeList/FocusedRow/React/index.html
+++ b/JSDemos/Demos/TreeList/FocusedRow/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/FocusedRow/Vue/index.html
+++ b/JSDemos/Demos/TreeList/FocusedRow/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/FocusedRow/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/FocusedRow/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>

--- a/JSDemos/Demos/TreeList/FormEditing/Angular/index.html
+++ b/JSDemos/Demos/TreeList/FormEditing/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/FormEditing/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/FormEditing/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/FormEditing/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/FormEditing/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/FormEditing/React/index.html
+++ b/JSDemos/Demos/TreeList/FormEditing/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/FormEditing/Vue/index.html
+++ b/JSDemos/Demos/TreeList/FormEditing/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/FormEditing/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/FormEditing/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/KeyboardNavigation/Angular/index.html
+++ b/JSDemos/Demos/TreeList/KeyboardNavigation/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/KeyboardNavigation/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/KeyboardNavigation/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/angular-sanitize/angular-sanitize.min.js"></script>

--- a/JSDemos/Demos/TreeList/KeyboardNavigation/React/index.html
+++ b/JSDemos/Demos/TreeList/KeyboardNavigation/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/KeyboardNavigation/Vue/index.html
+++ b/JSDemos/Demos/TreeList/KeyboardNavigation/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/KeyboardNavigation/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/KeyboardNavigation/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/LoadDataOnDemand/Angular/index.html
+++ b/JSDemos/Demos/TreeList/LoadDataOnDemand/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/LoadDataOnDemand/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/LoadDataOnDemand/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/LoadDataOnDemand/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/LoadDataOnDemand/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/TreeList/LoadDataOnDemand/React/index.html
+++ b/JSDemos/Demos/TreeList/LoadDataOnDemand/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/LoadDataOnDemand/Vue/index.html
+++ b/JSDemos/Demos/TreeList/LoadDataOnDemand/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/LoadDataOnDemand/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/LoadDataOnDemand/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/TreeList/LocalReordering/Angular/index.html
+++ b/JSDemos/Demos/TreeList/LocalReordering/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/LocalReordering/React/index.html
+++ b/JSDemos/Demos/TreeList/LocalReordering/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/LocalReordering/Vue/index.html
+++ b/JSDemos/Demos/TreeList/LocalReordering/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/LocalReordering/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/LocalReordering/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/MultipleRowSelection/Angular/index.html
+++ b/JSDemos/Demos/TreeList/MultipleRowSelection/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/MultipleRowSelection/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/MultipleRowSelection/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/MultipleRowSelection/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/MultipleRowSelection/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/MultipleRowSelection/React/index.html
+++ b/JSDemos/Demos/TreeList/MultipleRowSelection/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/MultipleRowSelection/Vue/index.html
+++ b/JSDemos/Demos/TreeList/MultipleRowSelection/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/MultipleRowSelection/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/MultipleRowSelection/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/MultipleSorting/Angular/index.html
+++ b/JSDemos/Demos/TreeList/MultipleSorting/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/MultipleSorting/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/MultipleSorting/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/MultipleSorting/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/MultipleSorting/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/MultipleSorting/React/index.html
+++ b/JSDemos/Demos/TreeList/MultipleSorting/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/MultipleSorting/Vue/index.html
+++ b/JSDemos/Demos/TreeList/MultipleSorting/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/MultipleSorting/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/MultipleSorting/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/Overview/Angular/index.html
+++ b/JSDemos/Demos/TreeList/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/Overview/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/Overview/React/index.html
+++ b/JSDemos/Demos/TreeList/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/Overview/Vue/index.html
+++ b/JSDemos/Demos/TreeList/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/Overview/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/Paging/Angular/index.html
+++ b/JSDemos/Demos/TreeList/Paging/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/Paging/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/Paging/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/Paging/React/index.html
+++ b/JSDemos/Demos/TreeList/Paging/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/Paging/Vue/index.html
+++ b/JSDemos/Demos/TreeList/Paging/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/Paging/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/Paging/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/PopupEditing/Angular/index.html
+++ b/JSDemos/Demos/TreeList/PopupEditing/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/PopupEditing/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/PopupEditing/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/PopupEditing/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/PopupEditing/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/PopupEditing/React/index.html
+++ b/JSDemos/Demos/TreeList/PopupEditing/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/PopupEditing/Vue/index.html
+++ b/JSDemos/Demos/TreeList/PopupEditing/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/PopupEditing/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/PopupEditing/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/Reordering/Angular/index.html
+++ b/JSDemos/Demos/TreeList/Reordering/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/Reordering/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/Reordering/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/TreeList/Reordering/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/Reordering/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/Reordering/React/index.html
+++ b/JSDemos/Demos/TreeList/Reordering/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/Reordering/Vue/index.html
+++ b/JSDemos/Demos/TreeList/Reordering/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/Reordering/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/Reordering/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/Resizing/Angular/index.html
+++ b/JSDemos/Demos/TreeList/Resizing/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/Resizing/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/Resizing/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/TreeList/Resizing/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/Resizing/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/Resizing/React/index.html
+++ b/JSDemos/Demos/TreeList/Resizing/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/Resizing/Vue/index.html
+++ b/JSDemos/Demos/TreeList/Resizing/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/Resizing/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/Resizing/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/RowEditing/Angular/index.html
+++ b/JSDemos/Demos/TreeList/RowEditing/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/RowEditing/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/RowEditing/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/RowEditing/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/RowEditing/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/RowEditing/React/index.html
+++ b/JSDemos/Demos/TreeList/RowEditing/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/RowEditing/Vue/index.html
+++ b/JSDemos/Demos/TreeList/RowEditing/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/RowEditing/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/RowEditing/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/SimpleArrayHierarchicalStructure/Angular/index.html
+++ b/JSDemos/Demos/TreeList/SimpleArrayHierarchicalStructure/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/SimpleArrayHierarchicalStructure/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/SimpleArrayHierarchicalStructure/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/TreeList/SimpleArrayHierarchicalStructure/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/SimpleArrayHierarchicalStructure/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/SimpleArrayHierarchicalStructure/React/index.html
+++ b/JSDemos/Demos/TreeList/SimpleArrayHierarchicalStructure/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/SimpleArrayHierarchicalStructure/Vue/index.html
+++ b/JSDemos/Demos/TreeList/SimpleArrayHierarchicalStructure/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/SimpleArrayHierarchicalStructure/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/SimpleArrayHierarchicalStructure/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/SimpleArrayPlainStructure/Angular/index.html
+++ b/JSDemos/Demos/TreeList/SimpleArrayPlainStructure/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/SimpleArrayPlainStructure/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/SimpleArrayPlainStructure/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/TreeList/SimpleArrayPlainStructure/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/SimpleArrayPlainStructure/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/SimpleArrayPlainStructure/React/index.html
+++ b/JSDemos/Demos/TreeList/SimpleArrayPlainStructure/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/SimpleArrayPlainStructure/Vue/index.html
+++ b/JSDemos/Demos/TreeList/SimpleArrayPlainStructure/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/SimpleArrayPlainStructure/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/SimpleArrayPlainStructure/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/SingleRowSelection/Angular/index.html
+++ b/JSDemos/Demos/TreeList/SingleRowSelection/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/SingleRowSelection/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/SingleRowSelection/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/SingleRowSelection/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/SingleRowSelection/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/SingleRowSelection/React/index.html
+++ b/JSDemos/Demos/TreeList/SingleRowSelection/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/SingleRowSelection/Vue/index.html
+++ b/JSDemos/Demos/TreeList/SingleRowSelection/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/SingleRowSelection/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/SingleRowSelection/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/StatePersistence/Angular/index.html
+++ b/JSDemos/Demos/TreeList/StatePersistence/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/StatePersistence/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/StatePersistence/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/StatePersistence/React/index.html
+++ b/JSDemos/Demos/TreeList/StatePersistence/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/StatePersistence/Vue/index.html
+++ b/JSDemos/Demos/TreeList/StatePersistence/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/StatePersistence/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/StatePersistence/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/UsingFilterRow/Angular/index.html
+++ b/JSDemos/Demos/TreeList/UsingFilterRow/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/UsingFilterRow/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/UsingFilterRow/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/TreeList/UsingFilterRow/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/UsingFilterRow/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/UsingFilterRow/React/index.html
+++ b/JSDemos/Demos/TreeList/UsingFilterRow/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/UsingFilterRow/Vue/index.html
+++ b/JSDemos/Demos/TreeList/UsingFilterRow/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/UsingFilterRow/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/UsingFilterRow/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/UsingHeaderFilter/Angular/index.html
+++ b/JSDemos/Demos/TreeList/UsingHeaderFilter/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/UsingHeaderFilter/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/UsingHeaderFilter/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/angular/angular.min.js"></script>

--- a/JSDemos/Demos/TreeList/UsingHeaderFilter/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/UsingHeaderFilter/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/UsingHeaderFilter/React/index.html
+++ b/JSDemos/Demos/TreeList/UsingHeaderFilter/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/UsingHeaderFilter/Vue/index.html
+++ b/JSDemos/Demos/TreeList/UsingHeaderFilter/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/UsingHeaderFilter/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/UsingHeaderFilter/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/jszip/dist/jszip.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/UsingSearchPanel/Angular/index.html
+++ b/JSDemos/Demos/TreeList/UsingSearchPanel/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/UsingSearchPanel/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/UsingSearchPanel/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/UsingSearchPanel/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/UsingSearchPanel/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/UsingSearchPanel/React/index.html
+++ b/JSDemos/Demos/TreeList/UsingSearchPanel/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/UsingSearchPanel/Vue/index.html
+++ b/JSDemos/Demos/TreeList/UsingSearchPanel/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/UsingSearchPanel/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/UsingSearchPanel/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeList/WebAPIService/Angular/index.html
+++ b/JSDemos/Demos/TreeList/WebAPIService/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/WebAPIService/AngularJS/index.html
+++ b/JSDemos/Demos/TreeList/WebAPIService/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeList/WebAPIService/Knockout/index.html
+++ b/JSDemos/Demos/TreeList/WebAPIService/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>

--- a/JSDemos/Demos/TreeList/WebAPIService/React/index.html
+++ b/JSDemos/Demos/TreeList/WebAPIService/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeList/WebAPIService/Vue/index.html
+++ b/JSDemos/Demos/TreeList/WebAPIService/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeList/WebAPIService/jQuery/index.html
+++ b/JSDemos/Demos/TreeList/WebAPIService/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>

--- a/JSDemos/Demos/TreeView/ContextMenuIntegration/Angular/index.html
+++ b/JSDemos/Demos/TreeView/ContextMenuIntegration/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/ContextMenuIntegration/AngularJS/index.html
+++ b/JSDemos/Demos/TreeView/ContextMenuIntegration/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeView/ContextMenuIntegration/Knockout/index.html
+++ b/JSDemos/Demos/TreeView/ContextMenuIntegration/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeView/ContextMenuIntegration/React/index.html
+++ b/JSDemos/Demos/TreeView/ContextMenuIntegration/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeView/ContextMenuIntegration/Vue/index.html
+++ b/JSDemos/Demos/TreeView/ContextMenuIntegration/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/ContextMenuIntegration/jQuery/index.html
+++ b/JSDemos/Demos/TreeView/ContextMenuIntegration/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeView/DragAndDropHierarchicalDataStructure/Angular/index.html
+++ b/JSDemos/Demos/TreeView/DragAndDropHierarchicalDataStructure/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/DragAndDropHierarchicalDataStructure/AngularJS/index.html
+++ b/JSDemos/Demos/TreeView/DragAndDropHierarchicalDataStructure/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeView/DragAndDropHierarchicalDataStructure/Knockout/index.html
+++ b/JSDemos/Demos/TreeView/DragAndDropHierarchicalDataStructure/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../js/jquery.min.js"></script>
     <script src="../../../../js/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../css/dx.light.css" />
     <script src="../../../../js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeView/DragAndDropHierarchicalDataStructure/React/index.html
+++ b/JSDemos/Demos/TreeView/DragAndDropHierarchicalDataStructure/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeView/DragAndDropHierarchicalDataStructure/Vue/index.html
+++ b/JSDemos/Demos/TreeView/DragAndDropHierarchicalDataStructure/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/DragAndDropHierarchicalDataStructure/jQuery/index.html
+++ b/JSDemos/Demos/TreeView/DragAndDropHierarchicalDataStructure/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeView/DragAndDropPlainDataStructure/Angular/index.html
+++ b/JSDemos/Demos/TreeView/DragAndDropPlainDataStructure/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/DragAndDropPlainDataStructure/AngularJS/index.html
+++ b/JSDemos/Demos/TreeView/DragAndDropPlainDataStructure/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeView/DragAndDropPlainDataStructure/Knockout/index.html
+++ b/JSDemos/Demos/TreeView/DragAndDropPlainDataStructure/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../js/jquery.min.js"></script>
     <script src="../../../../js/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../css/dx.light.css" />
     <script src="../../../../js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeView/DragAndDropPlainDataStructure/React/index.html
+++ b/JSDemos/Demos/TreeView/DragAndDropPlainDataStructure/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeView/DragAndDropPlainDataStructure/Vue/index.html
+++ b/JSDemos/Demos/TreeView/DragAndDropPlainDataStructure/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/DragAndDropPlainDataStructure/jQuery/index.html
+++ b/JSDemos/Demos/TreeView/DragAndDropPlainDataStructure/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeView/FlatDataStructure/Angular/index.html
+++ b/JSDemos/Demos/TreeView/FlatDataStructure/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/FlatDataStructure/AngularJS/index.html
+++ b/JSDemos/Demos/TreeView/FlatDataStructure/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeView/FlatDataStructure/Knockout/index.html
+++ b/JSDemos/Demos/TreeView/FlatDataStructure/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeView/FlatDataStructure/React/index.html
+++ b/JSDemos/Demos/TreeView/FlatDataStructure/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeView/FlatDataStructure/Vue/index.html
+++ b/JSDemos/Demos/TreeView/FlatDataStructure/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/FlatDataStructure/jQuery/index.html
+++ b/JSDemos/Demos/TreeView/FlatDataStructure/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeView/HierarchicalDataStructure/Angular/index.html
+++ b/JSDemos/Demos/TreeView/HierarchicalDataStructure/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/HierarchicalDataStructure/AngularJS/index.html
+++ b/JSDemos/Demos/TreeView/HierarchicalDataStructure/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeView/HierarchicalDataStructure/Knockout/index.html
+++ b/JSDemos/Demos/TreeView/HierarchicalDataStructure/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeView/HierarchicalDataStructure/React/index.html
+++ b/JSDemos/Demos/TreeView/HierarchicalDataStructure/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeView/HierarchicalDataStructure/Vue/index.html
+++ b/JSDemos/Demos/TreeView/HierarchicalDataStructure/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/HierarchicalDataStructure/jQuery/index.html
+++ b/JSDemos/Demos/TreeView/HierarchicalDataStructure/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeView/ItemSelectionAndCustomization/Angular/index.html
+++ b/JSDemos/Demos/TreeView/ItemSelectionAndCustomization/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/ItemSelectionAndCustomization/AngularJS/index.html
+++ b/JSDemos/Demos/TreeView/ItemSelectionAndCustomization/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeView/ItemSelectionAndCustomization/Knockout/index.html
+++ b/JSDemos/Demos/TreeView/ItemSelectionAndCustomization/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeView/ItemSelectionAndCustomization/React/index.html
+++ b/JSDemos/Demos/TreeView/ItemSelectionAndCustomization/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeView/ItemSelectionAndCustomization/Vue/index.html
+++ b/JSDemos/Demos/TreeView/ItemSelectionAndCustomization/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/ItemSelectionAndCustomization/jQuery/index.html
+++ b/JSDemos/Demos/TreeView/ItemSelectionAndCustomization/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeView/LoadDataOnDemand/Angular/index.html
+++ b/JSDemos/Demos/TreeView/LoadDataOnDemand/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/LoadDataOnDemand/AngularJS/index.html
+++ b/JSDemos/Demos/TreeView/LoadDataOnDemand/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeView/LoadDataOnDemand/Knockout/index.html
+++ b/JSDemos/Demos/TreeView/LoadDataOnDemand/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeView/LoadDataOnDemand/React/index.html
+++ b/JSDemos/Demos/TreeView/LoadDataOnDemand/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/LoadDataOnDemand/Vue/index.html
+++ b/JSDemos/Demos/TreeView/LoadDataOnDemand/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/LoadDataOnDemand/jQuery/index.html
+++ b/JSDemos/Demos/TreeView/LoadDataOnDemand/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeView/TreeViewWithSearchBar/Angular/index.html
+++ b/JSDemos/Demos/TreeView/TreeViewWithSearchBar/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/TreeViewWithSearchBar/AngularJS/index.html
+++ b/JSDemos/Demos/TreeView/TreeViewWithSearchBar/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeView/TreeViewWithSearchBar/Knockout/index.html
+++ b/JSDemos/Demos/TreeView/TreeViewWithSearchBar/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeView/TreeViewWithSearchBar/React/index.html
+++ b/JSDemos/Demos/TreeView/TreeViewWithSearchBar/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/TreeView/TreeViewWithSearchBar/Vue/index.html
+++ b/JSDemos/Demos/TreeView/TreeViewWithSearchBar/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/TreeViewWithSearchBar/jQuery/index.html
+++ b/JSDemos/Demos/TreeView/TreeViewWithSearchBar/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeView/VirtualMode/Angular/index.html
+++ b/JSDemos/Demos/TreeView/VirtualMode/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/VirtualMode/AngularJS/index.html
+++ b/JSDemos/Demos/TreeView/VirtualMode/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/TreeView/VirtualMode/Knockout/index.html
+++ b/JSDemos/Demos/TreeView/VirtualMode/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/TreeView/VirtualMode/React/index.html
+++ b/JSDemos/Demos/TreeView/VirtualMode/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/VirtualMode/Vue/index.html
+++ b/JSDemos/Demos/TreeView/VirtualMode/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/TreeView/VirtualMode/jQuery/index.html
+++ b/JSDemos/Demos/TreeView/VirtualMode/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Validation/Overview/Angular/index.html
+++ b/JSDemos/Demos/Validation/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Validation/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/Validation/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/Validation/Overview/Knockout/index.html
+++ b/JSDemos/Demos/Validation/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/Validation/Overview/React/index.html
+++ b/JSDemos/Demos/Validation/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/Validation/Overview/Vue/index.html
+++ b/JSDemos/Demos/Validation/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Validation/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Validation/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/VectorMap/AreaWithLabelsAndTwoLegends/Angular/index.html
+++ b/JSDemos/Demos/VectorMap/AreaWithLabelsAndTwoLegends/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/AreaWithLabelsAndTwoLegends/AngularJS/index.html
+++ b/JSDemos/Demos/VectorMap/AreaWithLabelsAndTwoLegends/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/VectorMap/AreaWithLabelsAndTwoLegends/Knockout/index.html
+++ b/JSDemos/Demos/VectorMap/AreaWithLabelsAndTwoLegends/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/AreaWithLabelsAndTwoLegends/React/index.html
+++ b/JSDemos/Demos/VectorMap/AreaWithLabelsAndTwoLegends/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/VectorMap/AreaWithLabelsAndTwoLegends/Vue/index.html
+++ b/JSDemos/Demos/VectorMap/AreaWithLabelsAndTwoLegends/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/AreaWithLabelsAndTwoLegends/jQuery/index.html
+++ b/JSDemos/Demos/VectorMap/AreaWithLabelsAndTwoLegends/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/BubbleMarkers/Angular/index.html
+++ b/JSDemos/Demos/VectorMap/BubbleMarkers/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/BubbleMarkers/AngularJS/index.html
+++ b/JSDemos/Demos/VectorMap/BubbleMarkers/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/VectorMap/BubbleMarkers/Knockout/index.html
+++ b/JSDemos/Demos/VectorMap/BubbleMarkers/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/BubbleMarkers/React/index.html
+++ b/JSDemos/Demos/VectorMap/BubbleMarkers/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/VectorMap/BubbleMarkers/Vue/index.html
+++ b/JSDemos/Demos/VectorMap/BubbleMarkers/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/BubbleMarkers/jQuery/index.html
+++ b/JSDemos/Demos/VectorMap/BubbleMarkers/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/ColorsCustomization/Angular/index.html
+++ b/JSDemos/Demos/VectorMap/ColorsCustomization/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/ColorsCustomization/AngularJS/index.html
+++ b/JSDemos/Demos/VectorMap/ColorsCustomization/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/VectorMap/ColorsCustomization/Knockout/index.html
+++ b/JSDemos/Demos/VectorMap/ColorsCustomization/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/ColorsCustomization/React/index.html
+++ b/JSDemos/Demos/VectorMap/ColorsCustomization/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/VectorMap/ColorsCustomization/Vue/index.html
+++ b/JSDemos/Demos/VectorMap/ColorsCustomization/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/ColorsCustomization/jQuery/index.html
+++ b/JSDemos/Demos/VectorMap/ColorsCustomization/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/CustomAnnotations/Angular/index.html
+++ b/JSDemos/Demos/VectorMap/CustomAnnotations/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/CustomAnnotations/React/index.html
+++ b/JSDemos/Demos/VectorMap/CustomAnnotations/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/VectorMap/CustomAnnotations/Vue/index.html
+++ b/JSDemos/Demos/VectorMap/CustomAnnotations/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/CustomAnnotations/jQuery/index.html
+++ b/JSDemos/Demos/VectorMap/CustomAnnotations/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/CustomMapData/Angular/index.html
+++ b/JSDemos/Demos/VectorMap/CustomMapData/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/CustomMapData/AngularJS/index.html
+++ b/JSDemos/Demos/VectorMap/CustomMapData/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/VectorMap/CustomMapData/Knockout/index.html
+++ b/JSDemos/Demos/VectorMap/CustomMapData/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/VectorMap/CustomMapData/React/index.html
+++ b/JSDemos/Demos/VectorMap/CustomMapData/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/VectorMap/CustomMapData/Vue/index.html
+++ b/JSDemos/Demos/VectorMap/CustomMapData/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/CustomMapData/jQuery/index.html
+++ b/JSDemos/Demos/VectorMap/CustomMapData/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/VectorMap/CustomProjection/Angular/index.html
+++ b/JSDemos/Demos/VectorMap/CustomProjection/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/CustomProjection/AngularJS/index.html
+++ b/JSDemos/Demos/VectorMap/CustomProjection/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/VectorMap/CustomProjection/Knockout/index.html
+++ b/JSDemos/Demos/VectorMap/CustomProjection/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/CustomProjection/React/index.html
+++ b/JSDemos/Demos/VectorMap/CustomProjection/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/VectorMap/CustomProjection/Vue/index.html
+++ b/JSDemos/Demos/VectorMap/CustomProjection/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/CustomProjection/jQuery/index.html
+++ b/JSDemos/Demos/VectorMap/CustomProjection/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/DynamicViewport/Angular/index.html
+++ b/JSDemos/Demos/VectorMap/DynamicViewport/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/DynamicViewport/AngularJS/index.html
+++ b/JSDemos/Demos/VectorMap/DynamicViewport/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/VectorMap/DynamicViewport/Knockout/index.html
+++ b/JSDemos/Demos/VectorMap/DynamicViewport/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/DynamicViewport/React/index.html
+++ b/JSDemos/Demos/VectorMap/DynamicViewport/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/VectorMap/DynamicViewport/Vue/index.html
+++ b/JSDemos/Demos/VectorMap/DynamicViewport/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/DynamicViewport/jQuery/index.html
+++ b/JSDemos/Demos/VectorMap/DynamicViewport/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/FloorPlan/Angular/index.html
+++ b/JSDemos/Demos/VectorMap/FloorPlan/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/FloorPlan/AngularJS/index.html
+++ b/JSDemos/Demos/VectorMap/FloorPlan/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/VectorMap/FloorPlan/Knockout/index.html
+++ b/JSDemos/Demos/VectorMap/FloorPlan/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/VectorMap/FloorPlan/React/index.html
+++ b/JSDemos/Demos/VectorMap/FloorPlan/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/VectorMap/FloorPlan/Vue/index.html
+++ b/JSDemos/Demos/VectorMap/FloorPlan/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/FloorPlan/jQuery/index.html
+++ b/JSDemos/Demos/VectorMap/FloorPlan/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/JSDemos/Demos/VectorMap/ImageMarkers/Angular/index.html
+++ b/JSDemos/Demos/VectorMap/ImageMarkers/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/ImageMarkers/AngularJS/index.html
+++ b/JSDemos/Demos/VectorMap/ImageMarkers/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/VectorMap/ImageMarkers/Knockout/index.html
+++ b/JSDemos/Demos/VectorMap/ImageMarkers/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/ImageMarkers/React/index.html
+++ b/JSDemos/Demos/VectorMap/ImageMarkers/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/VectorMap/ImageMarkers/Vue/index.html
+++ b/JSDemos/Demos/VectorMap/ImageMarkers/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/ImageMarkers/jQuery/index.html
+++ b/JSDemos/Demos/VectorMap/ImageMarkers/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/MultipleLayers/Angular/index.html
+++ b/JSDemos/Demos/VectorMap/MultipleLayers/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/MultipleLayers/AngularJS/index.html
+++ b/JSDemos/Demos/VectorMap/MultipleLayers/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/VectorMap/MultipleLayers/Knockout/index.html
+++ b/JSDemos/Demos/VectorMap/MultipleLayers/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/MultipleLayers/React/index.html
+++ b/JSDemos/Demos/VectorMap/MultipleLayers/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/VectorMap/MultipleLayers/Vue/index.html
+++ b/JSDemos/Demos/VectorMap/MultipleLayers/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/MultipleLayers/jQuery/index.html
+++ b/JSDemos/Demos/VectorMap/MultipleLayers/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/Overview/Angular/index.html
+++ b/JSDemos/Demos/VectorMap/Overview/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/Overview/AngularJS/index.html
+++ b/JSDemos/Demos/VectorMap/Overview/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/VectorMap/Overview/Knockout/index.html
+++ b/JSDemos/Demos/VectorMap/Overview/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/Overview/React/index.html
+++ b/JSDemos/Demos/VectorMap/Overview/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/VectorMap/Overview/Vue/index.html
+++ b/JSDemos/Demos/VectorMap/Overview/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/Overview/jQuery/index.html
+++ b/JSDemos/Demos/VectorMap/Overview/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/Palette/Angular/index.html
+++ b/JSDemos/Demos/VectorMap/Palette/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/Palette/AngularJS/index.html
+++ b/JSDemos/Demos/VectorMap/Palette/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/VectorMap/Palette/Knockout/index.html
+++ b/JSDemos/Demos/VectorMap/Palette/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/Palette/React/index.html
+++ b/JSDemos/Demos/VectorMap/Palette/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/VectorMap/Palette/Vue/index.html
+++ b/JSDemos/Demos/VectorMap/Palette/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/Palette/jQuery/index.html
+++ b/JSDemos/Demos/VectorMap/Palette/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/PieMarkers/Angular/index.html
+++ b/JSDemos/Demos/VectorMap/PieMarkers/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/PieMarkers/AngularJS/index.html
+++ b/JSDemos/Demos/VectorMap/PieMarkers/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/VectorMap/PieMarkers/Knockout/index.html
+++ b/JSDemos/Demos/VectorMap/PieMarkers/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/PieMarkers/React/index.html
+++ b/JSDemos/Demos/VectorMap/PieMarkers/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/VectorMap/PieMarkers/Vue/index.html
+++ b/JSDemos/Demos/VectorMap/PieMarkers/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/PieMarkers/jQuery/index.html
+++ b/JSDemos/Demos/VectorMap/PieMarkers/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/TooltipHTMLSupport/Angular/index.html
+++ b/JSDemos/Demos/VectorMap/TooltipHTMLSupport/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/TooltipHTMLSupport/AngularJS/index.html
+++ b/JSDemos/Demos/VectorMap/TooltipHTMLSupport/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/VectorMap/TooltipHTMLSupport/Knockout/index.html
+++ b/JSDemos/Demos/VectorMap/TooltipHTMLSupport/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/TooltipHTMLSupport/React/index.html
+++ b/JSDemos/Demos/VectorMap/TooltipHTMLSupport/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/VectorMap/TooltipHTMLSupport/Vue/index.html
+++ b/JSDemos/Demos/VectorMap/TooltipHTMLSupport/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/TooltipHTMLSupport/jQuery/index.html
+++ b/JSDemos/Demos/VectorMap/TooltipHTMLSupport/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/ZoomingAndCentering/Angular/index.html
+++ b/JSDemos/Demos/VectorMap/ZoomingAndCentering/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/ZoomingAndCentering/AngularJS/index.html
+++ b/JSDemos/Demos/VectorMap/ZoomingAndCentering/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/JSDemos/Demos/VectorMap/ZoomingAndCentering/Knockout/index.html
+++ b/JSDemos/Demos/VectorMap/ZoomingAndCentering/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/JSDemos/Demos/VectorMap/ZoomingAndCentering/React/index.html
+++ b/JSDemos/Demos/VectorMap/ZoomingAndCentering/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
 

--- a/JSDemos/Demos/VectorMap/ZoomingAndCentering/Vue/index.html
+++ b/JSDemos/Demos/VectorMap/ZoomingAndCentering/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/VectorMap/ZoomingAndCentering/jQuery/index.html
+++ b/JSDemos/Demos/VectorMap/ZoomingAndCentering/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/vectormap-data/world.js"></script>

--- a/MVCDemos/App_Start/BundleConfig.cs
+++ b/MVCDemos/App_Start/BundleConfig.cs
@@ -22,7 +22,6 @@ namespace DevExtreme.MVC.Demos {
             var bundle = new StyleBundle(StyleBundlePath);
             bundle.Include("~/Content/DevExtreme/dx-diagram.min.css");
             bundle.Include("~/Content/DevExtreme/dx-gantt.min.css");
-            bundle.Include("~/Content/DevExtreme/dx.common.css");
             return bundle;
         }
 

--- a/MVCDemos/DevExtreme.MVC.Demos.csproj
+++ b/MVCDemos/DevExtreme.MVC.Demos.csproj
@@ -1108,7 +1108,6 @@
     <Content Include="Content\DevExtreme\dx-gantt.css" />
     <Content Include="Content\DevExtreme\dx-gantt.min.css" />
     <Content Include="Content\DevExtreme\dx.carmine.css" />
-    <Content Include="Content\DevExtreme\dx.common.css" />
     <Content Include="Content\DevExtreme\dx.contrast.compact.css" />
     <Content Include="Content\DevExtreme\dx.contrast.css" />
     <Content Include="Content\DevExtreme\dx.dark.compact.css" />

--- a/NetCoreDemos/bundleconfig.json
+++ b/NetCoreDemos/bundleconfig.json
@@ -5,7 +5,6 @@
     "inputFiles": [
       "wwwroot/css/dx-diagram.min.css",
       "wwwroot/css/dx-gantt.min.css",
-      "wwwroot/css/dx.common.css",
       "wwwroot/DemoShell/hljs/highlightjs.gh.css"
     ]
   },

--- a/utils/templates/Angular/index.html
+++ b/utils/templates/Angular/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/utils/templates/AngularJS/index.html
+++ b/utils/templates/AngularJS/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/angular/angular.min.js"></script>
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>

--- a/utils/templates/Knockout/index.html
+++ b/utils/templates/Knockout/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/knockout/build/output/knockout-latest.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>

--- a/utils/templates/React/index.html
+++ b/utils/templates/React/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/utils/templates/Vue/index.html
+++ b/utils/templates/Vue/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/utils/templates/jQuery/index.html
+++ b/utils/templates/jQuery/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme/dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme/dist/js/dx.all.js"></script>
     <script src="data.js"></script>


### PR DESCRIPTION
Since 21.1, the content of `dx.common.css` is:
```
/*!
This file is kept for backward compatibility.
It is no longer required.
*/
```

https://cdnjs.cloudflare.com/ajax/libs/devextreme/20.2.3/css/dx.common.css
https://cdnjs.cloudflare.com/ajax/libs/devextreme/21.1.3/css/dx.common.css