### PR TITLE
DataGrid: Fix the issue with width and grouping in some demos.

### DIFF
--- a/JSDemos/Demos/DataGrid/ColumnChooser/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/ColumnChooser/Angular/app/app.component.html
@@ -2,7 +2,6 @@
   id="employees"
   [dataSource]="employees"
   [keyExpr]="'ID'"
-  parentIdExpr="Head_ID"
   [showRowLines]="true"
   [width]="'100%'"
   [showBorders]="true"

--- a/JSDemos/Demos/DataGrid/ColumnChooser/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/ColumnChooser/Angular/app/app.component.html
@@ -1,9 +1,10 @@
 <dx-data-grid
   id="employees"
   [dataSource]="employees"
-  keyExpr="ID"
+  [keyExpr]="'ID'"
   parentIdExpr="Head_ID"
   [showRowLines]="true"
+  [width]="'100%'"
   [showBorders]="true"
   [columnAutoWidth]="true"
 >

--- a/JSDemos/Demos/DataGrid/ColumnChooser/React/App.js
+++ b/JSDemos/Demos/DataGrid/ColumnChooser/React/App.js
@@ -48,10 +48,11 @@ class App extends React.Component {
         <DataGrid
           id="employees"
           dataSource={employees}
+          keyExpr="ID"
           columnAutoWidth={true}
           showRowLines={true}
+          width="100%"
           showBorders={true}
-          keyExpr="ID"
         >
           <Column dataField='FirstName' allowHiding={false} />
           <Column dataField='LastName' />

--- a/JSDemos/Demos/DataGrid/ColumnChooser/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/ColumnChooser/Vue/App.vue
@@ -3,10 +3,11 @@
     <DxDataGrid
       id="employees"
       :data-source="employees"
+      :key-expr="'ID'"
       :column-auto-width="true"
       :show-row-lines="true"
+      :width="'100%'"
       :show-borders="true"
-      key-expr="ID"
     >
       <DxColumn
         data-field="FirstName"

--- a/JSDemos/Demos/DataGrid/ColumnChooser/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/ColumnChooser/jQuery/index.js
@@ -28,6 +28,7 @@ $(() => {
     }],
     columnAutoWidth: true,
     showRowLines: true,
+    width: '100%',
     showBorders: true,
     columnChooser: {
       enabled: true,

--- a/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/Angular/app/app.component.html
@@ -1,7 +1,8 @@
 <dx-data-grid
   id="gridContainer"
   [dataSource]="companies"
-  keyExpr="ID"
+  [keyExpr]="'ID'"
+  [width]="'100%'"
   [showBorders]="true"
   (onExporting)="onExporting($event)"
 >

--- a/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/React/App.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/React/App.js
@@ -24,6 +24,7 @@ class App extends React.Component {
           id="gridContainer"
           dataSource={this.companies}
           keyExpr="ID"
+          width="100%"
           showBorders={true}
           onExporting={this.onExporting}>
 

--- a/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/Vue/App.vue
@@ -3,7 +3,8 @@
     <DxDataGrid
       id="gridContainer"
       :data-source="companies"
-      key-expr="ID"
+      :key-expr="'ID'"
+      :width="'100%'"
       :show-borders="true"
       @exporting="onExporting"
     >

--- a/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSCellCustomization/jQuery/index.js
@@ -2,6 +2,7 @@ $(() => {
   $('#gridContainer').dxDataGrid({
     dataSource: companies,
     keyExpr: 'ID',
+    width: '100%',
     showBorders: true,
     groupPanel: {
       visible: true,

--- a/JSDemos/Demos/DataGrid/ExcelJSOverview/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/ExcelJSOverview/Angular/app/app.component.html
@@ -1,7 +1,8 @@
 <dx-data-grid
   id="gridContainer"
   [dataSource]="employees"
-  keyExpr="ID"
+  [keyExpr]="'ID'"
+  [width]="'100%'"
   [showBorders]="true"
   (onExporting)="onExporting($event)"
 >

--- a/JSDemos/Demos/DataGrid/ExcelJSOverview/React/App.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSOverview/React/App.js
@@ -22,6 +22,7 @@ class App extends React.Component {
         id="gridContainer"
         dataSource={this.employees}
         keyExpr="ID"
+        width="100%"
         showBorders={true}
         onExporting={this.onExporting}>
 

--- a/JSDemos/Demos/DataGrid/ExcelJSOverview/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/ExcelJSOverview/Vue/App.vue
@@ -3,7 +3,8 @@
     <DxDataGrid
       id="gridContainer"
       :data-source="employees"
-      key-expr="ID"
+      :key-expr="'ID'"
+      :width="'100%'"
       :show-borders="true"
       @exporting="onExporting"
     >

--- a/JSDemos/Demos/DataGrid/ExcelJSOverview/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSOverview/jQuery/index.js
@@ -2,6 +2,7 @@ $(() => {
   $('#gridContainer').dxDataGrid({
     dataSource: employees,
     keyExpr: 'ID',
+    width: '100%',
     showBorders: true,
     selection: {
       mode: 'multiple',

--- a/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/Angular/app/app.component.html
@@ -1,7 +1,8 @@
 <dx-data-grid
   id="gridContainer"
   [dataSource]="dataSource"
-  keyExpr="ID"
+  [keyExpr]="'ID'"
+  [width]="'100%'"
   [columnHidingEnabled]="true"
   [showBorders]="true"
 >

--- a/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/React/App.js
+++ b/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/React/App.js
@@ -21,6 +21,7 @@ class App extends React.Component {
           dataSource={this.dataSource}
           keyExpr="ID"
           columnHidingEnabled={true}
+          width="100%"
           showBorders={true}>
           <Editing allowAdding={true} allowUpdating={true} mode="batch" />
           <Grouping contextMenuEnabled={true} expandMode="rowClick" />

--- a/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/Vue/App.vue
@@ -3,8 +3,9 @@
     <DxDataGrid
       id="gridContainer"
       :data-source="dataSource"
-      key-expr="ID"
+      :key-expr="'ID'"
       :column-hiding-enabled="true"
+      :width="'100%'"
       :show-borders="true"
     >
       <DxEditing

--- a/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/GridAdaptabilityOverview/jQuery/index.js
@@ -3,6 +3,7 @@ $(() => {
     dataSource: orders,
     keyExpr: 'ID',
     columnHidingEnabled: true,
+    width: '100%',
     showBorders: true,
     editing: {
       allowAdding: true,

--- a/JSDemos/Demos/DataGrid/MultiRowHeadersBands/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/MultiRowHeadersBands/Angular/app/app.component.html
@@ -4,8 +4,9 @@
 <dx-data-grid
   id="gridContainer"
   [dataSource]="countries"
-  keyExpr="ID"
+  [keyExpr]="'ID'"
   [columnAutoWidth]="true"
+  [width]="'100%'"
   [showBorders]="true"
   [allowColumnReordering]="true"
 >

--- a/JSDemos/Demos/DataGrid/MultiRowHeadersBands/React/App.js
+++ b/JSDemos/Demos/DataGrid/MultiRowHeadersBands/React/App.js
@@ -17,6 +17,7 @@ class App extends React.Component {
         keyExpr="ID"
         columnAutoWidth={true}
         allowColumnReordering={true}
+        width="100%"
         showBorders={true}
       >
         <ColumnChooser enabled={true} />

--- a/JSDemos/Demos/DataGrid/MultiRowHeadersBands/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/MultiRowHeadersBands/Vue/App.vue
@@ -2,9 +2,10 @@
   <DxDataGrid
     id="grid"
     :data-source="countries"
-    key-expr="ID"
+    :key-expr="'ID'"
     :column-auto-width="true"
     :allow-column-reordering="true"
+    :width="'100%'"
     :show-borders="true"
   >
     <DxColumnChooser :enabled="true"/>

--- a/JSDemos/Demos/DataGrid/MultiRowHeadersBands/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/MultiRowHeadersBands/jQuery/index.js
@@ -4,6 +4,7 @@ $(() => {
     keyExpr: 'ID',
     columnAutoWidth: true,
     allowColumnReordering: true,
+    width: '100%',
     showBorders: true,
     columnChooser: {
       enabled: true,

--- a/JSDemos/Demos/DataGrid/Overview/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/Overview/Angular/app/app.component.html
@@ -5,6 +5,7 @@
   [allowColumnReordering]="true"
   [rowAlternationEnabled]="true"
   [showBorders]="true"
+  [width]="'100%'"
   (onContentReady)="contentReady($event)"
 >
   <dxo-paging [pageSize]="10"></dxo-paging>

--- a/JSDemos/Demos/DataGrid/Overview/React/App.js
+++ b/JSDemos/Demos/DataGrid/Overview/React/App.js
@@ -43,6 +43,7 @@ class App extends React.Component {
         allowColumnReordering={true}
         rowAlternationEnabled={true}
         showBorders={true}
+        width="100%"
         onContentReady={this.onContentReady}
       >
         <GroupPanel visible={true} />

--- a/JSDemos/Demos/DataGrid/Overview/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/Overview/Vue/App.vue
@@ -5,6 +5,7 @@
     :allow-column-reordering="true"
     :row-alternation-enabled="true"
     :show-borders="true"
+    :width="'100%'"
     @content-ready="onContentReady"
   >
     <DxColumn

--- a/JSDemos/Demos/DataGrid/Overview/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/Overview/jQuery/index.js
@@ -31,6 +31,7 @@ $(() => {
     allowColumnReordering: true,
     rowAlternationEnabled: true,
     showBorders: true,
+    width: '100%',
     columns: [
       {
         dataField: 'Product',

--- a/JSDemos/Demos/DataGrid/PDFCellCustomization/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/PDFCellCustomization/Angular/app/app.component.html
@@ -1,7 +1,8 @@
 <dx-data-grid
   id="gridContainer"
   [dataSource]="companies"
-  keyExpr="ID"
+  [keyExpr]="'ID'"
+  [width]="'100%'"
   [showBorders]="true"
   (onExporting)="onExporting($event)"
 >

--- a/JSDemos/Demos/DataGrid/PDFCellCustomization/React/App.js
+++ b/JSDemos/Demos/DataGrid/PDFCellCustomization/React/App.js
@@ -61,6 +61,7 @@ export default function App() {
         id="gridContainer"
         dataSource={companies}
         keyExpr="ID"
+        width="100%"
         showBorders={true}
         onExporting={onExporting}>
 

--- a/JSDemos/Demos/DataGrid/PDFCellCustomization/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/PDFCellCustomization/Vue/App.vue
@@ -2,8 +2,9 @@
   <div>
     <DxDataGrid
       id="gridContainer"
-      key-expr="ID"
+      :key-expr="'ID'"
       :data-source="companies"
+      :width="'100%'"
       :show-borders="true"
       @exporting="onExporting"
     >

--- a/JSDemos/Demos/DataGrid/PDFCellCustomization/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/PDFCellCustomization/jQuery/index.js
@@ -6,6 +6,7 @@ $(() => {
   $('#gridContainer').dxDataGrid({
     dataSource: companies,
     keyExpr: 'ID',
+    width: '100%',
     showBorders: true,
     groupPanel: {
       visible: true,

--- a/JSDemos/Demos/DataGrid/RecordGrouping/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/RecordGrouping/Angular/app/app.component.html
@@ -1,8 +1,9 @@
 <dx-data-grid
   id="gridContainer"
   [dataSource]="customers"
-  keyExpr="ID"
+  [keyExpr]="'ID'"
   [allowColumnReordering]="true"
+  [width]="'100%'"
   [showBorders]="true"
 >
   <dxi-column dataField="CompanyName"></dxi-column>

--- a/JSDemos/Demos/DataGrid/RecordGrouping/React/App.js
+++ b/JSDemos/Demos/DataGrid/RecordGrouping/React/App.js
@@ -28,6 +28,7 @@ class App extends React.Component {
           dataSource={customers}
           keyExpr="ID"
           allowColumnReordering={true}
+          width="100%"
           showBorders={true}
         >
           <GroupPanel visible={true} />

--- a/JSDemos/Demos/DataGrid/RecordGrouping/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/RecordGrouping/Vue/App.vue
@@ -3,7 +3,8 @@
     <DxDataGrid
       :allow-column-reordering="true"
       :data-source="customers"
-      key-expr="ID"
+      :key-expr="'ID'"
+      :width="'100%'"
       :show-borders="true"
     >
 

--- a/JSDemos/Demos/DataGrid/RecordGrouping/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/RecordGrouping/jQuery/index.js
@@ -3,6 +3,7 @@ $(() => {
     dataSource: customers,
     keyExpr: 'ID',
     allowColumnReordering: true,
+    width: '100%',
     showBorders: true,
     grouping: {
       autoExpandAll: true,

--- a/JSDemos/Demos/DataGrid/RemoteGrouping/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/RemoteGrouping/Angular/app/app.component.html
@@ -3,6 +3,7 @@
   [dataSource]="dataSource"
   [remoteOperations]="{ groupPaging: true }"
   [wordWrapEnabled]="true"
+  [width]="'100%'"
   [showBorders]="true"
 >
   <dxo-scrolling mode="virtual"></dxo-scrolling>

--- a/JSDemos/Demos/DataGrid/RemoteGrouping/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/RemoteGrouping/Vue/App.vue
@@ -3,6 +3,7 @@
     id="gridContainer"
     :word-wrap-enabled="true"
     :data-source="dataSource"
+    :width="'100%'"
     :show-borders="true"
   >
     <DxRemoteOperations :group-paging="true"/>

--- a/JSDemos/Demos/DataGrid/RemoteGrouping/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/RemoteGrouping/jQuery/index.js
@@ -15,6 +15,7 @@ $(() => {
       visible: true,
     },
     wordWrapEnabled: true,
+    width: '100%',
     showBorders: true,
     columns: [{
       dataField: 'Id',

--- a/JSDemos/Demos/DataGrid/StatePersistence/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/StatePersistence/Angular/app/app.component.html
@@ -8,12 +8,12 @@
 >
 <dx-data-grid
   id="gridContainer"
-  #dataGrid
   [dataSource]="orders"
+  [keyExpr]="'ID'"
   [allowColumnResizing]="true"
   [allowColumnReordering]="true"
+  [width]="'100%'"
   [showBorders]="true"
-  keyExpr="ID"
 >
   <dxo-selection mode="single"></dxo-selection>
   <dxo-filter-row [visible]="true"></dxo-filter-row>

--- a/JSDemos/Demos/DataGrid/StatePersistence/React/App.js
+++ b/JSDemos/Demos/DataGrid/StatePersistence/React/App.js
@@ -29,12 +29,13 @@ class App extends React.Component {
         <div id="descContainer">Sort and filter data, group, reorder and resize columns, change page numbers and page size. Once you are done, <a onClick={this.onRefreshClick}>refresh</a> the web page to see that the grid’s state is automatically persisted to continue working from where you stopped or you can <a onClick={this.onStateResetClick}>reset</a> the grid to its initial state.</div>
         <DataGrid
           id="gridContainer"
+          ref={this.dataGrid}
           dataSource={this.orders}
+          keyExpr="ID"
           allowColumnResizing={true}
           allowColumnReordering={true}
-          showBorders={true}
-          keyExpr="ID"
-          ref={this.dataGrid}>
+          width="100%"
+          showBorders={true}>
           <Selection mode="single" />
           <FilterRow visible={true} />
           <GroupPanel visible={true} />

--- a/JSDemos/Demos/DataGrid/StatePersistence/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/StatePersistence/Vue/App.vue
@@ -9,10 +9,11 @@
       id="gridContainer"
       ref="dataGrid"
       :data-source="orders"
+      :key-expr="'ID'"
       :allow-column-resizing="true"
       :allow-column-reordering="true"
+      :width="'100%'"
       :show-borders="true"
-      key-expr="ID"
     >
       <DxSelection mode="single"/>
       <DxFilterRow :visible="true"/>

--- a/JSDemos/Demos/DataGrid/StatePersistence/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/StatePersistence/jQuery/index.js
@@ -4,6 +4,7 @@ $(() => {
     keyExpr: 'ID',
     allowColumnReordering: true,
     allowColumnResizing: true,
+    width: '100%',
     showBorders: true,
     selection: {
       mode: 'single',

--- a/JSDemos/Demos/DataGrid/WebAPIService/Angular/app/app.component.html
+++ b/JSDemos/Demos/DataGrid/WebAPIService/Angular/app/app.component.html
@@ -1,6 +1,7 @@
 <dx-data-grid
   [dataSource]="dataSource"
   [remoteOperations]="true"
+  [width]="'100%'"
   [height]="600"
   [showBorders]="true"
 >

--- a/JSDemos/Demos/DataGrid/WebAPIService/React/App.js
+++ b/JSDemos/Demos/DataGrid/WebAPIService/React/App.js
@@ -58,6 +58,7 @@ class App extends React.Component {
       <DataGrid
         dataSource={dataSource}
         showBorders={true}
+        width="100%"
         height={600}
         remoteOperations={true}
       >

--- a/JSDemos/Demos/DataGrid/WebAPIService/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/WebAPIService/Vue/App.vue
@@ -3,6 +3,7 @@
     :show-borders="true"
     :data-source="dataSource"
     :remote-operations="true"
+    :width="'100%'"
     :height="600"
   >
     <DxColumn

--- a/JSDemos/Demos/DataGrid/WebAPIService/jQuery/index.js
+++ b/JSDemos/Demos/DataGrid/WebAPIService/jQuery/index.js
@@ -85,6 +85,7 @@ $(() => {
     scrolling: {
       mode: 'virtual',
     },
+    width: '100%',
     height: 600,
     showBorders: true,
     masterDetail: {

--- a/MVCDemos/Views/DataGrid/ColumnChooser.cshtml
+++ b/MVCDemos/Views/DataGrid/ColumnChooser.cshtml
@@ -35,6 +35,7 @@
 
     })
     .ColumnAutoWidth(true)
+    .Width("100%")
     .ShowRowLines(true)
     .ShowBorders(true)
     .ColumnChooser(cc => {
@@ -62,7 +63,7 @@
 
 <div class="options">
     <div class="caption">Options</div>
-    
+
     <div class='selectboxes-container'>
         <div class="option">
             <span>Column chooser mode</span>
@@ -102,7 +103,7 @@
 
         </div>
     </div>
-    
+
     <div class='checkboxes-container'>
         <div class="option">
             @(Html.DevExtreme().CheckBox()

--- a/MVCDemos/Views/DataGrid/ExcelJSCellCustomization.cshtml
+++ b/MVCDemos/Views/DataGrid/ExcelJSCellCustomization.cshtml
@@ -10,6 +10,7 @@
         .ID("gridContainer")
         .DataSource(new JS("companies"))
         .KeyExpr("ID")
+        .Width("100%")
         .ShowBorders(true)
         .GroupPanel(groupPanel => groupPanel.Visible(true))
         .Grouping(grouping => grouping.AutoExpandAll(true))

--- a/MVCDemos/Views/DataGrid/ExcelJSOverview.cshtml
+++ b/MVCDemos/Views/DataGrid/ExcelJSOverview.cshtml
@@ -12,6 +12,7 @@
     .DataSource(Model, "ID")
     .Selection(s => s.Mode(SelectionMode.Multiple))
     .Export(e => e.Enabled(true).AllowExportSelectedData(true))
+    .Width("100%")
     .ShowBorders(true)
     .GroupPanel(groupPanel => groupPanel.Visible(true))
     .Grouping(grouping => grouping.AutoExpandAll(true))

--- a/MVCDemos/Views/DataGrid/GridAdaptabilityOverview.cshtml
+++ b/MVCDemos/Views/DataGrid/GridAdaptabilityOverview.cshtml
@@ -6,6 +6,7 @@
     .ID("gridContainer")
     .DataSource(Model, new[] { "ID" })
     .ColumnHidingEnabled(true)
+    .Width("100%")
     .ShowBorders(true)
     .Editing(e => e
         .AllowAdding(true)

--- a/MVCDemos/Views/DataGrid/MultiRowHeadersBands.cshtml
+++ b/MVCDemos/Views/DataGrid/MultiRowHeadersBands.cshtml
@@ -9,6 +9,7 @@
     .DataSource(Model, "ID")
     .ColumnAutoWidth(true)
     .AllowColumnReordering(true)
+    .Width("100%")
     .ShowBorders(true)
     .ColumnChooser(c => c.Enabled(true))
     .Columns(c => {

--- a/MVCDemos/Views/DataGrid/Overview.cshtml
+++ b/MVCDemos/Views/DataGrid/Overview.cshtml
@@ -15,6 +15,7 @@
     .RemoteOperations(false)
     .AllowColumnReordering(true)
     .RowAlternationEnabled(true)
+    .Width("100%")
     .ShowBorders(true)
     .OnContentReady("contentReady")
     .Paging(p => p.PageSize(10))

--- a/MVCDemos/Views/DataGrid/PDFCellCustomization.cshtml
+++ b/MVCDemos/Views/DataGrid/PDFCellCustomization.cshtml
@@ -11,6 +11,7 @@
         .ID("gridContainer")
         .DataSource(new JS("companies"))
         .KeyExpr("ID")
+        .Width("100%")
         .ShowBorders(true)
         .GroupPanel(groupPanel => groupPanel.Visible(true))
         .Grouping(grouping => grouping.AutoExpandAll(true))

--- a/MVCDemos/Views/DataGrid/RecordGrouping.cshtml
+++ b/MVCDemos/Views/DataGrid/RecordGrouping.cshtml
@@ -13,6 +13,7 @@
             .GroupIndex(0);
     })
     .AllowColumnReordering(true)
+    .Width("100%")
     .ShowBorders(true)
     .Grouping(grouping => grouping.AutoExpandAll(true))
     .SearchPanel(searchPanel => searchPanel.Visible(true))

--- a/MVCDemos/Views/DataGrid/RemoteGrouping.cshtml
+++ b/MVCDemos/Views/DataGrid/RemoteGrouping.cshtml
@@ -11,6 +11,7 @@
     .GroupPanel(groupPanel => groupPanel.Visible(true))
     .Grouping(grouping => grouping.AutoExpandAll(false))
     .WordWrapEnabled(true)
+    .Width("100%")
     .ShowBorders(true)
 
     .Columns(columns => {

--- a/MVCDemos/Views/DataGrid/StatePersistence.cshtml
+++ b/MVCDemos/Views/DataGrid/StatePersistence.cshtml
@@ -9,6 +9,7 @@
     .DataSource(Model, "ID")
     .AllowColumnReordering(true)
     .AllowColumnResizing(true)
+    .Width("100%")
     .ShowBorders(true)
     .Selection(s => s.Mode(SelectionMode.Single))
     .FilterRow(r => r.Visible(true))

--- a/MVCDemos/Views/DataGrid/WebAPIService.cshtml
+++ b/MVCDemos/Views/DataGrid/WebAPIService.cshtml
@@ -35,6 +35,7 @@
     .HeaderFilter(f => f.Visible(true))
     .GroupPanel(p => p.Visible(true))
     .Scrolling(s => s.Mode(GridScrollingMode.Virtual))
+    .Width("100%")
     .Height(600)
     .ShowBorders(true)
     .MasterDetail(md => md

--- a/NetCoreDemos/Views/DataGrid/ColumnChooser.cshtml
+++ b/NetCoreDemos/Views/DataGrid/ColumnChooser.cshtml
@@ -35,6 +35,7 @@
 
     })
     .ColumnAutoWidth(true)
+    .Width("100%")
     .ShowRowLines(true)
     .ShowBorders(true)
     .ColumnChooser(cc => {
@@ -62,7 +63,7 @@
 
 <div class="options">
     <div class="caption">Options</div>
-    
+
     <div class='selectboxes-container'>
         <div class="option">
             <span>Column chooser mode</span>
@@ -102,7 +103,7 @@
 
         </div>
     </div>
-    
+
     <div class='checkboxes-container'>
         <div class="option">
             @(Html.DevExtreme().CheckBox()

--- a/NetCoreDemos/Views/DataGrid/ExcelJSCellCustomization.cshtml
+++ b/NetCoreDemos/Views/DataGrid/ExcelJSCellCustomization.cshtml
@@ -10,6 +10,7 @@
     .ID("gridContainer")
     .DataSource(new JS("companies"))
     .KeyExpr("ID")
+    .Width("100%")
     .ShowBorders(true)
     .GroupPanel(groupPanel => groupPanel.Visible(true))
     .Grouping(grouping => grouping.AutoExpandAll(true))

--- a/NetCoreDemos/Views/DataGrid/ExcelJSOverview.cshtml
+++ b/NetCoreDemos/Views/DataGrid/ExcelJSOverview.cshtml
@@ -12,6 +12,7 @@
         .DataSource(Model, "ID")
         .Selection(s => s.Mode(SelectionMode.Multiple))
         .Export(e => e.Enabled(true).AllowExportSelectedData(true))
+        .Width("100%")
         .ShowBorders(true)
         .GroupPanel(groupPanel => groupPanel.Visible(true))
         .Grouping(grouping => grouping.AutoExpandAll(true))

--- a/NetCoreDemos/Views/DataGrid/GridAdaptabilityOverview.cshtml
+++ b/NetCoreDemos/Views/DataGrid/GridAdaptabilityOverview.cshtml
@@ -6,6 +6,7 @@
     .ID("gridContainer")
     .DataSource(Model, new[] { "ID" })
     .ColumnHidingEnabled(true)
+    .Width("100%")
     .ShowBorders(true)
     .Editing(e => e
         .AllowAdding(true)

--- a/NetCoreDemos/Views/DataGrid/MultiRowHeadersBands.cshtml
+++ b/NetCoreDemos/Views/DataGrid/MultiRowHeadersBands.cshtml
@@ -9,6 +9,7 @@
     .DataSource(Model, "ID")
     .ColumnAutoWidth(true)
     .AllowColumnReordering(true)
+    .Width("100%")
     .ShowBorders(true)
     .ColumnChooser(c => c.Enabled(true))
     .Columns(c => {

--- a/NetCoreDemos/Views/DataGrid/Overview.cshtml
+++ b/NetCoreDemos/Views/DataGrid/Overview.cshtml
@@ -15,6 +15,7 @@
     .RemoteOperations(false)
     .AllowColumnReordering(true)
     .RowAlternationEnabled(true)
+    .Width("100%")
     .ShowBorders(true)
     .OnContentReady("contentReady")
     .Paging(p => p.PageSize(10))

--- a/NetCoreDemos/Views/DataGrid/PDFCellCustomization.cshtml
+++ b/NetCoreDemos/Views/DataGrid/PDFCellCustomization.cshtml
@@ -11,6 +11,7 @@
     .ID("gridContainer")
     .DataSource(new JS("companies"))
     .KeyExpr("ID")
+    .Width("100%")
     .ShowBorders(true)
     .GroupPanel(groupPanel => groupPanel.Visible(true))
     .Grouping(grouping => grouping.AutoExpandAll(true))

--- a/NetCoreDemos/Views/DataGrid/RecordGrouping.cshtml
+++ b/NetCoreDemos/Views/DataGrid/RecordGrouping.cshtml
@@ -13,6 +13,7 @@
             .GroupIndex(0);
     })
     .AllowColumnReordering(true)
+    .Width("100%")
     .ShowBorders(true)
     .Grouping(grouping => grouping.AutoExpandAll(true))
     .SearchPanel(searchPanel => searchPanel.Visible(true))

--- a/NetCoreDemos/Views/DataGrid/RemoteGrouping.cshtml
+++ b/NetCoreDemos/Views/DataGrid/RemoteGrouping.cshtml
@@ -11,6 +11,7 @@
     .Grouping(g => g.AutoExpandAll(false))
     .GroupPanel(gp => gp.Visible(true))
     .WordWrapEnabled(true)
+    .Width("100%")
     .ShowBorders(true)
 
     .Columns(columns => {

--- a/NetCoreDemos/Views/DataGrid/StatePersistence.cshtml
+++ b/NetCoreDemos/Views/DataGrid/StatePersistence.cshtml
@@ -9,6 +9,7 @@
     .DataSource(Model, "ID")
     .AllowColumnReordering(true)
     .AllowColumnResizing(true)
+    .Width("100%")
     .ShowBorders(true)
     .Selection(s => s.Mode(SelectionMode.Single))
     .FilterRow(r => r.Visible(true))

--- a/NetCoreDemos/Views/DataGrid/WebAPIService.cshtml
+++ b/NetCoreDemos/Views/DataGrid/WebAPIService.cshtml
@@ -35,6 +35,7 @@
     .HeaderFilter(f => f.Visible(true))
     .GroupPanel(p => p.Visible(true))
     .Scrolling(s => s.Mode(GridScrollingMode.Virtual))
+    .Width("100%")
     .Height(600)
     .ShowBorders(true)
     .MasterDetail(md => md


### PR DESCRIPTION
Fixed the problem of reducing the width of the DataGrid in some demos.

**Problem:**
If all auto-width columns are grouped, the width of the DataGrid is reduced.

**Solution:**
Width set: 100%, in demos that allow column grouping.