### PR TITLE
Fix "subscribe" Deprecate

### DIFF
--- a/JSDemos/Demos/Diagram/Adaptability/Angular/app/app.component.ts
+++ b/JSDemos/Demos/Diagram/Adaptability/Angular/app/app.component.ts
@@ -21,10 +21,9 @@ export class AppComponent {
   @ViewChild(DxDiagramComponent, { static: false }) diagram: DxDiagramComponent;
 
   constructor(http: HttpClient) {
-    http.get('../../../../data/diagram-flow.json').subscribe((data) => {
-      this.diagram.instance.import(JSON.stringify(data));
-    }, (err) => {
-      throw 'Data Loading Error';
+    http.get('../../../../data/diagram-flow.json').subscribe({
+      next: (data) => { this.diagram.instance.import(JSON.stringify(data)); },
+      error: (err) => { throw 'Data Loading Error'; },
     });
   }
 }

--- a/JSDemos/Demos/Diagram/Containers/Angular/app/app.component.ts
+++ b/JSDemos/Demos/Diagram/Containers/Angular/app/app.component.ts
@@ -21,10 +21,9 @@ export class AppComponent {
   @ViewChild(DxDiagramComponent, { static: false }) diagram: DxDiagramComponent;
 
   constructor(http: HttpClient) {
-    http.get('../../../../data/diagram-structure.json').subscribe((data) => {
-      this.diagram.instance.import(JSON.stringify(data));
-    }, (err) => {
-      throw 'Data Loading Error';
+    http.get('../../../../data/diagram-structure.json').subscribe({
+      next: (data) => { this.diagram.instance.import(JSON.stringify(data)); },
+      error: (err) => { throw 'Data Loading Error'; },
     });
   }
 }

--- a/JSDemos/Demos/Diagram/CustomShapesWithIcons/Angular/app/app.component.ts
+++ b/JSDemos/Demos/Diagram/CustomShapesWithIcons/Angular/app/app.component.ts
@@ -21,10 +21,9 @@ export class AppComponent {
   @ViewChild(DxDiagramComponent, { static: false }) diagram: DxDiagramComponent;
 
   constructor(http: HttpClient) {
-    http.get('../../../../data/diagram-hardware.json').subscribe((data) => {
-      this.diagram.instance.import(JSON.stringify(data));
-    }, (err) => {
-      throw 'Data Loading Error';
+    http.get('../../../../data/diagram-hardware.json').subscribe({
+      next: (data) => { this.diagram.instance.import(JSON.stringify(data)); },
+      error: (err) => { throw 'Data Loading Error'; },
     });
   }
 }

--- a/JSDemos/Demos/Diagram/CustomShapesWithTexts/Angular/app/app.component.ts
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTexts/Angular/app/app.component.ts
@@ -27,10 +27,9 @@ export class AppComponent {
   constructor(service: Service, http: HttpClient) {
     this.employees = service.getEmployees();
 
-    http.get('../../../../data/diagram-employees.json').subscribe((data) => {
-      this.diagram.instance.import(JSON.stringify(data));
-    }, (err) => {
-      throw 'Data Loading Error';
+    http.get('../../../../data/diagram-employees.json').subscribe({
+      next: (data) => { this.diagram.instance.import(JSON.stringify(data)); },
+      error: (err) => { throw 'Data Loading Error'; },
     });
   }
 }

--- a/JSDemos/Demos/Diagram/Overview/Angular/app/app.component.ts
+++ b/JSDemos/Demos/Diagram/Overview/Angular/app/app.component.ts
@@ -21,10 +21,9 @@ export class AppComponent {
   @ViewChild(DxDiagramComponent, { static: false }) diagram: DxDiagramComponent;
 
   constructor(http: HttpClient) {
-    http.get('../../../../data/diagram-flow.json').subscribe((data) => {
-      this.diagram.instance.import(JSON.stringify(data));
-    }, (err) => {
-      throw 'Data Loading Error';
+    http.get('../../../../data/diagram-flow.json').subscribe({
+      next: (data) => { this.diagram.instance.import(JSON.stringify(data)); },
+      error: (err) => { throw 'Data Loading Error'; },
     });
   }
 }

--- a/JSDemos/Demos/Diagram/ReadOnly/Angular/app/app.component.ts
+++ b/JSDemos/Demos/Diagram/ReadOnly/Angular/app/app.component.ts
@@ -21,10 +21,9 @@ export class AppComponent {
   @ViewChild(DxDiagramComponent, { static: false }) diagram: DxDiagramComponent;
 
   constructor(http: HttpClient) {
-    http.get('../../../../data/diagram-structure.json').subscribe((data) => {
-      this.diagram.instance.import(JSON.stringify(data));
-    }, (err) => {
-      throw 'Data Loading Error';
+    http.get('../../../../data/diagram-structure.json').subscribe({
+      next: (data) => { this.diagram.instance.import(JSON.stringify(data)); },
+      error: (err) => { throw 'Data Loading Error'; },
     });
   }
 }

--- a/JSDemos/Demos/Diagram/UICustomization/Angular/app/app.component.ts
+++ b/JSDemos/Demos/Diagram/UICustomization/Angular/app/app.component.ts
@@ -22,10 +22,9 @@ export class AppComponent {
   @ViewChild(DxDiagramComponent, { static: false }) diagram: DxDiagramComponent;
 
   constructor(http: HttpClient) {
-    http.get('../../../../data/diagram-flow.json').subscribe((data) => {
-      this.diagram.instance.import(JSON.stringify(data));
-    }, (err) => {
-      throw 'Data Loading Error';
+    http.get('../../../../data/diagram-flow.json').subscribe({
+      next: (data) => { this.diagram.instance.import(JSON.stringify(data)); },
+      error: (err) => { throw 'Data Loading Error'; },
     });
   }
 


### PR DESCRIPTION
Fix "subscribe" Deprecate: https://github.com/angular/angular/issues/44708 (may block TS upgrade):
> error  'subscribe' is deprecated. Instead of passing separate callback arguments, use an observer argument. Signatures taking separate callback arguments will be removed in v8. Details: https://rxjs.dev/deprecations/subscribe-arguments  deprecation/deprecation