### PR TITLE
MVCDemos - Disable script bundle transforms / min

### DIFF
--- a/MVCDemos/App_Start/BundleConfig.cs
+++ b/MVCDemos/App_Start/BundleConfig.cs
@@ -37,6 +37,7 @@ namespace DevExtreme.MVC.Demos {
                 .Include("~/Scripts/dx.aspnet.data.js")
                 .Include("~/Scripts/vectormap-data/world.js")
                 .Include("~/Scripts/vectormap-data/usa.js");
+            bundle.Transforms.Clear();
             return bundle;
         }
     }


### PR DESCRIPTION
MVCDemos - Disable script bundle transforms / min similar to NetCoreDemos at #2760.
The dx.all.js script file is already minified, and fails during bundling:

```
[NullReferenceException: Object reference not set to an instance of an object.]
Microsoft.Ajax.Utilities.JSParser.ParseObjectLiteralProperty(Boolean isBindingPattern) +944
...
Microsoft.Ajax.Utilities.JSParser.InternalParse() +830
Microsoft.Ajax.Utilities.Minifier.MinifyJavaScript(String source, CodeSettings codeSettings) +811
System.Web.Optimization.JsMinify.Process(BundleContext context, BundleResponse response) +115
```
