### PR TITLE
Form Validation Demo: update editors' settings to make `reset` button behavior more intuitive

### DIFF
--- a/JSDemos/Demos/Form/Validation/Angular/app/app.component.html
+++ b/JSDemos/Demos/Form/Validation/Angular/app/app.component.html
@@ -9,7 +9,7 @@
     validationGroup="customerData"
   >
     <dxi-item itemType="group" caption="Credentials">
-      <dxi-item dataField="Email">
+      <dxi-item dataField="Email" [editorOptions]="emailOptions">
         <dxi-validation-rule type="required" message="Email is required">
         </dxi-validation-rule>
         <dxi-validation-rule type="email" message="Email is invalid">
@@ -28,6 +28,7 @@
       <dxi-item
         name="ConfirmPassword"
         editorType="dxTextBox"
+        dataField="ConfirmPassword"
         [editorOptions]="confirmOptions"
       >
         <dxo-label text="Confirm Password"> </dxo-label>
@@ -45,7 +46,7 @@
       </dxi-item>
     </dxi-item>
     <dxi-item itemType="group" caption="Personal Data">
-      <dxi-item dataField="Name">
+      <dxi-item dataField="Name" [editorOptions]="nameOptions">
         <dxi-validation-rule type="required" message="Name is required">
         </dxi-validation-rule>
         <dxi-validation-rule
@@ -58,11 +59,7 @@
       <dxi-item
         dataField="Date"
         editorType="dxDateBox"
-        [editorOptions]="{
-          placeholder: 'Birth Date',
-          invalidDateMessage:
-            'The date must have the following format: MM/dd/yyyy'
-        }"
+        [editorOptions]="dateBoxOptions"
       >
         <dxo-label text="Date of birth"> </dxo-label>
         <dxi-validation-rule
@@ -114,18 +111,14 @@
         <dxi-validation-rule type="required" message="City is required">
         </dxi-validation-rule>
       </dxi-item>
-      <dxi-item dataField="Address">
+      <dxi-item dataField="Address" [editorOptions]="addressOptions">
         <dxi-validation-rule type="required" message="Address is required">
         </dxi-validation-rule>
       </dxi-item>
       <dxi-item
         dataField="Phone"
         helpText="Enter the phone number in USA phone format"
-        [editorOptions]="{
-          mask: '+1 (X00) 000-0000',
-          maskRules: phoneRules,
-          maskInvalidMessage: 'The phone must have a correct USA phone format'
-        }"
+        [editorOptions]="phoneOptions"
       >
         <dxi-validation-rule
           type="pattern"

--- a/JSDemos/Demos/Form/Validation/Angular/app/app.component.html
+++ b/JSDemos/Demos/Form/Validation/Angular/app/app.component.html
@@ -9,7 +9,7 @@
     validationGroup="customerData"
   >
     <dxi-item itemType="group" caption="Credentials">
-      <dxi-item dataField="Email" [editorOptions]="emailOptions">
+      <dxi-item dataField="Email" [editorOptions]="emailEditorOptions">
         <dxi-validation-rule type="required" message="Email is required">
         </dxi-validation-rule>
         <dxi-validation-rule type="email" message="Email is invalid">
@@ -21,7 +21,7 @@
         >
         </dxi-validation-rule>
       </dxi-item>
-      <dxi-item dataField="Password" [editorOptions]="passwordOptions">
+      <dxi-item dataField="Password" [editorOptions]="passwordEditorOptions">
         <dxi-validation-rule type="required" message="Password is required">
         </dxi-validation-rule>
       </dxi-item>
@@ -29,7 +29,7 @@
         name="ConfirmPassword"
         editorType="dxTextBox"
         dataField="ConfirmPassword"
-        [editorOptions]="confirmOptions"
+        [editorOptions]="confirmPasswordEditorOptions"
       >
         <dxo-label text="Confirm Password"> </dxo-label>
         <dxi-validation-rule
@@ -46,7 +46,7 @@
       </dxi-item>
     </dxi-item>
     <dxi-item itemType="group" caption="Personal Data">
-      <dxi-item dataField="Name" [editorOptions]="nameOptions">
+      <dxi-item dataField="Name" [editorOptions]="nameEditorOptions">
         <dxi-validation-rule type="required" message="Name is required">
         </dxi-validation-rule>
         <dxi-validation-rule
@@ -111,14 +111,14 @@
         <dxi-validation-rule type="required" message="City is required">
         </dxi-validation-rule>
       </dxi-item>
-      <dxi-item dataField="Address" [editorOptions]="addressOptions">
+      <dxi-item dataField="Address" [editorOptions]="addressEditorOptions">
         <dxi-validation-rule type="required" message="Address is required">
         </dxi-validation-rule>
       </dxi-item>
       <dxi-item
         dataField="Phone"
         helpText="Enter the phone number in USA phone format"
-        [editorOptions]="phoneOptions"
+        [editorOptions]="phoneEditorOptions"
       >
         <dxi-validation-rule
           type="pattern"

--- a/JSDemos/Demos/Form/Validation/Angular/app/app.component.ts
+++ b/JSDemos/Demos/Form/Validation/Angular/app/app.component.ts
@@ -39,7 +39,7 @@ const sendRequest = function (value) {
 export class AppComponent {
   @ViewChild(DxFormComponent, { static: false }) form:DxFormComponent;
 
-  passwordOptions: any = {
+  passwordEditorOptions: any = {
     mode: 'password',
     valueChangeEvent: 'keyup',
     onValueChanged: () => {
@@ -62,19 +62,19 @@ export class AppComponent {
     ],
   };
 
-  emailOptions: any = {
+  emailEditorOptions: any = {
     valueChangeEvent: 'keyup',
   };
 
-  nameOptions: any = {
+  nameEditorOptions: any = {
     valueChangeEvent: 'keyup',
   };
 
-  addressOptions: any = {
+  addressEditorOptions: any = {
     valueChangeEvent: 'keyup',
   };
 
-  phoneOptions: any = {
+  phoneEditorOptions: any = {
     mask: '+1 (X00) 000-0000',
     maskRules: {
       X: /[02-9]/,
@@ -83,7 +83,7 @@ export class AppComponent {
     valueChangeEvent: 'keyup',
   };
 
-  confirmOptions: any = {
+  confirmPasswordEditorOptions: any = {
     mode: 'password',
     valueChangeEvent: 'keyup',
     buttons: [

--- a/JSDemos/Demos/Form/Validation/Angular/app/app.component.ts
+++ b/JSDemos/Demos/Form/Validation/Angular/app/app.component.ts
@@ -41,6 +41,7 @@ export class AppComponent {
 
   passwordOptions: any = {
     mode: 'password',
+    valueChangeEvent: 'keyup',
     onValueChanged: () => {
       let editor = this.form.instance.getEditor('ConfirmPassword');
       if (editor.option('value')) {
@@ -61,8 +62,30 @@ export class AppComponent {
     ],
   };
 
+  emailOptions: any = {
+    valueChangeEvent: 'keyup',
+  };
+
+  nameOptions: any = {
+    valueChangeEvent: 'keyup',
+  };
+
+  addressOptions: any = {
+    valueChangeEvent: 'keyup',
+  };
+
+  phoneOptions: any = {
+    mask: '+1 (X00) 000-0000',
+    maskRules: {
+      X: /[02-9]/,
+    },
+    maskInvalidMessage: 'The phone must have a correct USA phone format',
+    valueChangeEvent: 'keyup',
+  };
+
   confirmOptions: any = {
     mode: 'password',
+    valueChangeEvent: 'keyup',
     buttons: [
       {
         name: 'password',
@@ -99,13 +122,17 @@ export class AppComponent {
 
   phonePattern: any = /^[02-9]\d{9}$/;
 
-  phoneRules: any = {
-    X: /[02-9]/,
+  dateBoxOptions = {
+    placeholder: 'Birth Date',
+    acceptCustomValue: false,
+    invalidDateMessage:
+      'The date must have the following format: MM/dd/yyyy',
   };
 
   dateRangeBoxOptions = {
     startDatePlaceholder: 'Start Date',
     endDatePlaceholder: 'End Date',
+    acceptCustomValue: false,
     invalidDateMessage:
       'The date must have the following format: MM/dd/yyyy',
   };

--- a/JSDemos/Demos/Form/Validation/React/App.js
+++ b/JSDemos/Demos/Form/Validation/React/App.js
@@ -28,6 +28,7 @@ const checkBoxOptions = {
 
 const cityEditorOptions = {
   dataSource: service.getCities(),
+  valueChangeEvent: 'keyup',
   minSearchLength: 2,
 };
 
@@ -35,8 +36,21 @@ const countryEditorOptions = {
   dataSource: service.getCountries(),
 };
 
+const emailEditorOptions = {
+  valueChangeEvent: 'keyup',
+};
+
+const nameEditorOptions = {
+  valueChangeEvent: 'keyup',
+};
+
+const addressEditorOptions = {
+  valueChangeEvent: 'keyup',
+};
+
 const phoneEditorOptions = {
   mask: '+1 (X00) 000-0000',
+  valueChangeEvent: 'keyup',
   maskRules: {
     X: /[02-9]/,
   },
@@ -54,6 +68,7 @@ const maxDate = new Date().setFullYear(new Date().getFullYear() - 21);
 
 const dateBoxOptions = {
   placeholder: 'Birth Date',
+  acceptCustomValue: false,
   invalidDateMessage:
     'The date must have the following format: MM/dd/yyyy',
 };
@@ -61,6 +76,7 @@ const dateBoxOptions = {
 const dateRangeBoxOptions = {
   startDatePlaceholder: 'Start Date',
   endDatePlaceholder: 'End Date',
+  acceptCustomValue: false,
   invalidDateMessage: 'The date must have the following format: MM/dd/yyyy',
 };
 
@@ -101,6 +117,7 @@ function App() {
 
   const getPasswordOptions = React.useCallback(() => ({
     mode: 'password',
+    valueChangeEvent: 'keyup',
     onValueChanged: () => {
       const editor = formInstance.current.getEditor('ConfirmPassword');
       if (editor.option('value')) {
@@ -123,6 +140,7 @@ function App() {
 
   const getConfirmOptions = React.useCallback(() => ({
     mode: 'password',
+    valueChangeEvent: 'keyup',
     buttons: [
       {
         name: 'password',
@@ -175,7 +193,7 @@ function App() {
           validationGroup="customerData"
         >
           <GroupItem caption="Credentials">
-            <SimpleItem dataField="Email" editorType="dxTextBox">
+            <SimpleItem dataField="Email" editorType="dxTextBox" editorOptions={emailEditorOptions}>
               <RequiredRule message="Email is required" />
               <EmailRule message="Email is invalid" />
               <AsyncRule
@@ -185,7 +203,7 @@ function App() {
             <SimpleItem dataField="Password" editorType="dxTextBox" editorOptions={getPasswordOptions()}>
               <RequiredRule message="Password is required" />
             </SimpleItem>
-            <SimpleItem name="ConfirmPassword" editorType="dxTextBox" editorOptions={getConfirmOptions()}>
+            <SimpleItem name="ConfirmPassword" dataField="ConfirmPassword" editorType="dxTextBox" editorOptions={getConfirmOptions()}>
               <Label text="Confirm Password" />
               <RequiredRule message="Confirm Password is required" />
               <CompareRule
@@ -195,7 +213,7 @@ function App() {
             </SimpleItem>
           </GroupItem>
           <GroupItem caption="Personal Data">
-            <SimpleItem dataField="Name">
+            <SimpleItem dataField="Name" editorOptions={nameEditorOptions}>
               <RequiredRule message="Name is required" />
               <PatternRule message="Do not use digits in the Name"
                 pattern={/^[^0-9]+$/} />
@@ -225,7 +243,7 @@ function App() {
               <StringLengthRule min={2} message="City must have at least 2 symbols" />
               <RequiredRule message="City is required" />
             </SimpleItem>
-            <SimpleItem dataField="Address">
+            <SimpleItem dataField="Address" editorOptions={addressEditorOptions}>
               <RequiredRule message="Address is required" />
             </SimpleItem>
             <SimpleItem dataField="Phone"

--- a/JSDemos/Demos/Form/Validation/Vue/App.vue
+++ b/JSDemos/Demos/Form/Validation/Vue/App.vue
@@ -15,9 +15,9 @@
           validation-group="customerData"
         >
           <DxGroupItem caption="Credentials">
-            <DxSimpleItem 
-            data-field="Email"
-            :editor-options="emailOptions"
+            <DxSimpleItem
+              data-field="Email"
+              :editor-options="emailOptions"
             >
               <DxRequiredRule message="Email is required"/>
               <DxEmailRule message="Email is invalid"/>
@@ -47,7 +47,7 @@
             </DxSimpleItem>
           </DxGroupItem>
           <DxGroupItem caption="Personal Data">
-            <DxSimpleItem 
+            <DxSimpleItem
               data-field="Name"
               :editor-options="nameOptions"
             >
@@ -101,7 +101,7 @@
               />
               <DxRequiredRule message="City is required"/>
             </DxSimpleItem>
-            <DxSimpleItem 
+            <DxSimpleItem
               data-field="Address"
               :editor-options="addressOptions"
             >

--- a/JSDemos/Demos/Form/Validation/Vue/App.vue
+++ b/JSDemos/Demos/Form/Validation/Vue/App.vue
@@ -17,7 +17,7 @@
           <DxGroupItem caption="Credentials">
             <DxSimpleItem
               data-field="Email"
-              :editor-options="emailOptions"
+              :editor-options="emailEditorOptions"
             >
               <DxRequiredRule message="Email is required"/>
               <DxEmailRule message="Email is invalid"/>
@@ -27,7 +27,7 @@
               />
             </DxSimpleItem>
             <DxSimpleItem
-              :editor-options="passwordOptions"
+              :editor-options="passwordEditorOptions"
               data-field="Password"
             >
               <DxRequiredRule message="Password is required"/>
@@ -35,7 +35,7 @@
             <DxSimpleItem
               name="ConfirmPassword"
               data-field="ConfirmPassword"
-              :editor-options="confirmPasswordOptions"
+              :editor-options="confirmPasswordEditorOptions"
               editor-type="dxTextBox"
             >
               <DxLabel text="Confirm Password"/>
@@ -49,7 +49,7 @@
           <DxGroupItem caption="Personal Data">
             <DxSimpleItem
               data-field="Name"
-              :editor-options="nameOptions"
+              :editor-options="nameEditorOptions"
             >
               <DxRequiredRule message="Name is required"/>
               <DxPatternRule
@@ -103,7 +103,7 @@
             </DxSimpleItem>
             <DxSimpleItem
               data-field="Address"
-              :editor-options="addressOptions"
+              :editor-options="addressEditorOptions"
             >
               <DxRequiredRule message="Address is required"/>
             </DxSimpleItem>
@@ -227,7 +227,7 @@ export default {
         md: 2,
         lg: 2,
       },
-      passwordOptions: {
+      passwordEditorOptions: {
         mode: 'password',
         valueChangeEvent: 'keyup',
         onValueChanged: () => {
@@ -249,7 +249,7 @@ export default {
           },
         ],
       },
-      confirmPasswordOptions: {
+      confirmPasswordEditorOptions: {
         mode: 'password',
         valueChangeEvent: 'keyup',
         buttons: [
@@ -264,13 +264,13 @@ export default {
           },
         ],
       },
-      emailOptions: {
+      emailEditorOptions: {
         valueChangeEvent: 'keyup',
       },
-      nameOptions: {
+      nameEditorOptions: {
         valueChangeEvent: 'keyup',
       },
-      addressOptions: {
+      addressEditorOptions: {
         valueChangeEvent: 'keyup',
       },
       dateBoxOptions: {

--- a/JSDemos/Demos/Form/Validation/Vue/App.vue
+++ b/JSDemos/Demos/Form/Validation/Vue/App.vue
@@ -15,7 +15,10 @@
           validation-group="customerData"
         >
           <DxGroupItem caption="Credentials">
-            <DxSimpleItem data-field="Email">
+            <DxSimpleItem 
+            data-field="Email"
+            :editor-options="emailOptions"
+            >
               <DxRequiredRule message="Email is required"/>
               <DxEmailRule message="Email is invalid"/>
               <DxAsyncRule
@@ -31,6 +34,7 @@
             </DxSimpleItem>
             <DxSimpleItem
               name="ConfirmPassword"
+              data-field="ConfirmPassword"
               :editor-options="confirmPasswordOptions"
               editor-type="dxTextBox"
             >
@@ -43,7 +47,10 @@
             </DxSimpleItem>
           </DxGroupItem>
           <DxGroupItem caption="Personal Data">
-            <DxSimpleItem data-field="Name">
+            <DxSimpleItem 
+              data-field="Name"
+              :editor-options="nameOptions"
+            >
               <DxRequiredRule message="Name is required"/>
               <DxPatternRule
                 :pattern="namePattern"
@@ -94,7 +101,10 @@
               />
               <DxRequiredRule message="City is required"/>
             </DxSimpleItem>
-            <DxSimpleItem data-field="Address">
+            <DxSimpleItem 
+              data-field="Address"
+              :editor-options="addressOptions"
+            >
               <DxRequiredRule message="Address is required"/>
             </DxSimpleItem>
             <DxSimpleItem
@@ -219,6 +229,7 @@ export default {
       },
       passwordOptions: {
         mode: 'password',
+        valueChangeEvent: 'keyup',
         onValueChanged: () => {
           const editor = this.formInstance.getEditor('ConfirmPassword');
           if (editor.option('value')) {
@@ -240,6 +251,7 @@ export default {
       },
       confirmPasswordOptions: {
         mode: 'password',
+        valueChangeEvent: 'keyup',
         buttons: [
           {
             name: 'password',
@@ -252,14 +264,25 @@ export default {
           },
         ],
       },
+      emailOptions: {
+        valueChangeEvent: 'keyup',
+      },
+      nameOptions: {
+        valueChangeEvent: 'keyup',
+      },
+      addressOptions: {
+        valueChangeEvent: 'keyup',
+      },
       dateBoxOptions: {
         placeholder: 'Birth Date',
+        acceptCustomValue: false,
         invalidDateMessage:
           'The date must have the following format: MM/dd/yyyy',
       },
       dateRangeBoxOptions: {
         endDatePlaceholder: 'End Date',
         startDatePlaceholder: 'Start Date',
+        acceptCustomValue: false,
         invalidDateMessage:
           'The date must have the following format: MM/dd/yyyy',
       },
@@ -270,6 +293,7 @@ export default {
       },
       phoneEditorOptions: {
         mask: '+1 (X00) 000-0000',
+        valueChangeEvent: 'keyup',
         maskRules: {
           X: /[02-9]/,
         },
@@ -277,6 +301,7 @@ export default {
       },
       cityEditorOptions: {
         dataSource: service.getCities(),
+        valueChangeEvent: 'keyup',
         minSearchLength: 2,
       },
       countryEditorOptions: {

--- a/JSDemos/Demos/Form/Validation/jQuery/index.js
+++ b/JSDemos/Demos/Form/Validation/jQuery/index.js
@@ -30,6 +30,9 @@ $(() => {
       caption: 'Credentials',
       items: [{
         dataField: 'Email',
+        editorOptions: {
+          valueChangeEvent: 'keyup',
+        },
         validationRules: [{
           type: 'required',
           message: 'Email is required',
@@ -47,6 +50,7 @@ $(() => {
         dataField: 'Password',
         editorOptions: {
           mode: 'password',
+          valueChangeEvent: 'keyup',
           onValueChanged() {
             const editor = formWidget.getEditor('ConfirmPassword');
             if (editor.option('value')) {
@@ -69,12 +73,14 @@ $(() => {
         }],
       }, {
         name: 'ConfirmPassword',
+        dataField: 'ConfirmPassword',
         label: {
           text: 'Confirm Password',
         },
         editorType: 'dxTextBox',
         editorOptions: {
           mode: 'password',
+          valueChangeEvent: 'keyup',
           buttons: [{
             name: 'password',
             location: 'after',
@@ -101,6 +107,9 @@ $(() => {
       caption: 'Personal Data',
       items: [{
         dataField: 'Name',
+        editorOptions: {
+          valueChangeEvent: 'keyup',
+        },
         validationRules: [{
           type: 'required',
           message: 'Name is required',
@@ -118,6 +127,7 @@ $(() => {
         editorOptions: {
           invalidDateMessage: 'The date must have the following format: MM/dd/yyyy',
           placeholder: 'Birth Date',
+          acceptCustomValue: false,
         },
         validationRules: [{
           type: 'required',
@@ -137,6 +147,7 @@ $(() => {
           startDatePlaceholder: 'Start Date',
           endDatePlaceholder: 'End Date',
           invalidDateMessage: 'The date must have the following format: MM/dd/yyyy',
+          acceptCustomValue: false,
         },
       }],
     }, {
@@ -158,6 +169,7 @@ $(() => {
         editorOptions: {
           dataSource: cities,
           minSearchLength: 2,
+          valueChangeEvent: 'keyup',
         },
         validationRules: [{
           type: 'pattern',
@@ -173,6 +185,9 @@ $(() => {
         }],
       }, {
         dataField: 'Address',
+        editorOptions: {
+          valueChangeEvent: 'keyup',
+        },
         validationRules: [{
           type: 'required',
           message: 'Address is required',
@@ -186,6 +201,7 @@ $(() => {
             X: /[02-9]/,
           },
           maskInvalidMessage: 'The phone must have a correct USA phone format',
+          valueChangeEvent: 'keyup',
         },
         validationRules: [{
           type: 'pattern',

--- a/MVCDemos/Views/Form/Validation.cshtml
+++ b/MVCDemos/Views/Form/Validation.cshtml
@@ -16,8 +16,8 @@
                     .Items(groupItems => {
                         groupItems.AddSimpleFor(m => m.Email)
                             .Editor(e => e.TextBox()
-								.ValueChangeEvent("keyup")
-							);
+                                .ValueChangeEvent("keyup")
+                            );
 
                         groupItems.AddSimpleFor(m => m.Password)
                             .Editor(e => e.TextBox()
@@ -61,14 +61,14 @@
                     .Items(groupItems => {
                         groupItems.AddSimpleFor(m => m.Name)
                             .Editor(e => e.TextBox()
-								.ValueChangeEvent("keyup")
-							);
+                                .ValueChangeEvent("keyup")
+                            );
                         groupItems.AddSimpleFor(m => m.Date)
                             .Editor(e => e
-								.DateBox()
-								.Placeholder("Birth Date")
-								.AcceptCustomValue(false)
-							);
+                                .DateBox()
+                                .Placeholder("Birth Date")
+                                .AcceptCustomValue(false)
+                            );
                         groupItems.AddSimpleFor(m => m.VacationDates)
                             .Editor(e => e
                                 .DateRangeBox()
@@ -98,8 +98,8 @@
 
                         groupItems.AddSimpleFor(m => m.Address)
                             .Editor(e => e.TextBox()
-								.ValueChangeEvent("keyup")
-							);
+                                .ValueChangeEvent("keyup")
+                            );
 
                         groupItems.AddSimpleFor(m => m.Phone)
                             .HelpText("Enter the phone number in USA phone format")

--- a/MVCDemos/Views/Form/Validation.cshtml
+++ b/MVCDemos/Views/Form/Validation.cshtml
@@ -14,13 +14,17 @@
                 items.AddGroup()
                     .Caption("Credentials")
                     .Items(groupItems => {
-                        groupItems.AddSimpleFor(m => m.Email);
+                        groupItems.AddSimpleFor(m => m.Email)
+                            .Editor(e => e.TextBox()
+								.ValueChangeEvent("keyup")
+							);
 
                         groupItems.AddSimpleFor(m => m.Password)
                             .Editor(e => e.TextBox()
-                                .InputAttr("aria-label", "Password")
                                 .Mode(TextBoxMode.Password)
+                                .InputAttr("aria-label", "Password")
                                 .OnValueChanged("passwordChanged")
+                                .ValueChangeEvent("keyup")
                                 .Buttons(buttons => {
                                     buttons.Add()
                                         .Name("password")
@@ -29,7 +33,8 @@
                                             .Type(ButtonType.Default)
                                             .Icon("eyeopen")
                                             .StylingMode(ButtonStylingMode.Text)
-                                            .OnClick("() => changePasswordMode('Password')"));
+                                            .OnClick("() => changePasswordMode('Password')")
+                                        );
                                 })
                             );
 
@@ -37,6 +42,7 @@
                             .Editor(e => e.TextBox()
                                 .Mode(TextBoxMode.Password)
                                 .InputAttr("aria-label", "Password")
+                                .ValueChangeEvent("keyup")
                                 .Buttons(buttons => {
                                     buttons.Add()
                                         .Name("password")
@@ -53,11 +59,20 @@
                 items.AddGroup()
                     .Caption("Personal Data")
                     .Items(groupItems => {
-                        groupItems.AddSimpleFor(m => m.Name);
-                        groupItems.AddSimpleFor(m => m.Date);
+                        groupItems.AddSimpleFor(m => m.Name)
+                            .Editor(e => e.TextBox()
+								.ValueChangeEvent("keyup")
+							);
+                        groupItems.AddSimpleFor(m => m.Date)
+                            .Editor(e => e
+								.DateBox()
+								.Placeholder("Birth Date")
+								.AcceptCustomValue(false)
+							);
                         groupItems.AddSimpleFor(m => m.VacationDates)
                             .Editor(e => e
                                 .DateRangeBox()
+                                .AcceptCustomValue(false)
                                 .StartDatePlaceholder("Start Date")
                                 .EndDatePlaceholder("End Date")
                             );
@@ -76,17 +91,22 @@
                         groupItems.AddSimpleFor(m => m.City)
                             .Editor(e => e
                                 .Autocomplete()
+                                .ValueChangeEvent("keyup")
                                 .MinSearchLength(2)
                                 .DataSource(d => d.WebApi().RouteName("GeoNames").LoadAction("Cities"))
                             );
 
-                        groupItems.AddSimpleFor(m => m.Address);
+                        groupItems.AddSimpleFor(m => m.Address)
+                            .Editor(e => e.TextBox()
+								.ValueChangeEvent("keyup")
+							);
 
                         groupItems.AddSimpleFor(m => m.Phone)
                             .HelpText("Enter the phone number in USA phone format")
                             .Editor(e => e.TextBox()
                                 .Mask("+1 (X00) 000-0000")
-                                .InputAttr("aria-label", "Mask")
+                                .InputAttr("aria-label", "Phone")
+                                .ValueChangeEvent("keyup")
                                 .MaskRules(new { X = new JS("/[02-9]/") })
                                 .MaskInvalidMessage("The phone must have a correct USA phone format")
                             );

--- a/NetCoreDemos/Views/Form/Validation.cshtml
+++ b/NetCoreDemos/Views/Form/Validation.cshtml
@@ -14,13 +14,16 @@
                 items.AddGroup()
                     .Caption("Credentials")
                     .Items(groupItems => {
-                        groupItems.AddSimpleFor(m => m.Email);
-
-                        groupItems.AddSimpleFor(m => m.Password)
+                        groupItems.AddSimpleFor(m => m.Email)
+							.Editor(e => e.TextBox()
+								.ValueChangeEvent("keyup")
+							);
+						groupItems.AddSimpleFor(m => m.Password)
                             .Editor(e => e.TextBox()
                                 .Mode(TextBoxMode.Password)
                                 .InputAttr("aria-label", "Password")
                                 .OnValueChanged("passwordChanged")
+								.ValueChangeEvent("keyup")
                                 .Buttons(buttons => {
                                     buttons.Add()
                                         .Name("password")
@@ -38,6 +41,7 @@
                             .Editor(e => e.TextBox()
                                 .Mode(TextBoxMode.Password)
                                 .InputAttr("aria-label", "Password")
+                                .ValueChangeEvent("keyup")
                                 .Buttons(buttons => {
                                     buttons.Add()
                                         .Name("password")
@@ -55,12 +59,21 @@
                 items.AddGroup()
                     .Caption("Personal Data")
                     .Items(groupItems => {
-                        groupItems.AddSimpleFor(m => m.Name);
-                        groupItems.AddSimpleFor(m => m.Date);
+                        groupItems.AddSimpleFor(m => m.Name)
+							.Editor(e => e.TextBox()
+								.ValueChangeEvent("keyup")
+							);
+                        groupItems.AddSimpleFor(m => m.Date)
+							.Editor(e => e
+								.DateBox()
+								.Placeholder("Birth Date")
+								.AcceptCustomValue(false)
+							);
                         groupItems.AddSimpleFor(m => m.VacationDates)
                             .Editor(e => e
                                 .DateRangeBox()
                                 .StartDatePlaceholder("Start Date")
+								.AcceptCustomValue(false)
                                 .EndDatePlaceholder("End Date")
                             );
                     });
@@ -78,18 +91,23 @@
                         groupItems.AddSimpleFor(m => m.City)
                             .Editor(e => e
                                 .Autocomplete()
-                                .MinSearchLength(2)
+								.ValueChangeEvent("keyup")
+								.MinSearchLength(2)
                                 .DataSource(d => d.Mvc().Controller("GeoNames").LoadAction("Cities"))
                             );
 
-                        groupItems.AddSimpleFor(m => m.Address);
+                        groupItems.AddSimpleFor(m => m.Address)
+							.Editor(e => e.TextBox()
+								.ValueChangeEvent("keyup")
+							);
 
                         groupItems.AddSimpleFor(m => m.Phone)
                             .HelpText("Enter the phone number in USA phone format")
                             .Editor(e => e.TextBox()
                                 .Mask("+1 (X00) 000-0000")
                                 .InputAttr("aria-label", "Phone")
-                                .MaskRules(new { X = new JS("/[02-9]/") })
+								.ValueChangeEvent("keyup")
+								.MaskRules(new { X = new JS("/[02-9]/") })
                                 .MaskInvalidMessage("The phone must have a correct USA phone format")
                             );
                     });
@@ -100,10 +118,7 @@
                     .Items(groupItems => {
                         groupItems.AddSimpleFor(m => m.Accepted)
                             .Label(l => l.Visible(false))
-                            .Editor(editor => editor.CheckBox()
-                                .Width(270)
-                                .Text("I agree to the Terms and Conditions")
-                            );
+                            .Editor(editor => editor.CheckBox().Text("I agree to the Terms and Conditions"));
                         groupItems.AddGroup()
                             .ColCountByScreen(c => c.Md(2).Sm(2).Lg(2))
                             .CssClass("buttons-group")

--- a/NetCoreDemos/Views/Form/Validation.cshtml
+++ b/NetCoreDemos/Views/Form/Validation.cshtml
@@ -15,15 +15,15 @@
                     .Caption("Credentials")
                     .Items(groupItems => {
                         groupItems.AddSimpleFor(m => m.Email)
-							.Editor(e => e.TextBox()
-								.ValueChangeEvent("keyup")
-							);
-						groupItems.AddSimpleFor(m => m.Password)
+                            .Editor(e => e.TextBox()
+                                .ValueChangeEvent("keyup")
+                            );
+                        groupItems.AddSimpleFor(m => m.Password)
                             .Editor(e => e.TextBox()
                                 .Mode(TextBoxMode.Password)
                                 .InputAttr("aria-label", "Password")
                                 .OnValueChanged("passwordChanged")
-								.ValueChangeEvent("keyup")
+                                .ValueChangeEvent("keyup")
                                 .Buttons(buttons => {
                                     buttons.Add()
                                         .Name("password")
@@ -60,20 +60,20 @@
                     .Caption("Personal Data")
                     .Items(groupItems => {
                         groupItems.AddSimpleFor(m => m.Name)
-							.Editor(e => e.TextBox()
-								.ValueChangeEvent("keyup")
-							);
+                            .Editor(e => e.TextBox()
+                                .ValueChangeEvent("keyup")
+                            );
                         groupItems.AddSimpleFor(m => m.Date)
-							.Editor(e => e
-								.DateBox()
-								.Placeholder("Birth Date")
-								.AcceptCustomValue(false)
-							);
+                            .Editor(e => e
+                                .DateBox()
+                                .Placeholder("Birth Date")
+                                .AcceptCustomValue(false)
+                            );
                         groupItems.AddSimpleFor(m => m.VacationDates)
                             .Editor(e => e
                                 .DateRangeBox()
                                 .StartDatePlaceholder("Start Date")
-								.AcceptCustomValue(false)
+                                .AcceptCustomValue(false)
                                 .EndDatePlaceholder("End Date")
                             );
                     });
@@ -91,23 +91,23 @@
                         groupItems.AddSimpleFor(m => m.City)
                             .Editor(e => e
                                 .Autocomplete()
-								.ValueChangeEvent("keyup")
-								.MinSearchLength(2)
+                                .ValueChangeEvent("keyup")
+                                .MinSearchLength(2)
                                 .DataSource(d => d.Mvc().Controller("GeoNames").LoadAction("Cities"))
                             );
 
                         groupItems.AddSimpleFor(m => m.Address)
-							.Editor(e => e.TextBox()
-								.ValueChangeEvent("keyup")
-							);
+                            .Editor(e => e.TextBox()
+                                .ValueChangeEvent("keyup")
+                            );
 
                         groupItems.AddSimpleFor(m => m.Phone)
                             .HelpText("Enter the phone number in USA phone format")
                             .Editor(e => e.TextBox()
                                 .Mask("+1 (X00) 000-0000")
                                 .InputAttr("aria-label", "Phone")
-								.ValueChangeEvent("keyup")
-								.MaskRules(new { X = new JS("/[02-9]/") })
+                                .ValueChangeEvent("keyup")
+                                .MaskRules(new { X = new JS("/[02-9]/") })
                                 .MaskInvalidMessage("The phone must have a correct USA phone format")
                             );
                     });


### PR DESCRIPTION
1) valueChangeEvent for editors changed to keyup
2) applyCustomValue for dateboxes changed to false
3) confirmPassword dataField specified
