### PR TITLE
Turn off accessibility tests for not accessible components and skip rest errors

### DIFF
--- a/.github/workflows/visual_tests.yml
+++ b/.github/workflows/visual_tests.yml
@@ -150,7 +150,7 @@ jobs:
 
     - name: Run TestCafe tests
       shell: bash
-      continue-on-error: ${{ matrix.STRATEGY == 'accessibility' }}
+      # continue-on-error: ${{ matrix.STRATEGY == 'accessibility' }}
       env:
         STRATEGY: ${{ matrix.STRATEGY }}
         CHANGEDFILEINFOSPATH: ${{ github.workspace }}/changed-files.json

--- a/.github/workflows/visual_tests.yml
+++ b/.github/workflows/visual_tests.yml
@@ -150,7 +150,6 @@ jobs:
 
     - name: Run TestCafe tests
       shell: bash
-      # continue-on-error: ${{ matrix.STRATEGY == 'accessibility' }}
       env:
         STRATEGY: ${{ matrix.STRATEGY }}
         CHANGEDFILEINFOSPATH: ${{ github.workspace }}/changed-files.json

--- a/JSDemos/Demos/Localization/UsingGlobalize/jQuery/index.html
+++ b/JSDemos/Demos/Localization/UsingGlobalize/jQuery/index.html
@@ -31,14 +31,12 @@
   <body class="dx-viewport">
     <div class="demo-container">
       <div id="data-grid-demo">
-        <div id="data-grid-demo">
-          <div id="gridContainer"></div>
-          <div class="options">
-            <div class="caption">Options</div>
-            <div class="option">
-              <label for="selectInput">Language</label>
-              <div id="selectBox"></div>
-            </div>
+        <div id="gridContainer"></div>
+        <div class="options">
+          <div class="caption">Options</div>
+          <div class="option">
+            <label for="selectBox">Language</label>
+            <div id="selectBox"></div>
           </div>
         </div>
       </div>

--- a/testing/.eslintrc.js
+++ b/testing/.eslintrc.js
@@ -17,10 +17,6 @@ module.exports = {
       'error',
       'multi-line',
     ],
-    indent: [
-      'error',
-      2,
-    ],
     'spellcheck/spell-checker': spellcheckRule,
   },
 };

--- a/testing/common.test.js
+++ b/testing/common.test.js
@@ -198,9 +198,7 @@ const getTestSpecificSkipRules = (testName) => {
           const axeResult = await axeCheck(t, '.demo-container', options);
           const { error, results } = axeResult;
 
-          if (error) {
-            console.error('####%%%%####', JSON.stringify(error, Object.getOwnPropertyNames(error)));
-          } else if (results.violations.length > 0) {
+          if (results.violations.length > 0) {
             createMdReport({ testName, results });
             await t.report(createTestCafeReport(results.violations));
           }

--- a/testing/common.test.js
+++ b/testing/common.test.js
@@ -143,7 +143,8 @@ const execTestCafeCode = (t, code) => {
         }
 
         if (process.env.STRATEGY === 'accessibility') {
-          const { error, results } = await axeCheck(t, '.demo-container');
+          const options = { rules: { 'color-contrast': { enabled: false } } };
+          const { error, results } = await axeCheck(t, '.demo-container', options);
 
           if (results.violations.length > 0) {
             createMdReport({ testName, results });

--- a/testing/common.test.js
+++ b/testing/common.test.js
@@ -54,10 +54,41 @@ const execTestCafeCode = (t, code) => {
   return testCafeFunction(t);
 };
 
+const COMMON_SKIP_RULES = ['color-contrast'];
 const getTestSpecificSkipRules = (testName) => {
   switch (testName) {
   case 'Calendar-MultipleSelection':
+  case 'DataGrid-ExcelJSCellCustomization':
+  case 'DataGrid-HorizontalVirtualScrolling':
+  case 'DataGrid-PDFCellCustomization':
     return ['empty-table-header'];
+  case 'Autocomplete-Overview':
+  case 'DataGrid-Filtering':
+  case 'DataGrid-FilterPanel':
+  case 'Localization-UsingGlobalize':
+  case 'Localization-UsingIntl':
+    return ['label'];
+  case 'DataGrid-RowTemplate':
+  case 'DataGrid-Row3RdPartyEngineTemplate':
+    return ['aria-required-children', 'image-alt'];
+  case 'DataGrid-CustomNewRecordPosition':
+    return ['link-name'];
+  case 'DataGrid-Column3RdPartyEngineTemplate':
+  case 'DataGrid-ColumnTemplate':
+  case 'DataGrid-ExcelJSExportImages':
+  case 'DataGrid-FilteringAPI':
+  case 'DataGrid-MasterDetailAPI':
+  case 'DataGrid-PDFExportImages':
+  case 'DataGrid-RowSelection':
+  case 'FilterBuilder-WithList':
+  case 'Gallery-Overview':
+    return ['image-alt'];
+  case 'FileUploader-FileSelection':
+    return ['label-title-only'];
+  case 'TreeView-FlatDataStructure':
+    return ['image-redundant-alt'];
+  case 'TreeView-TreeViewWithSearchBar':
+    return ['aria-required-parent'];
   default:
     return [];
   }
@@ -155,13 +186,16 @@ const getTestSpecificSkipRules = (testName) => {
           const testSpecificSkipRules = getTestSpecificSkipRules(testName);
           const options = { rules: { } };
 
-          ['color-contrast', ...testSpecificSkipRules].forEach((ruleName) => {
+          [...COMMON_SKIP_RULES, ...testSpecificSkipRules].forEach((ruleName) => {
             options.rules[ruleName] = { enabled: false };
           });
 
-          const { error, results } = await axeCheck(t, '.demo-container', options);
+          const axeResult = await axeCheck(t, '.demo-container', options);
+          const { error, results } = axeResult;
 
-          if (results.violations.length > 0) {
+          if (error) {
+            console.error('####%%%%####', JSON.stringify(error, Object.getOwnPropertyNames(error)));
+          } else if (results.violations.length > 0) {
             createMdReport({ testName, results });
             await t.report(createTestCafeReport(results.violations));
           }

--- a/testing/common.test.js
+++ b/testing/common.test.js
@@ -79,6 +79,13 @@ const execTestCafeCode = (t, code) => {
 
   const getDemoPaths = (platform) => glob.sync('JSDemos/Demos/*/*')
     .map((path) => join(path, platform));
+  const ACCESSIBILITY_UNSUPPORTED_COMPONENTS = [
+    'Accordion',
+    'Charts',
+    'Diagram',
+    'FileManager',
+    'Gantt',
+  ];
 
   getDemoPaths(approach).forEach((demoPath, index) => {
     if (!shouldRunTestAtIndex(index + 1) || !existsSync(demoPath)) { return; }
@@ -104,6 +111,9 @@ const execTestCafeCode = (t, code) => {
         ...visualTestSettings[approachLowerCase],
       }) || {};
 
+      if (process.env.STRATEGY === 'accessibility' && ACCESSIBILITY_UNSUPPORTED_COMPONENTS.indexOf(widgetName) > -1) {
+        return;
+      }
       if (process.env.CI_ENV && process.env.DISABLE_DEMO_TEST_SETTINGS !== 'ignore') {
         if (mergedTestSettings.ignore) { return; }
       }

--- a/testing/common.test.js
+++ b/testing/common.test.js
@@ -58,40 +58,40 @@ const SKIP_ACCESSIBILITY_TESTS = ['TabPanel-Overview'];
 const COMMON_SKIP_RULES = ['color-contrast'];
 const getTestSpecificSkipRules = (testName) => {
   switch (testName) {
-  case 'Calendar-MultipleSelection':
-  case 'DataGrid-ExcelJSCellCustomization':
-  case 'DataGrid-HorizontalVirtualScrolling':
-  case 'DataGrid-PDFCellCustomization':
-    return ['empty-table-header'];
-  case 'Autocomplete-Overview':
-  case 'DataGrid-Filtering':
-  case 'DataGrid-FilterPanel':
-  case 'Localization-UsingGlobalize':
-  case 'Localization-UsingIntl':
-    return ['label'];
-  case 'DataGrid-RowTemplate':
-  case 'DataGrid-Row3RdPartyEngineTemplate':
-    return ['aria-required-children', 'image-alt'];
-  case 'DataGrid-CustomNewRecordPosition':
-    return ['link-name'];
-  case 'DataGrid-Column3RdPartyEngineTemplate':
-  case 'DataGrid-ColumnTemplate':
-  case 'DataGrid-ExcelJSExportImages':
-  case 'DataGrid-FilteringAPI':
-  case 'DataGrid-MasterDetailAPI':
-  case 'DataGrid-PDFExportImages':
-  case 'DataGrid-RowSelection':
-  case 'FilterBuilder-WithList':
-  case 'Gallery-Overview':
-    return ['image-alt'];
-  case 'FileUploader-FileSelection':
-    return ['label-title-only'];
-  case 'TreeView-FlatDataStructure':
-    return ['image-redundant-alt'];
-  case 'TreeView-TreeViewWithSearchBar':
-    return ['aria-required-parent'];
-  default:
-    return [];
+    case 'Calendar-MultipleSelection':
+    case 'DataGrid-ExcelJSCellCustomization':
+    case 'DataGrid-HorizontalVirtualScrolling':
+    case 'DataGrid-PDFCellCustomization':
+      return ['empty-table-header'];
+    case 'Autocomplete-Overview':
+    case 'DataGrid-Filtering':
+    case 'DataGrid-FilterPanel':
+    case 'Localization-UsingGlobalize':
+    case 'Localization-UsingIntl':
+      return ['label'];
+    case 'DataGrid-RowTemplate':
+    case 'DataGrid-Row3RdPartyEngineTemplate':
+      return ['aria-required-children', 'image-alt'];
+    case 'DataGrid-CustomNewRecordPosition':
+      return ['link-name'];
+    case 'DataGrid-Column3RdPartyEngineTemplate':
+    case 'DataGrid-ColumnTemplate':
+    case 'DataGrid-ExcelJSExportImages':
+    case 'DataGrid-FilteringAPI':
+    case 'DataGrid-MasterDetailAPI':
+    case 'DataGrid-PDFExportImages':
+    case 'DataGrid-RowSelection':
+    case 'FilterBuilder-WithList':
+    case 'Gallery-Overview':
+      return ['image-alt'];
+    case 'FileUploader-FileSelection':
+      return ['label-title-only'];
+    case 'TreeView-FlatDataStructure':
+      return ['image-redundant-alt'];
+    case 'TreeView-TreeViewWithSearchBar':
+      return ['aria-required-parent'];
+    default:
+      return [];
   }
 };
 
@@ -126,7 +126,6 @@ const getTestSpecificSkipRules = (testName) => {
     'Diagram',
     'FileManager',
     'Gantt',
-    // Grid's
     'Scheduler',
     'PivotGrid',
   ];
@@ -188,10 +187,10 @@ const getTestSpecificSkipRules = (testName) => {
             return;
           }
 
-          const testSpecificSkipRules = getTestSpecificSkipRules(testName);
+          const specificSkipRules = getTestSpecificSkipRules(testName);
           const options = { rules: { } };
 
-          [...COMMON_SKIP_RULES, ...testSpecificSkipRules].forEach((ruleName) => {
+          [...COMMON_SKIP_RULES, ...specificSkipRules].forEach((ruleName) => {
             options.rules[ruleName] = { enabled: false };
           });
 

--- a/testing/common.test.js
+++ b/testing/common.test.js
@@ -54,6 +54,15 @@ const execTestCafeCode = (t, code) => {
   return testCafeFunction(t);
 };
 
+const getTestSpecificSkipRules = (testName) => {
+  switch (testName) {
+  case 'Calendar-MultipleSelection':
+    return ['empty-table-header'];
+  default:
+    return [];
+  }
+};
+
 ['jQuery', 'React', 'Vue', 'Angular'].forEach((approach) => {
   if (!shouldRunFramework(approach)) { return; }
   fixture(approach)
@@ -143,7 +152,13 @@ const execTestCafeCode = (t, code) => {
         }
 
         if (process.env.STRATEGY === 'accessibility') {
-          const options = { rules: { 'color-contrast': { enabled: false } } };
+          const testSpecificSkipRules = getTestSpecificSkipRules(testName);
+          const options = { rules: { } };
+
+          ['color-contrast', ...testSpecificSkipRules].forEach((ruleName) => {
+            options.rules[ruleName] = { enabled: false };
+          });
+
           const { error, results } = await axeCheck(t, '.demo-container', options);
 
           if (results.violations.length > 0) {

--- a/testing/common.test.js
+++ b/testing/common.test.js
@@ -54,6 +54,7 @@ const execTestCafeCode = (t, code) => {
   return testCafeFunction(t);
 };
 
+const SKIP_ACCESSIBILITY_TESTS = ['TabPanel-Overview'];
 const COMMON_SKIP_RULES = ['color-contrast'];
 const getTestSpecificSkipRules = (testName) => {
   switch (testName) {
@@ -183,6 +184,10 @@ const getTestSpecificSkipRules = (testName) => {
         }
 
         if (process.env.STRATEGY === 'accessibility') {
+          if (SKIP_ACCESSIBILITY_TESTS.indexOf(testName) > -1) {
+            return;
+          }
+
           const testSpecificSkipRules = getTestSpecificSkipRules(testName);
           const options = { rules: { } };
 

--- a/testing/common.test.js
+++ b/testing/common.test.js
@@ -85,6 +85,9 @@ const execTestCafeCode = (t, code) => {
     'Diagram',
     'FileManager',
     'Gantt',
+    // Grid's
+    'Scheduler',
+    'PivotGrid',
   ];
 
   getDemoPaths(approach).forEach((demoPath, index) => {


### PR DESCRIPTION
1. Skipped the following tests:
- for Charts(all viz), FileManager, Gantt, Diagram, Scheduler, PivotGrid, Accordion
- all contrast issues
- reset specific errors (moved for planning, should be fixed in the nearest time).
2. We made accessibility task to be failed if some unexpected report is found.
After merge of this pull request we'll make this job required to be successfully passed.
3. Fixed issues with non-unique id in Grid's demo.