### PR TITLE
Log DevExtreme top commit

### DIFF
--- a/.github/workflows/visual_tests.yml
+++ b/.github/workflows/visual_tests.yml
@@ -35,6 +35,10 @@ jobs:
         BASE_BRANCH=$(node -p -e "require('./package.json').version.slice(0, 4).replace('.', '_')")
         test -d ./devextreme-repo || git clone -b $BASE_BRANCH https://github.com/devexpress/devextreme ./devextreme-repo
 
+    - name: Log devextreme top commit
+      working-directory: ./devextreme-repo
+      run: git log -1 --oneline
+
     #Build Devextreme
     - name: DevExtreme - Restore npm cache
       uses: actions/cache@v3

--- a/.github/workflows/visual_tests_frameworks.yml
+++ b/.github/workflows/visual_tests_frameworks.yml
@@ -35,6 +35,10 @@ jobs:
         BASE_BRANCH=$(node -p -e "require('./package.json').version.slice(0, 4).replace('.', '_')")
         test -d ./devextreme || git clone -b $BASE_BRANCH --depth 1 https://github.com/devexpress/devextreme ./devextreme
 
+    - name: Log devextreme top commit
+      working-directory: ./devextreme
+      run: git log -1 --oneline
+
     #Build Devextreme
     - name: Restore npm cache
       uses: actions/cache@v3


### PR DESCRIPTION
It is often necessary to re-run some check, and it would be useful to see the actual cloned devextreme top / head in logs (if it is changed between runs, etc.).

See Also:
https://github.com/DevExpress/DevExtreme/pull/26036