### PR TITLE
AspNet: Install DevExtreme.AspNet.Core package from file in release configuration

### DIFF
--- a/gulpfile.js/copy-asp-files.js
+++ b/gulpfile.js/copy-asp-files.js
@@ -34,6 +34,11 @@ function restorePackages(callback) {
   callback();
 }
 
+function installAspNetCorePackage(callback) {
+  systemSync('dotnet add NetCoreDemos package DevExtreme.AspNet.Core --prerelease --source NetCoreDemos/NuGet/');
+  callback();
+}
+
 task('prepareMisc', parallel(
   () => src('MVCDemos/AppData/*.ldf', { read: false }).pipe(clean()),
   () => src('NetCoreDemos/Northwind.mdf')
@@ -87,5 +92,5 @@ exports.copyAspFiles = series(
     () => src(`${aspnetPackagesPath}/*.nupkg`)
       .pipe(dest('NetCoreDemos/Nuget')),
   ),
-  restorePackages,
+  installAspNetCorePackage,
 );


### PR DESCRIPTION
When script is run in release configuration, add DevExtreme.AspNet.Core package from file (build result), update package reference in Nuget.config if needed. The command also runs dotnet restore