### PR TITLE
Named Imports for React Hooks

### DIFF
--- a/JSDemos/Demos/Accordion/Overview/React/App.tsx
+++ b/JSDemos/Demos/Accordion/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Accordion, { AccordionTypes } from 'devextreme-react/accordion';
 import CheckBox, { CheckBoxTypes } from 'devextreme-react/check-box';
 import TagBox, { TagBoxTypes } from 'devextreme-react/tag-box';
@@ -12,12 +12,12 @@ const companyLabel = { 'aria-label': 'Company' };
 const companies = service.getCompanies();
 
 const App = () => {
-  const [selectedItems, setSelectedItems] = React.useState([companies[0]]);
-  const [multiple, setMultiple] = React.useState(false);
-  const [collapsible, setCollapsible] = React.useState(false);
-  const [animationDuration, setAnimationDuration] = React.useState(300);
+  const [selectedItems, setSelectedItems] = useState([companies[0]]);
+  const [multiple, setMultiple] = useState(false);
+  const [collapsible, setCollapsible] = useState(false);
+  const [animationDuration, setAnimationDuration] = useState(300);
 
-  const selectionChanged = React.useCallback((e: AccordionTypes.SelectionChangedEvent) => {
+  const selectionChanged = useCallback((e: AccordionTypes.SelectionChangedEvent) => {
     let newItems = [...selectedItems];
     e.removedItems.forEach((item) => {
       const index = newItems.indexOf(item);
@@ -31,19 +31,19 @@ const App = () => {
     setSelectedItems(newItems);
   }, [selectedItems, setSelectedItems]);
 
-  const selectedItemsChanged = React.useCallback((e: TagBoxTypes.ValueChangedEvent) => {
+  const selectedItemsChanged = useCallback((e: TagBoxTypes.ValueChangedEvent) => {
     setSelectedItems(e.value);
   }, [setSelectedItems]);
 
-  const multipleChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const multipleChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setMultiple(e.value);
   }, [setMultiple]);
 
-  const collapsibleChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const collapsibleChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setCollapsible(e.value);
   }, [setCollapsible]);
 
-  const animationDurationChanged = React.useCallback((e: SliderTypes.ValueChangedEvent) => {
+  const animationDurationChanged = useCallback((e: SliderTypes.ValueChangedEvent) => {
     setAnimationDuration(e.value);
   }, [setAnimationDuration]);
 

--- a/JSDemos/Demos/Accordion/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/Accordion/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Accordion from 'devextreme-react/accordion';
 import CheckBox from 'devextreme-react/check-box';
 import TagBox from 'devextreme-react/tag-box';
@@ -10,11 +10,11 @@ import CustomItem from './CustomItem.js';
 const companyLabel = { 'aria-label': 'Company' };
 const companies = service.getCompanies();
 const App = () => {
-  const [selectedItems, setSelectedItems] = React.useState([companies[0]]);
-  const [multiple, setMultiple] = React.useState(false);
-  const [collapsible, setCollapsible] = React.useState(false);
-  const [animationDuration, setAnimationDuration] = React.useState(300);
-  const selectionChanged = React.useCallback(
+  const [selectedItems, setSelectedItems] = useState([companies[0]]);
+  const [multiple, setMultiple] = useState(false);
+  const [collapsible, setCollapsible] = useState(false);
+  const [animationDuration, setAnimationDuration] = useState(300);
+  const selectionChanged = useCallback(
     (e) => {
       let newItems = [...selectedItems];
       e.removedItems.forEach((item) => {
@@ -30,25 +30,25 @@ const App = () => {
     },
     [selectedItems, setSelectedItems],
   );
-  const selectedItemsChanged = React.useCallback(
+  const selectedItemsChanged = useCallback(
     (e) => {
       setSelectedItems(e.value);
     },
     [setSelectedItems],
   );
-  const multipleChanged = React.useCallback(
+  const multipleChanged = useCallback(
     (e) => {
       setMultiple(e.value);
     },
     [setMultiple],
   );
-  const collapsibleChanged = React.useCallback(
+  const collapsibleChanged = useCallback(
     (e) => {
       setCollapsible(e.value);
     },
     [setCollapsible],
   );
-  const animationDurationChanged = React.useCallback(
+  const animationDurationChanged = useCallback(
     (e) => {
       setAnimationDuration(e.value);
     },

--- a/JSDemos/Demos/ActionSheet/Basics/React/App.tsx
+++ b/JSDemos/Demos/ActionSheet/Basics/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import ActionSheet, { ActionSheetTypes } from 'devextreme-react/action-sheet';
 import Button from 'devextreme-react/button';
 import Switch, { SwitchTypes } from 'devextreme-react/switch';
@@ -6,32 +6,32 @@ import notify from 'devextreme/ui/notify';
 import { actionSheetItems } from './data.ts';
 
 const App = () => {
-  const [isActionSheetVisible, setIsActionSheetVisible] = React.useState(false);
-  const [showTitle, setShowTitle] = React.useState(true);
-  const [showCancelButton, setShowCancelButton] = React.useState(true);
+  const [isActionSheetVisible, setIsActionSheetVisible] = useState(false);
+  const [showTitle, setShowTitle] = useState(true);
+  const [showCancelButton, setShowCancelButton] = useState(true);
 
-  const showActionSheet = React.useCallback(() => {
+  const showActionSheet = useCallback(() => {
     setIsActionSheetVisible(true);
   }, [setIsActionSheetVisible]);
 
-  const onActionSheetButtonClick = React.useCallback((buttonName: string) => {
+  const onActionSheetButtonClick = useCallback((buttonName: string) => {
     setIsActionSheetVisible(false);
     notify(`The "${buttonName}" button is clicked.`);
   }, [setIsActionSheetVisible]);
 
-  const onActionSheetItemClick = React.useCallback((e: ActionSheetTypes.ItemClickEvent) => {
+  const onActionSheetItemClick = useCallback((e: ActionSheetTypes.ItemClickEvent) => {
     onActionSheetButtonClick(e.itemData.text);
   }, [onActionSheetButtonClick]);
 
-  const onActionSheetCancelClick = React.useCallback(() => {
+  const onActionSheetCancelClick = useCallback(() => {
     onActionSheetButtonClick('Cancel');
   }, [onActionSheetButtonClick]);
 
-  const changeTitle = React.useCallback((e: SwitchTypes.ValueChangedEvent) => {
+  const changeTitle = useCallback((e: SwitchTypes.ValueChangedEvent) => {
     setShowTitle(e.value);
   }, [setShowTitle]);
 
-  const changeCancelButton = React.useCallback((e: SwitchTypes.ValueChangedEvent) => {
+  const changeCancelButton = useCallback((e: SwitchTypes.ValueChangedEvent) => {
     setShowCancelButton(e.value);
   }, [setShowCancelButton]);
 

--- a/JSDemos/Demos/ActionSheet/Basics/ReactJs/App.js
+++ b/JSDemos/Demos/ActionSheet/Basics/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import ActionSheet from 'devextreme-react/action-sheet';
 import Button from 'devextreme-react/button';
 import Switch from 'devextreme-react/switch';
@@ -6,35 +6,35 @@ import notify from 'devextreme/ui/notify';
 import { actionSheetItems } from './data.js';
 
 const App = () => {
-  const [isActionSheetVisible, setIsActionSheetVisible] = React.useState(false);
-  const [showTitle, setShowTitle] = React.useState(true);
-  const [showCancelButton, setShowCancelButton] = React.useState(true);
-  const showActionSheet = React.useCallback(() => {
+  const [isActionSheetVisible, setIsActionSheetVisible] = useState(false);
+  const [showTitle, setShowTitle] = useState(true);
+  const [showCancelButton, setShowCancelButton] = useState(true);
+  const showActionSheet = useCallback(() => {
     setIsActionSheetVisible(true);
   }, [setIsActionSheetVisible]);
-  const onActionSheetButtonClick = React.useCallback(
+  const onActionSheetButtonClick = useCallback(
     (buttonName) => {
       setIsActionSheetVisible(false);
       notify(`The "${buttonName}" button is clicked.`);
     },
     [setIsActionSheetVisible],
   );
-  const onActionSheetItemClick = React.useCallback(
+  const onActionSheetItemClick = useCallback(
     (e) => {
       onActionSheetButtonClick(e.itemData.text);
     },
     [onActionSheetButtonClick],
   );
-  const onActionSheetCancelClick = React.useCallback(() => {
+  const onActionSheetCancelClick = useCallback(() => {
     onActionSheetButtonClick('Cancel');
   }, [onActionSheetButtonClick]);
-  const changeTitle = React.useCallback(
+  const changeTitle = useCallback(
     (e) => {
       setShowTitle(e.value);
     },
     [setShowTitle],
   );
-  const changeCancelButton = React.useCallback(
+  const changeCancelButton = useCallback(
     (e) => {
       setShowCancelButton(e.value);
     },

--- a/JSDemos/Demos/ActionSheet/PopoverMode/React/App.tsx
+++ b/JSDemos/Demos/ActionSheet/PopoverMode/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import ActionSheet, { ActionSheetTypes } from 'devextreme-react/action-sheet';
 import List, { ListTypes } from 'devextreme-react/list';
 
@@ -8,20 +8,20 @@ import RenderContactItem from './ContactItem.tsx';
 import { actionSheetItems, contacts } from './data.ts';
 
 const App = () => {
-  const [isActionSheetVisible, setIsActionSheetVisible] = React.useState(false);
-  const [actionSheetTarget, setActionSheetTarget] = React.useState<HTMLElement | string>('');
+  const [isActionSheetVisible, setIsActionSheetVisible] = useState(false);
+  const [actionSheetTarget, setActionSheetTarget] = useState<HTMLElement | string>('');
 
-  const onListItemClick = React.useCallback((e: ListTypes.ItemClickEvent) => {
+  const onListItemClick = useCallback((e: ListTypes.ItemClickEvent) => {
     setIsActionSheetVisible(true);
     setActionSheetTarget(e.itemElement);
   }, [setIsActionSheetVisible, setActionSheetTarget]);
 
-  const onActionSheetItemClick = React.useCallback((e: ActionSheetTypes.ItemClickEvent) => {
+  const onActionSheetItemClick = useCallback((e: ActionSheetTypes.ItemClickEvent) => {
     setIsActionSheetVisible(false);
     notify(`The "${e.itemData.text}" button is clicked.`);
   }, [setIsActionSheetVisible]);
 
-  const onVisibleChange = React.useCallback((isVisible: boolean) => {
+  const onVisibleChange = useCallback((isVisible: boolean) => {
     if (isVisible !== isActionSheetVisible) {
       setIsActionSheetVisible(isVisible);
     }

--- a/JSDemos/Demos/ActionSheet/PopoverMode/ReactJs/App.js
+++ b/JSDemos/Demos/ActionSheet/PopoverMode/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import ActionSheet from 'devextreme-react/action-sheet';
 import List from 'devextreme-react/list';
 import notify from 'devextreme/ui/notify';
@@ -6,23 +6,23 @@ import RenderContactItem from './ContactItem.js';
 import { actionSheetItems, contacts } from './data.js';
 
 const App = () => {
-  const [isActionSheetVisible, setIsActionSheetVisible] = React.useState(false);
-  const [actionSheetTarget, setActionSheetTarget] = React.useState('');
-  const onListItemClick = React.useCallback(
+  const [isActionSheetVisible, setIsActionSheetVisible] = useState(false);
+  const [actionSheetTarget, setActionSheetTarget] = useState('');
+  const onListItemClick = useCallback(
     (e) => {
       setIsActionSheetVisible(true);
       setActionSheetTarget(e.itemElement);
     },
     [setIsActionSheetVisible, setActionSheetTarget],
   );
-  const onActionSheetItemClick = React.useCallback(
+  const onActionSheetItemClick = useCallback(
     (e) => {
       setIsActionSheetVisible(false);
       notify(`The "${e.itemData.text}" button is clicked.`);
     },
     [setIsActionSheetVisible],
   );
-  const onVisibleChange = React.useCallback(
+  const onVisibleChange = useCallback(
     (isVisible) => {
       if (isVisible !== isActionSheetVisible) {
         setIsActionSheetVisible(isVisible);

--- a/JSDemos/Demos/Autocomplete/Overview/React/App.tsx
+++ b/JSDemos/Demos/Autocomplete/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import ODataStore from 'devextreme/data/odata/store';
 import { Autocomplete, AutocompleteTypes } from 'devextreme-react/autocomplete';
 import CustomStore from 'devextreme/data/custom_store';
@@ -47,25 +47,25 @@ const renderState = (data) => (
 );
 
 function App() {
-  const [firstName, setFirstName] = React.useState('');
-  const [lastName, setLastName] = React.useState('');
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
 
-  const [state, setState] = React.useState('');
-  const [currentClient, setCurrentClient] = React.useState('');
+  const [state, setState] = useState('');
+  const [currentClient, setCurrentClient] = useState('');
 
-  const handleFirstNameChange = React.useCallback((e: AutocompleteTypes.ValueChangedEvent) => {
+  const handleFirstNameChange = useCallback((e: AutocompleteTypes.ValueChangedEvent) => {
     setFirstName(e.value);
   }, []);
 
-  const handleLastNameChange = React.useCallback((e: AutocompleteTypes.ValueChangedEvent) => {
+  const handleLastNameChange = useCallback((e: AutocompleteTypes.ValueChangedEvent) => {
     setLastName(e.value);
   }, []);
 
-  const handleStateChange = React.useCallback((e: AutocompleteTypes.ValueChangedEvent) => {
+  const handleStateChange = useCallback((e: AutocompleteTypes.ValueChangedEvent) => {
     setState(e.value);
   }, []);
 
-  const handleCurrentClientChange = React.useCallback((e: AutocompleteTypes.ValueChangedEvent) => {
+  const handleCurrentClientChange = useCallback((e: AutocompleteTypes.ValueChangedEvent) => {
     setCurrentClient(e.value);
   }, []);
 

--- a/JSDemos/Demos/Autocomplete/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/Autocomplete/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import ODataStore from 'devextreme/data/odata/store';
 import { Autocomplete } from 'devextreme-react/autocomplete';
 import CustomStore from 'devextreme/data/custom_store';
@@ -42,20 +42,20 @@ const renderState = (data) => (
   </span>
 );
 function App() {
-  const [firstName, setFirstName] = React.useState('');
-  const [lastName, setLastName] = React.useState('');
-  const [state, setState] = React.useState('');
-  const [currentClient, setCurrentClient] = React.useState('');
-  const handleFirstNameChange = React.useCallback((e) => {
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [state, setState] = useState('');
+  const [currentClient, setCurrentClient] = useState('');
+  const handleFirstNameChange = useCallback((e) => {
     setFirstName(e.value);
   }, []);
-  const handleLastNameChange = React.useCallback((e) => {
+  const handleLastNameChange = useCallback((e) => {
     setLastName(e.value);
   }, []);
-  const handleStateChange = React.useCallback((e) => {
+  const handleStateChange = useCallback((e) => {
     setState(e.value);
   }, []);
-  const handleCurrentClientChange = React.useCallback((e) => {
+  const handleCurrentClientChange = useCallback((e) => {
     setCurrentClient(e.value);
   }, []);
   let fullInfo = '';

--- a/JSDemos/Demos/Calendar/MultipleSelection/React/App.tsx
+++ b/JSDemos/Demos/Calendar/MultipleSelection/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import CheckBox from 'devextreme-react/check-box';
 import SelectBox from 'devextreme-react/select-box';
 import Button from 'devextreme-react/button';
@@ -17,38 +17,38 @@ const msInDay = 1000 * 60 * 60 * 24;
 const initialValue = [now, now + msInDay];
 
 export default function App() {
-  const calendar = React.useRef(null);
-  const [selectWeekOnClick, setSelectWeekOnClick] = React.useState(true);
-  const [selectionMode, setSelectionMode] = React.useState<CalendarTypes.CalendarSelectionMode>('multiple');
-  const [minDateValue, setMinDateValue] = React.useState(null);
-  const [maxDateValue, setMaxDateValue] = React.useState(null);
-  const [weekendDisabled, setWeekendDisabled] = React.useState(null);
+  const calendar = useRef(null);
+  const [selectWeekOnClick, setSelectWeekOnClick] = useState(true);
+  const [selectionMode, setSelectionMode] = useState<CalendarTypes.CalendarSelectionMode>('multiple');
+  const [minDateValue, setMinDateValue] = useState(null);
+  const [maxDateValue, setMaxDateValue] = useState(null);
+  const [weekendDisabled, setWeekendDisabled] = useState(null);
 
-  const onSelectWeekOnClickChange = React.useCallback(({ value }) => {
+  const onSelectWeekOnClickChange = useCallback(({ value }) => {
     setSelectWeekOnClick(value);
   }, [setSelectWeekOnClick]);
 
-  const onSelectionModeChange = React.useCallback(({ value }) => {
+  const onSelectionModeChange = useCallback(({ value }) => {
     setSelectionMode(value);
   }, [setSelectionMode]);
 
-  const onMinDateChange = React.useCallback(({ value }) => {
+  const onMinDateChange = useCallback(({ value }) => {
     setMinDateValue(
       value ? new Date(new Date().getTime() - 1000 * 60 * 60 * 24 * 3) : null,
     );
   }, [setMinDateValue]);
 
-  const onMaxDateChange = React.useCallback(({ value }) => {
+  const onMaxDateChange = useCallback(({ value }) => {
     setMaxDateValue(
       value ? new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 3) : null,
     );
   }, [setMaxDateValue]);
 
-  const onDisableWeekendChange = React.useCallback(({ value }) => {
+  const onDisableWeekendChange = useCallback(({ value }) => {
     setWeekendDisabled(value);
   }, [setWeekendDisabled]);
 
-  const onClearButtonClick = React.useCallback(() => {
+  const onClearButtonClick = useCallback(() => {
     calendar.current.instance.clear();
   }, []);
 

--- a/JSDemos/Demos/Calendar/MultipleSelection/ReactJs/App.js
+++ b/JSDemos/Demos/Calendar/MultipleSelection/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import CheckBox from 'devextreme-react/check-box';
 import SelectBox from 'devextreme-react/select-box';
 import Button from 'devextreme-react/button';
@@ -15,43 +15,43 @@ const now = new Date().getTime();
 const msInDay = 1000 * 60 * 60 * 24;
 const initialValue = [now, now + msInDay];
 export default function App() {
-  const calendar = React.useRef(null);
-  const [selectWeekOnClick, setSelectWeekOnClick] = React.useState(true);
-  const [selectionMode, setSelectionMode] = React.useState('multiple');
-  const [minDateValue, setMinDateValue] = React.useState(null);
-  const [maxDateValue, setMaxDateValue] = React.useState(null);
-  const [weekendDisabled, setWeekendDisabled] = React.useState(null);
-  const onSelectWeekOnClickChange = React.useCallback(
+  const calendar = useRef(null);
+  const [selectWeekOnClick, setSelectWeekOnClick] = useState(true);
+  const [selectionMode, setSelectionMode] = useState('multiple');
+  const [minDateValue, setMinDateValue] = useState(null);
+  const [maxDateValue, setMaxDateValue] = useState(null);
+  const [weekendDisabled, setWeekendDisabled] = useState(null);
+  const onSelectWeekOnClickChange = useCallback(
     ({ value }) => {
       setSelectWeekOnClick(value);
     },
     [setSelectWeekOnClick],
   );
-  const onSelectionModeChange = React.useCallback(
+  const onSelectionModeChange = useCallback(
     ({ value }) => {
       setSelectionMode(value);
     },
     [setSelectionMode],
   );
-  const onMinDateChange = React.useCallback(
+  const onMinDateChange = useCallback(
     ({ value }) => {
       setMinDateValue(value ? new Date(new Date().getTime() - 1000 * 60 * 60 * 24 * 3) : null);
     },
     [setMinDateValue],
   );
-  const onMaxDateChange = React.useCallback(
+  const onMaxDateChange = useCallback(
     ({ value }) => {
       setMaxDateValue(value ? new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 3) : null);
     },
     [setMaxDateValue],
   );
-  const onDisableWeekendChange = React.useCallback(
+  const onDisableWeekendChange = useCallback(
     ({ value }) => {
       setWeekendDisabled(value);
     },
     [setWeekendDisabled],
   );
-  const onClearButtonClick = React.useCallback(() => {
+  const onClearButtonClick = useCallback(() => {
     calendar.current.instance.clear();
   }, []);
   return (

--- a/JSDemos/Demos/Calendar/Overview/React/App.tsx
+++ b/JSDemos/Demos/Calendar/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import CheckBox from 'devextreme-react/check-box';
 import SelectBox from 'devextreme-react/select-box';
 import DateBox from 'devextreme-react/date-box';
@@ -23,64 +23,64 @@ const dayLabel = { 'aria-label': 'First Day of Week' };
 const ruleLabel = { 'aria-label': 'Week Number Rule' };
 
 export default function App() {
-  const [zoomLevel, setZoomLevel] = React.useState<CalendarTypes.CalendarZoomLevel>('month');
-  const [currentValue, setCurrentValue] = React.useState(new Date());
-  const [useCellTemplate, setUseCellTemplate] = React.useState(null);
-  const [disabled, setDisabled] = React.useState(false);
-  const [showWeekNumbers, setShowWeekNumbers] = React.useState(false);
-  const [firstDay, setFirstDay] = React.useState<CalendarTypes.FirstDayOfWeek>(0);
-  const [weekNumberRule, setWeekNumberRule] = React.useState<CalendarTypes.WeekNumberRule>('auto');
+  const [zoomLevel, setZoomLevel] = useState<CalendarTypes.CalendarZoomLevel>('month');
+  const [currentValue, setCurrentValue] = useState(new Date());
+  const [useCellTemplate, setUseCellTemplate] = useState(null);
+  const [disabled, setDisabled] = useState(false);
+  const [showWeekNumbers, setShowWeekNumbers] = useState(false);
+  const [firstDay, setFirstDay] = useState<CalendarTypes.FirstDayOfWeek>(0);
+  const [weekNumberRule, setWeekNumberRule] = useState<CalendarTypes.WeekNumberRule>('auto');
 
-  const onCurrentValueChange = React.useCallback(
+  const onCurrentValueChange = useCallback(
     ({ value }) => {
       setCurrentValue(value);
     },
     [setCurrentValue],
   );
 
-  const onDisabledChange = React.useCallback(
+  const onDisabledChange = useCallback(
     ({ value }) => {
       setDisabled(value);
     },
     [setDisabled],
   );
 
-  const onZoomLevelChange = React.useCallback(
+  const onZoomLevelChange = useCallback(
     ({ value }) => {
       setZoomLevel(value);
     },
     [setZoomLevel],
   );
 
-  const onFirstDayChange = React.useCallback(
+  const onFirstDayChange = useCallback(
     ({ value }) => {
       setFirstDay(value);
     },
     [setFirstDay],
   );
 
-  const onWeekNumberRuleChange = React.useCallback(
+  const onWeekNumberRuleChange = useCallback(
     ({ value }) => {
       setWeekNumberRule(value);
     },
     [setWeekNumberRule],
   );
 
-  const onShowWeekNumbersChange = React.useCallback(
+  const onShowWeekNumbersChange = useCallback(
     ({ value }) => {
       setShowWeekNumbers(value);
     },
     [setShowWeekNumbers],
   );
 
-  const onUseCellTemplateChange = React.useCallback(
+  const onUseCellTemplateChange = useCallback(
     ({ value }) => {
       setUseCellTemplate(!!value);
     },
     [setUseCellTemplate],
   );
 
-  const onOptionChange = React.useCallback(
+  const onOptionChange = useCallback(
     (e: { name: string }) => {
       if (e.name === 'zoomLevel') {
         onZoomLevelChange(e);

--- a/JSDemos/Demos/Calendar/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/Calendar/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import CheckBox from 'devextreme-react/check-box';
 import SelectBox from 'devextreme-react/select-box';
 import DateBox from 'devextreme-react/date-box';
@@ -21,56 +21,56 @@ const zoomLevelLabel = { 'aria-label': 'Zoom Level' };
 const dayLabel = { 'aria-label': 'First Day of Week' };
 const ruleLabel = { 'aria-label': 'Week Number Rule' };
 export default function App() {
-  const [zoomLevel, setZoomLevel] = React.useState('month');
-  const [currentValue, setCurrentValue] = React.useState(new Date());
-  const [useCellTemplate, setUseCellTemplate] = React.useState(null);
-  const [disabled, setDisabled] = React.useState(false);
-  const [showWeekNumbers, setShowWeekNumbers] = React.useState(false);
-  const [firstDay, setFirstDay] = React.useState(0);
-  const [weekNumberRule, setWeekNumberRule] = React.useState('auto');
-  const onCurrentValueChange = React.useCallback(
+  const [zoomLevel, setZoomLevel] = useState('month');
+  const [currentValue, setCurrentValue] = useState(new Date());
+  const [useCellTemplate, setUseCellTemplate] = useState(null);
+  const [disabled, setDisabled] = useState(false);
+  const [showWeekNumbers, setShowWeekNumbers] = useState(false);
+  const [firstDay, setFirstDay] = useState(0);
+  const [weekNumberRule, setWeekNumberRule] = useState('auto');
+  const onCurrentValueChange = useCallback(
     ({ value }) => {
       setCurrentValue(value);
     },
     [setCurrentValue],
   );
-  const onDisabledChange = React.useCallback(
+  const onDisabledChange = useCallback(
     ({ value }) => {
       setDisabled(value);
     },
     [setDisabled],
   );
-  const onZoomLevelChange = React.useCallback(
+  const onZoomLevelChange = useCallback(
     ({ value }) => {
       setZoomLevel(value);
     },
     [setZoomLevel],
   );
-  const onFirstDayChange = React.useCallback(
+  const onFirstDayChange = useCallback(
     ({ value }) => {
       setFirstDay(value);
     },
     [setFirstDay],
   );
-  const onWeekNumberRuleChange = React.useCallback(
+  const onWeekNumberRuleChange = useCallback(
     ({ value }) => {
       setWeekNumberRule(value);
     },
     [setWeekNumberRule],
   );
-  const onShowWeekNumbersChange = React.useCallback(
+  const onShowWeekNumbersChange = useCallback(
     ({ value }) => {
       setShowWeekNumbers(value);
     },
     [setShowWeekNumbers],
   );
-  const onUseCellTemplateChange = React.useCallback(
+  const onUseCellTemplateChange = useCallback(
     ({ value }) => {
       setUseCellTemplate(!!value);
     },
     [setUseCellTemplate],
   );
-  const onOptionChange = React.useCallback(
+  const onOptionChange = useCallback(
     (e) => {
       if (e.name === 'zoomLevel') {
         onZoomLevelChange(e);

--- a/JSDemos/Demos/Charts/APIDisplayATooltip/React/App.tsx
+++ b/JSDemos/Demos/Charts/APIDisplayATooltip/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import PieChart, {
   Series, Tooltip, Size, Legend, PieChartTypes,
 } from 'devextreme-react/pie-chart';
@@ -10,19 +10,19 @@ const customizeTooltip = (pointInfo) => ({
 });
 
 function App() {
-  const [selectedRegion, setSelectedRegion] = React.useState(null);
-  const pieChartRef = React.useRef<PieChart>(null);
+  const [selectedRegion, setSelectedRegion] = useState(null);
+  const pieChartRef = useRef<PieChart>(null);
 
-  const showTooltip = React.useCallback((point) => {
+  const showTooltip = useCallback((point) => {
     point.showTooltip();
     setSelectedRegion(point.argument);
   }, [setSelectedRegion]);
 
-  const onPointClick = React.useCallback(({ target: point }: PieChartTypes.PointClickEvent) => {
+  const onPointClick = useCallback(({ target: point }: PieChartTypes.PointClickEvent) => {
     showTooltip(point);
   }, [showTooltip]);
 
-  const onRegionChanged = React.useCallback(({ value }) => {
+  const onRegionChanged = useCallback(({ value }) => {
     const point = pieChartRef.current.instance.getAllSeries()[0].getPointsByArg(value)[0];
     showTooltip(point);
   }, [showTooltip]);

--- a/JSDemos/Demos/Charts/APIDisplayATooltip/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/APIDisplayATooltip/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import PieChart, {
   Series, Tooltip, Size, Legend,
 } from 'devextreme-react/pie-chart';
@@ -9,22 +9,22 @@ const customizeTooltip = (pointInfo) => ({
   text: `${pointInfo.argumentText}<br/>${pointInfo.valueText}`,
 });
 function App() {
-  const [selectedRegion, setSelectedRegion] = React.useState(null);
-  const pieChartRef = React.useRef(null);
-  const showTooltip = React.useCallback(
+  const [selectedRegion, setSelectedRegion] = useState(null);
+  const pieChartRef = useRef(null);
+  const showTooltip = useCallback(
     (point) => {
       point.showTooltip();
       setSelectedRegion(point.argument);
     },
     [setSelectedRegion],
   );
-  const onPointClick = React.useCallback(
+  const onPointClick = useCallback(
     ({ target: point }) => {
       showTooltip(point);
     },
     [showTooltip],
   );
-  const onRegionChanged = React.useCallback(
+  const onRegionChanged = useCallback(
     ({ value }) => {
       const point = pieChartRef.current.instance.getAllSeries()[0].getPointsByArg(value)[0];
       showTooltip(point);

--- a/JSDemos/Demos/Charts/Area/React/App.tsx
+++ b/JSDemos/Demos/Charts/Area/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 import {
   Chart,
@@ -16,9 +16,9 @@ import { dataSource, seriesTypeLabel } from './data.ts';
 const types: ChartTypes.SeriesType[] = ['area', 'stackedarea', 'fullstackedarea'];
 
 function App() {
-  const [type, setType] = React.useState<ChartTypes.SeriesType>(types[0]);
+  const [type, setType] = useState<ChartTypes.SeriesType>(types[0]);
 
-  const handleChange = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const handleChange = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setType(e.value);
   }, [setType]);
 

--- a/JSDemos/Demos/Charts/Area/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/Area/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import {
   Chart,
@@ -13,8 +13,8 @@ import { dataSource, seriesTypeLabel } from './data.js';
 
 const types = ['area', 'stackedarea', 'fullstackedarea'];
 function App() {
-  const [type, setType] = React.useState(types[0]);
-  const handleChange = React.useCallback(
+  const [type, setType] = useState(types[0]);
+  const handleChange = useCallback(
     (e) => {
       setType(e.value);
     },

--- a/JSDemos/Demos/Charts/AxisCustomPosition/React/App.tsx
+++ b/JSDemos/Demos/Charts/AxisCustomPosition/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import NumberBox, { NumberBoxTypes } from 'devextreme-react/number-box';
 import {
   Chart,
@@ -15,24 +15,24 @@ const dataSource = generateDataSource();
 const defaultVisualRange = [-20, 20];
 
 function App() {
-  const [argumentCustomPosition, setArgumentCustomPosition] = React.useState(0);
-  const [argumentOffset, setArgumentOffset] = React.useState(0);
-  const [valueCustomPosition, setValueCustomPosition] = React.useState(0);
-  const [valueOffset, setValueOffset] = React.useState(0);
+  const [argumentCustomPosition, setArgumentCustomPosition] = useState(0);
+  const [argumentOffset, setArgumentOffset] = useState(0);
+  const [valueCustomPosition, setValueCustomPosition] = useState(0);
+  const [valueOffset, setValueOffset] = useState(0);
 
-  const changeArgumentPosition = React.useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
+  const changeArgumentPosition = useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
     setArgumentCustomPosition(e.value);
   }, [setArgumentCustomPosition]);
 
-  const changeArgumentOffset = React.useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
+  const changeArgumentOffset = useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
     setArgumentOffset(e.value);
   }, [setArgumentOffset]);
 
-  const changeValuePosition = React.useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
+  const changeValuePosition = useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
     setValueCustomPosition(e.value);
   }, [setValueCustomPosition]);
 
-  const changeValueOffset = React.useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
+  const changeValueOffset = useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
     setValueOffset(e.value);
   }, [setValueOffset]);
 

--- a/JSDemos/Demos/Charts/AxisCustomPosition/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/AxisCustomPosition/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import NumberBox from 'devextreme-react/number-box';
 import {
   Chart,
@@ -14,29 +14,29 @@ import { generateDataSource, customPositionLabel, offsetLabel } from './data.js'
 const dataSource = generateDataSource();
 const defaultVisualRange = [-20, 20];
 function App() {
-  const [argumentCustomPosition, setArgumentCustomPosition] = React.useState(0);
-  const [argumentOffset, setArgumentOffset] = React.useState(0);
-  const [valueCustomPosition, setValueCustomPosition] = React.useState(0);
-  const [valueOffset, setValueOffset] = React.useState(0);
-  const changeArgumentPosition = React.useCallback(
+  const [argumentCustomPosition, setArgumentCustomPosition] = useState(0);
+  const [argumentOffset, setArgumentOffset] = useState(0);
+  const [valueCustomPosition, setValueCustomPosition] = useState(0);
+  const [valueOffset, setValueOffset] = useState(0);
+  const changeArgumentPosition = useCallback(
     (e) => {
       setArgumentCustomPosition(e.value);
     },
     [setArgumentCustomPosition],
   );
-  const changeArgumentOffset = React.useCallback(
+  const changeArgumentOffset = useCallback(
     (e) => {
       setArgumentOffset(e.value);
     },
     [setArgumentOffset],
   );
-  const changeValuePosition = React.useCallback(
+  const changeValuePosition = useCallback(
     (e) => {
       setValueCustomPosition(e.value);
     },
     [setValueCustomPosition],
   );
-  const changeValueOffset = React.useCallback(
+  const changeValueOffset = useCallback(
     (e) => {
       setValueOffset(e.value);
     },

--- a/JSDemos/Demos/Charts/AxisLabelsOverlapping/React/App.tsx
+++ b/JSDemos/Demos/Charts/AxisLabelsOverlapping/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 import {
   Chart,
@@ -10,9 +10,9 @@ import {
 import { overlappingModes, population, seriesTypeLabel } from './data.ts';
 
 function App() {
-  const [currentMode, setCurrentMode] = React.useState(overlappingModes[0]);
+  const [currentMode, setCurrentMode] = useState(overlappingModes[0]);
 
-  const handleChange = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const handleChange = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setCurrentMode(e.value);
   }, [setCurrentMode]);
 

--- a/JSDemos/Demos/Charts/AxisLabelsOverlapping/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/AxisLabelsOverlapping/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import {
   Chart, Series, ArgumentAxis, Legend, Label,
@@ -6,8 +6,8 @@ import {
 import { overlappingModes, population, seriesTypeLabel } from './data.js';
 
 function App() {
-  const [currentMode, setCurrentMode] = React.useState(overlappingModes[0]);
-  const handleChange = React.useCallback(
+  const [currentMode, setCurrentMode] = useState(overlappingModes[0]);
+  const handleChange = useCallback(
     (e) => {
       setCurrentMode(e.value);
     },

--- a/JSDemos/Demos/Charts/BarSparklines/React/App.tsx
+++ b/JSDemos/Demos/Charts/BarSparklines/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 import DataSource from 'devextreme/data/data_source';
 import CustomStore from 'devextreme/data/custom_store';
@@ -20,7 +20,7 @@ const dataSource = new DataSource({
 });
 
 function App() {
-  const onValueChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const onValueChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     dataSource.filter(['month', '<=', e.value]);
     dataSource.load();
   }, []);

--- a/JSDemos/Demos/Charts/BarSparklines/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/BarSparklines/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import DataSource from 'devextreme/data/data_source';
 import CustomStore from 'devextreme/data/custom_store';
@@ -21,7 +21,7 @@ const dataSource = new DataSource({
   paginate: false,
 });
 function App() {
-  const onValueChanged = React.useCallback((e) => {
+  const onValueChanged = useCallback((e) => {
     dataSource.filter(['month', '<=', e.value]);
     dataSource.load();
   }, []);

--- a/JSDemos/Demos/Charts/ChartsDrillDown/React/App.tsx
+++ b/JSDemos/Demos/Charts/ChartsDrillDown/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   Chart,
   Series,
@@ -12,10 +12,10 @@ import service from './data.ts';
 const colors = ['#6babac', '#e55253'];
 
 function App() {
-  const [isFirstLevel, setIsFirstLevel] = React.useState(true);
-  const [data, setData] = React.useState(service.filterData(''));
+  const [isFirstLevel, setIsFirstLevel] = useState(true);
+  const [data, setData] = useState(service.filterData(''));
 
-  const customizePoint = React.useCallback((): {
+  const customizePoint = useCallback((): {
     color: string,
     hoverStyle?: {
       color?: string,
@@ -28,14 +28,14 @@ function App() {
     } : {},
   }), [isFirstLevel]);
 
-  const onPointClick = React.useCallback((e: ChartTypes.PointClickEvent) => {
+  const onPointClick = useCallback((e: ChartTypes.PointClickEvent) => {
     if (isFirstLevel) {
       setIsFirstLevel(false);
       setData(service.filterData(e.target.originalArgument.toString()));
     }
   }, [isFirstLevel, setData, setIsFirstLevel]);
 
-  const onButtonClick = React.useCallback(() => {
+  const onButtonClick = useCallback(() => {
     if (!isFirstLevel) {
       setIsFirstLevel(true);
       setData(service.filterData(''));

--- a/JSDemos/Demos/Charts/ChartsDrillDown/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/ChartsDrillDown/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   Chart, Series, Legend, ValueAxis,
 } from 'devextreme-react/chart';
@@ -7,9 +7,9 @@ import service from './data.js';
 
 const colors = ['#6babac', '#e55253'];
 function App() {
-  const [isFirstLevel, setIsFirstLevel] = React.useState(true);
-  const [data, setData] = React.useState(service.filterData(''));
-  const customizePoint = React.useCallback(
+  const [isFirstLevel, setIsFirstLevel] = useState(true);
+  const [data, setData] = useState(service.filterData(''));
+  const customizePoint = useCallback(
     () => ({
       color: colors[Number(isFirstLevel)],
       hoverStyle: !isFirstLevel
@@ -20,7 +20,7 @@ function App() {
     }),
     [isFirstLevel],
   );
-  const onPointClick = React.useCallback(
+  const onPointClick = useCallback(
     (e) => {
       if (isFirstLevel) {
         setIsFirstLevel(false);
@@ -29,7 +29,7 @@ function App() {
     },
     [isFirstLevel, setData, setIsFirstLevel],
   );
-  const onButtonClick = React.useCallback(() => {
+  const onButtonClick = useCallback(() => {
     if (!isFirstLevel) {
       setIsFirstLevel(true);
       setData(service.filterData(''));

--- a/JSDemos/Demos/Charts/Colorization/React/App.tsx
+++ b/JSDemos/Demos/Charts/Colorization/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TreeMap, { Tooltip, ITooltipProps } from 'devextreme-react/tree-map';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 import { salesAmount, colorizationOptions, colorizationTypeLabel } from './data.ts';
@@ -12,9 +12,9 @@ const customizeTooltip: ITooltipProps['customizeTooltip'] = (arg) => {
 };
 
 function App() {
-  const [typeOptions, setTypeOptions] = React.useState(colorizationOptions[2].options);
+  const [typeOptions, setTypeOptions] = useState(colorizationOptions[2].options);
 
-  const setType = React.useCallback((data: SelectBoxTypes.ValueChangedEvent) => {
+  const setType = useCallback((data: SelectBoxTypes.ValueChangedEvent) => {
     setTypeOptions(data.value);
   }, [setTypeOptions]);
 

--- a/JSDemos/Demos/Charts/Colorization/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/Colorization/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TreeMap, { Tooltip } from 'devextreme-react/tree-map';
 import SelectBox from 'devextreme-react/select-box';
 import { salesAmount, colorizationOptions, colorizationTypeLabel } from './data.js';
@@ -12,8 +12,8 @@ const customizeTooltip = (arg) => {
   };
 };
 function App() {
-  const [typeOptions, setTypeOptions] = React.useState(colorizationOptions[2].options);
-  const setType = React.useCallback(
+  const [typeOptions, setTypeOptions] = useState(colorizationOptions[2].options);
+  const setType = useCallback(
     (data) => {
       setTypeOptions(data.value);
     },

--- a/JSDemos/Demos/Charts/CustomizePointsAndLabels/React/App.tsx
+++ b/JSDemos/Demos/Charts/CustomizePointsAndLabels/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
   Chart,
   Series,
@@ -19,7 +19,7 @@ function customizeText(arg: { valueText: string; }) {
 }
 
 function App() {
-  const customizePoint = React.useCallback((arg: { value: number; }) => {
+  const customizePoint = useCallback((arg: { value: number; }) => {
     if (arg.value > highAverage) {
       return { color: '#ff7c7c', hoverStyle: { color: '#ff7c7c' } };
     }
@@ -29,7 +29,7 @@ function App() {
     return null;
   }, []);
 
-  const customizeLabel = React.useCallback((arg: { value: number; }) => {
+  const customizeLabel = useCallback((arg: { value: number; }) => {
     if (arg.value > highAverage) {
       return {
         visible: true,

--- a/JSDemos/Demos/Charts/CustomizePointsAndLabels/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/CustomizePointsAndLabels/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
   Chart,
   Series,
@@ -17,7 +17,7 @@ function customizeText(arg) {
   return `${arg.valueText}&#176F`;
 }
 function App() {
-  const customizePoint = React.useCallback((arg) => {
+  const customizePoint = useCallback((arg) => {
     if (arg.value > highAverage) {
       return { color: '#ff7c7c', hoverStyle: { color: '#ff7c7c' } };
     }
@@ -26,7 +26,7 @@ function App() {
     }
     return null;
   }, []);
-  const customizeLabel = React.useCallback((arg) => {
+  const customizeLabel = useCallback((arg) => {
     if (arg.value > highAverage) {
       return {
         visible: true,

--- a/JSDemos/Demos/Charts/DiscreteAxisZoomingAndScrolling/React/App.tsx
+++ b/JSDemos/Demos/Charts/DiscreteAxisZoomingAndScrolling/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Chart, {
   ValueAxis,
   Label,
@@ -36,9 +36,9 @@ function formatValueAxisLabel(e: { valueText: string; }) {
 }
 
 function App() {
-  const [visualRange, setVisualRange] = React.useState<VisualRange>({ startValue: 'Inner Core', endValue: 'Upper Crust' });
+  const [visualRange, setVisualRange] = useState<VisualRange>({ startValue: 'Inner Core', endValue: 'Upper Crust' });
 
-  const updateVisualRange = React.useCallback((e: RangeSelectorTypes.ValueChangedEvent) => {
+  const updateVisualRange = useCallback((e: RangeSelectorTypes.ValueChangedEvent) => {
     setVisualRange(e.value);
   }, [setVisualRange]);
 

--- a/JSDemos/Demos/Charts/DiscreteAxisZoomingAndScrolling/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/DiscreteAxisZoomingAndScrolling/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Chart, {
   ValueAxis,
   Label,
@@ -37,11 +37,11 @@ function formatValueAxisLabel(e) {
   return `${e.valueText}%`;
 }
 function App() {
-  const [visualRange, setVisualRange] = React.useState({
+  const [visualRange, setVisualRange] = useState({
     startValue: 'Inner Core',
     endValue: 'Upper Crust',
   });
-  const updateVisualRange = React.useCallback(
+  const updateVisualRange = useCallback(
     (e) => {
       setVisualRange(e.value);
     },

--- a/JSDemos/Demos/Charts/DiscreteData/React/App.tsx
+++ b/JSDemos/Demos/Charts/DiscreteData/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 import {
   PolarChart,
@@ -9,9 +9,9 @@ import {
 import { types, dataSource, seriesTypeLabel } from './data.ts';
 
 function App() {
-  const [currentType, setCurrentType] = React.useState(types[0]);
+  const [currentType, setCurrentType] = useState(types[0]);
 
-  const handleChange = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const handleChange = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setCurrentType(e.value);
   }, [setCurrentType]);
 

--- a/JSDemos/Demos/Charts/DiscreteData/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/DiscreteData/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import {
   PolarChart, CommonSeriesSettings, Series, Margin,
@@ -6,8 +6,8 @@ import {
 import { types, dataSource, seriesTypeLabel } from './data.js';
 
 function App() {
-  const [currentType, setCurrentType] = React.useState(types[0]);
-  const handleChange = React.useCallback(
+  const [currentType, setCurrentType] = useState(types[0]);
+  const handleChange = useCallback(
     (e) => {
       setCurrentType(e.value);
     },

--- a/JSDemos/Demos/Charts/DrillDown/React/App.tsx
+++ b/JSDemos/Demos/Charts/DrillDown/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TreeMap, {
   Size, Title, Colorizer, TreeMapTypes,
 } from 'devextreme-react/tree-map';
@@ -18,9 +18,9 @@ function nodeClick(e: TreeMapTypes.ClickEvent) {
 }
 
 function App() {
-  const [drillInfo, setDrillInfo] = React.useState<DrillInfo[]>([]);
+  const [drillInfo, setDrillInfo] = useState<DrillInfo[]>([]);
 
-  const drill = React.useCallback((e: TreeMapTypes.DrillEvent) => {
+  const drill = useCallback((e: TreeMapTypes.DrillEvent) => {
     const newDrillInfo = [];
     for (let node = e.node.getParent(); node; node = node.getParent()) {
       newDrillInfo.unshift({

--- a/JSDemos/Demos/Charts/DrillDown/React/Breadcrumb.tsx
+++ b/JSDemos/Demos/Charts/DrillDown/React/Breadcrumb.tsx
@@ -1,5 +1,5 @@
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import { DrillInfo } from './data';
 
 interface BreadcrumbProps {
@@ -11,7 +11,7 @@ interface BreadcrumbProps {
 }
 
 function Breadcrumb(props: BreadcrumbProps) {
-  const onClick = React.useCallback(() => {
+  const onClick = useCallback(() => {
     props.onClick(props.info.node);
   }, [props]);
 

--- a/JSDemos/Demos/Charts/DrillDown/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/DrillDown/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TreeMap, { Size, Title, Colorizer } from 'devextreme-react/tree-map';
 import { citiesPopulation } from './data.js';
 import TreeMapBreadcrumbs from './TreeMapBreadcrumbs.js';
@@ -12,8 +12,8 @@ function nodeClick(e) {
   e.node.drillDown();
 }
 function App() {
-  const [drillInfo, setDrillInfo] = React.useState([]);
-  const drill = React.useCallback(
+  const [drillInfo, setDrillInfo] = useState([]);
+  const drill = useCallback(
     (e) => {
       const newDrillInfo = [];
       for (let node = e.node.getParent(); node; node = node.getParent()) {

--- a/JSDemos/Demos/Charts/DrillDown/ReactJs/Breadcrumb.js
+++ b/JSDemos/Demos/Charts/DrillDown/ReactJs/Breadcrumb.js
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 function Breadcrumb(props) {
-  const onClick = React.useCallback(() => {
+  const onClick = useCallback(() => {
     props.onClick(props.info.node);
   }, [props]);
   return (

--- a/JSDemos/Demos/Charts/ExportAndPrintingAPI/React/App.tsx
+++ b/JSDemos/Demos/Charts/ExportAndPrintingAPI/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import Chart, {
   Series,
   Legend,
@@ -22,13 +22,13 @@ function customizeLabelText({ value }) {
 }
 
 function App() {
-  const chartRef = React.useRef(null);
+  const chartRef = useRef(null);
 
-  const printChart = React.useCallback(() => {
+  const printChart = useCallback(() => {
     chartRef.current.instance.print();
   }, []);
 
-  const exportChart = React.useCallback(() => {
+  const exportChart = useCallback(() => {
     chartRef.current.instance.exportTo('Example', 'png');
   }, []);
 

--- a/JSDemos/Demos/Charts/ExportAndPrintingAPI/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/ExportAndPrintingAPI/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import Chart, {
   Series,
   Legend,
@@ -20,11 +20,11 @@ function customizeLabelText({ value }) {
   return `${value} m`;
 }
 function App() {
-  const chartRef = React.useRef(null);
-  const printChart = React.useCallback(() => {
+  const chartRef = useRef(null);
+  const printChart = useCallback(() => {
     chartRef.current.instance.print();
   }, []);
-  const exportChart = React.useCallback(() => {
+  const exportChart = useCallback(() => {
     chartRef.current.instance.exportTo('Example', 'png');
   }, []);
   return (

--- a/JSDemos/Demos/Charts/ExportCustomMarkup/React/App.tsx
+++ b/JSDemos/Demos/Charts/ExportCustomMarkup/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import {
   Chart, CommonSeriesSettings, Series, Legend, Title, Subtitle,
 } from 'devextreme-react/chart';
@@ -16,10 +16,10 @@ function prepareMarkup(chartSvg, markup) {
 }
 
 function App() {
-  const childRef = React.useRef(null);
-  const chartRef = React.useRef(null);
+  const childRef = useRef(null);
+  const chartRef = useRef(null);
 
-  const onClick = React.useCallback(() => {
+  const onClick = useCallback(() => {
     exportFromMarkup(
       prepareMarkup(chartRef.current.instance.svg(),
         childRef.current.innerHTML), {

--- a/JSDemos/Demos/Charts/ExportCustomMarkup/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/ExportCustomMarkup/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import {
   Chart,
   CommonSeriesSettings,
@@ -21,9 +21,9 @@ function prepareMarkup(chartSvg, markup) {
   );
 }
 function App() {
-  const childRef = React.useRef(null);
-  const chartRef = React.useRef(null);
-  const onClick = React.useCallback(() => {
+  const childRef = useRef(null);
+  const chartRef = useRef(null);
+  const onClick = useCallback(() => {
     exportFromMarkup(prepareMarkup(chartRef.current.instance.svg(), childRef.current.innerHTML), {
       width: 820,
       height: 420,

--- a/JSDemos/Demos/Charts/ExportSeveralCharts/React/App.tsx
+++ b/JSDemos/Demos/Charts/ExportSeveralCharts/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import Chart, { Series, Label, Legend } from 'devextreme-react/chart';
 import PieChart, { Series as PieSeries, Label as PieLabel, Connector } from 'devextreme-react/pie-chart';
 import { Button } from 'devextreme-react/button';
@@ -6,10 +6,10 @@ import { exportWidgets } from 'devextreme/viz/export';
 import { allMedals, goldMedals } from './data.ts';
 
 function App() {
-  const chartRef = React.useRef(null);
-  const pieChartRef = React.useRef(null);
+  const chartRef = useRef(null);
+  const pieChartRef = useRef(null);
 
-  const onClick = React.useCallback(() => {
+  const onClick = useCallback(() => {
     exportWidgets([[chartRef.current.instance, pieChartRef.current.instance]], {
       fileName: 'chart',
       format: 'PNG',

--- a/JSDemos/Demos/Charts/ExportSeveralCharts/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/ExportSeveralCharts/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import Chart, { Series, Label, Legend } from 'devextreme-react/chart';
 import PieChart, {
   Series as PieSeries,
@@ -10,9 +10,9 @@ import { exportWidgets } from 'devextreme/viz/export';
 import { allMedals, goldMedals } from './data.js';
 
 function App() {
-  const chartRef = React.useRef(null);
-  const pieChartRef = React.useRef(null);
-  const onClick = React.useCallback(() => {
+  const chartRef = useRef(null);
+  const pieChartRef = useRef(null);
+  const onClick = useCallback(() => {
     exportWidgets([[chartRef.current.instance, pieChartRef.current.instance]], {
       fileName: 'chart',
       format: 'PNG',

--- a/JSDemos/Demos/Charts/Line/React/App.tsx
+++ b/JSDemos/Demos/Charts/Line/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 import {
   Chart,
@@ -24,9 +24,9 @@ const types: (ChartPropsType['commonSeriesSettings']['type'])[] = ['line', 'stac
 const seriesTypeLabel = { 'aria-label': 'Series Type' };
 
 function App() {
-  const [type, setType] = React.useState(types[0]);
+  const [type, setType] = useState(types[0]);
 
-  const handleChange = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const handleChange = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setType(e.value);
   }, []);
 

--- a/JSDemos/Demos/Charts/Line/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/Line/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import {
   Chart,
@@ -20,8 +20,8 @@ const energySources = service.getEnergySources();
 const types = ['line', 'stackedline', 'fullstackedline'];
 const seriesTypeLabel = { 'aria-label': 'Series Type' };
 function App() {
-  const [type, setType] = React.useState(types[0]);
-  const handleChange = React.useCallback((e) => {
+  const [type, setType] = useState(types[0]);
+  const handleChange = useCallback((e) => {
     setType(e.value);
   }, []);
   return (

--- a/JSDemos/Demos/Charts/LoadDataOnDemand/React/App.tsx
+++ b/JSDemos/Demos/Charts/LoadDataOnDemand/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataSource from 'devextreme/data/data_source';
 import {
   Chart,
@@ -31,12 +31,12 @@ const wholeRange = {
 };
 
 function App() {
-  const [visualRange, setVisualRange] = React.useState({
+  const [visualRange, setVisualRange] = useState({
     startValue: new Date(2017, 3, 1),
     endValue: new Date(2017, 3, 15),
   });
 
-  const uploadDataByVisualRange = React.useCallback((component) => {
+  const uploadDataByVisualRange = useCallback((component) => {
     const dataSource = component.getDataSource();
     const storage = dataSource.items();
     const ajaxArgs = {
@@ -81,7 +81,7 @@ function App() {
     }
   }, [visualRange]);
 
-  const onVisualRangeChanged = React.useCallback((component) => {
+  const onVisualRangeChanged = useCallback((component) => {
     const items = component.getDataSource().items();
     if (
       !items.length
@@ -92,7 +92,7 @@ function App() {
     }
   }, [visualRange, uploadDataByVisualRange]);
 
-  const handleChange = React.useCallback((e: ChartTypes.OptionChangedEvent) => {
+  const handleChange = useCallback((e: ChartTypes.OptionChangedEvent) => {
     if (e.fullName === 'argumentAxis.visualRange') {
       const stateStart = visualRange.startValue;
       const currentStart = e.value.startValue;

--- a/JSDemos/Demos/Charts/LoadDataOnDemand/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/LoadDataOnDemand/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataSource from 'devextreme/data/data_source';
 import {
   Chart,
@@ -27,11 +27,11 @@ const wholeRange = {
   endValue: new Date(2017, 11, 31),
 };
 function App() {
-  const [visualRange, setVisualRange] = React.useState({
+  const [visualRange, setVisualRange] = useState({
     startValue: new Date(2017, 3, 1),
     endValue: new Date(2017, 3, 15),
   });
-  const uploadDataByVisualRange = React.useCallback(
+  const uploadDataByVisualRange = useCallback(
     (component) => {
       const dataSource = component.getDataSource();
       const storage = dataSource.items();
@@ -70,7 +70,7 @@ function App() {
     },
     [visualRange],
   );
-  const onVisualRangeChanged = React.useCallback(
+  const onVisualRangeChanged = useCallback(
     (component) => {
       const items = component.getDataSource().items();
       if (
@@ -83,7 +83,7 @@ function App() {
     },
     [visualRange, uploadDataByVisualRange],
   );
-  const handleChange = React.useCallback(
+  const handleChange = useCallback(
     (e) => {
       if (e.fullName === 'argumentAxis.visualRange') {
         const stateStart = visualRange.startValue;

--- a/JSDemos/Demos/Charts/Palette/React/App.tsx
+++ b/JSDemos/Demos/Charts/Palette/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import PieChart, {
   Series,
   Legend,
@@ -10,14 +10,14 @@ import {
 } from './data.ts';
 
 function App() {
-  const [palette, setPalette] = React.useState(paletteCollection[0]);
-  const [extensionMode, setExtensionMode] = React.useState(paletteExtensionModes[1]);
+  const [palette, setPalette] = useState(paletteCollection[0]);
+  const [extensionMode, setExtensionMode] = useState(paletteExtensionModes[1]);
 
-  const handlePaletteChange = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const handlePaletteChange = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setPalette(e.value);
   }, [setPalette]);
 
-  const handleExtensionModeChange = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const handleExtensionModeChange = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setExtensionMode(e.value);
   }, [setExtensionMode]);
 

--- a/JSDemos/Demos/Charts/Palette/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/Palette/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import PieChart, { Series, Legend } from 'devextreme-react/pie-chart';
 import SelectBox from 'devextreme-react/select-box';
 import { getPalette } from 'devextreme/viz/palette';
@@ -11,15 +11,15 @@ import {
 } from './data.js';
 
 function App() {
-  const [palette, setPalette] = React.useState(paletteCollection[0]);
-  const [extensionMode, setExtensionMode] = React.useState(paletteExtensionModes[1]);
-  const handlePaletteChange = React.useCallback(
+  const [palette, setPalette] = useState(paletteCollection[0]);
+  const [extensionMode, setExtensionMode] = useState(paletteExtensionModes[1]);
+  const handlePaletteChange = useCallback(
     (e) => {
       setPalette(e.value);
     },
     [setPalette],
   );
-  const handleExtensionModeChange = React.useCallback(
+  const handleExtensionModeChange = useCallback(
     (e) => {
       setExtensionMode(e.value);
     },

--- a/JSDemos/Demos/Charts/PieWithResolvedLabelOverlapping/React/App.tsx
+++ b/JSDemos/Demos/Charts/PieWithResolvedLabelOverlapping/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 import PieChart, {
@@ -20,9 +20,9 @@ function formatText(arg: { argumentText: string; percentText: string; }) {
 }
 
 function App() {
-  const [resolveMode, setResolveMode] = React.useState(resolveModes[0]);
+  const [resolveMode, setResolveMode] = useState(resolveModes[0]);
 
-  const handleResolveModeChange = React.useCallback((data: SelectBoxTypes.ValueChangedEvent) => {
+  const handleResolveModeChange = useCallback((data: SelectBoxTypes.ValueChangedEvent) => {
     setResolveMode(data.value);
   }, [setResolveMode]);
 

--- a/JSDemos/Demos/Charts/PieWithResolvedLabelOverlapping/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/PieWithResolvedLabelOverlapping/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import PieChart, {
   Series,
@@ -15,8 +15,8 @@ function formatText(arg) {
   return `${arg.argumentText} (${arg.percentText})`;
 }
 function App() {
-  const [resolveMode, setResolveMode] = React.useState(resolveModes[0]);
-  const handleResolveModeChange = React.useCallback(
+  const [resolveMode, setResolveMode] = useState(resolveModes[0]);
+  const handleResolveModeChange = useCallback(
     (data) => {
       setResolveMode(data.value);
     },

--- a/JSDemos/Demos/Charts/PointsAggregation/React/App.tsx
+++ b/JSDemos/Demos/Charts/PointsAggregation/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Chart, {
   CommonSeriesSettings,
   Series,
@@ -46,23 +46,23 @@ const customizeTooltip = (pointInfo) => {
 };
 
 function App() {
-  const [useAggregation, setUseAggregation] = React.useState(true);
-  const [currentFunction, setCurrentFunction] = React.useState(aggregationFunctions[0].func);
-  const [currentInterval, setCurrentInterval] = React.useState(aggregationIntervals[0].interval);
+  const [useAggregation, setUseAggregation] = useState(true);
+  const [currentFunction, setCurrentFunction] = useState(aggregationFunctions[0].func);
+  const [currentInterval, setCurrentInterval] = useState(aggregationIntervals[0].interval);
 
-  const updateAggregationUsage = React.useCallback(({ value }) => {
+  const updateAggregationUsage = useCallback(({ value }) => {
     setUseAggregation(value);
   }, [setUseAggregation]);
 
-  const updateInterval = React.useCallback(({ value }) => {
+  const updateInterval = useCallback(({ value }) => {
     setCurrentInterval(value);
   }, [setCurrentInterval]);
 
-  const updateMethod = React.useCallback(({ value }) => {
+  const updateMethod = useCallback(({ value }) => {
     setCurrentFunction(value);
   }, [setCurrentFunction]);
 
-  const calculateRangeArea = React.useCallback<IAggregationProps['calculate']>((aggregationInfo) => {
+  const calculateRangeArea = useCallback<IAggregationProps['calculate']>((aggregationInfo) => {
     if (!aggregationInfo.data.length) {
       return null;
     }

--- a/JSDemos/Demos/Charts/PointsAggregation/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/PointsAggregation/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Chart, {
   CommonSeriesSettings,
   Series,
@@ -46,28 +46,28 @@ const customizeTooltip = (pointInfo) => {
   return handlers[pointInfo.seriesName](pointInfo);
 };
 function App() {
-  const [useAggregation, setUseAggregation] = React.useState(true);
-  const [currentFunction, setCurrentFunction] = React.useState(aggregationFunctions[0].func);
-  const [currentInterval, setCurrentInterval] = React.useState(aggregationIntervals[0].interval);
-  const updateAggregationUsage = React.useCallback(
+  const [useAggregation, setUseAggregation] = useState(true);
+  const [currentFunction, setCurrentFunction] = useState(aggregationFunctions[0].func);
+  const [currentInterval, setCurrentInterval] = useState(aggregationIntervals[0].interval);
+  const updateAggregationUsage = useCallback(
     ({ value }) => {
       setUseAggregation(value);
     },
     [setUseAggregation],
   );
-  const updateInterval = React.useCallback(
+  const updateInterval = useCallback(
     ({ value }) => {
       setCurrentInterval(value);
     },
     [setCurrentInterval],
   );
-  const updateMethod = React.useCallback(
+  const updateMethod = useCallback(
     ({ value }) => {
       setCurrentFunction(value);
     },
     [setCurrentFunction],
   );
-  const calculateRangeArea = React.useCallback((aggregationInfo) => {
+  const calculateRangeArea = useCallback((aggregationInfo) => {
     if (!aggregationInfo.data.length) {
       return null;
     }

--- a/JSDemos/Demos/Charts/PointsAggregationFinancialChart/React/App.tsx
+++ b/JSDemos/Demos/Charts/PointsAggregationFinancialChart/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Chart, {
   Series,
   Aggregation,
@@ -23,9 +23,9 @@ import RangeSelector, {
 import { dataSource } from './data.ts';
 
 function App() {
-  const [visualRange, setVisualRange] = React.useState({});
+  const [visualRange, setVisualRange] = useState({});
 
-  const updateVisualRange = React.useCallback((e: RangeSelectorTypes.ValueChangedEvent) => {
+  const updateVisualRange = useCallback((e: RangeSelectorTypes.ValueChangedEvent) => {
     setVisualRange(e.value);
   }, [setVisualRange]);
 

--- a/JSDemos/Demos/Charts/PointsAggregationFinancialChart/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/PointsAggregationFinancialChart/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Chart, {
   Series,
   Aggregation,
@@ -22,8 +22,8 @@ import RangeSelector, {
 import { dataSource } from './data.js';
 
 function App() {
-  const [visualRange, setVisualRange] = React.useState({});
-  const updateVisualRange = React.useCallback(
+  const [visualRange, setVisualRange] = useState({});
+  const updateVisualRange = useCallback(
     (e) => {
       setVisualRange(e.value);
     },

--- a/JSDemos/Demos/Charts/PolarChartZoomingAndScrollingAPI/React/App.tsx
+++ b/JSDemos/Demos/Charts/PolarChartZoomingAndScrollingAPI/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import PolarChart, {
   CommonSeriesSettings,
@@ -23,9 +23,9 @@ import { VisualRange } from 'devextreme-react/common/charts';
 import { dataSource } from './data.ts';
 
 function App() {
-  const [visualRange, setVisualRange] = React.useState<VisualRange>({ startValue: 0, endValue: 8 });
+  const [visualRange, setVisualRange] = useState<VisualRange>({ startValue: 0, endValue: 8 });
 
-  const updateVisualRange = React.useCallback((e: RangeSelectorTypes.ValueChangedEvent) => {
+  const updateVisualRange = useCallback((e: RangeSelectorTypes.ValueChangedEvent) => {
     setVisualRange(e.value);
   }, [setVisualRange]);
 

--- a/JSDemos/Demos/Charts/PolarChartZoomingAndScrollingAPI/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/PolarChartZoomingAndScrollingAPI/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import PolarChart, {
   CommonSeriesSettings,
   Series,
@@ -18,8 +18,8 @@ import RangeSelector, {
 import { dataSource } from './data.js';
 
 function App() {
-  const [visualRange, setVisualRange] = React.useState({ startValue: 0, endValue: 8 });
-  const updateVisualRange = React.useCallback(
+  const [visualRange, setVisualRange] = useState({ startValue: 0, endValue: 8 });
+  const updateVisualRange = useCallback(
     (e) => {
       setVisualRange(e.value);
     },

--- a/JSDemos/Demos/Charts/ScaleBreaks/React/App.tsx
+++ b/JSDemos/Demos/Charts/ScaleBreaks/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Chart, {
   Legend,
   Series,
@@ -14,19 +14,19 @@ const lineStyles: ('straight' | 'waved')[] = ['waved', 'straight'];
 const breaksCount = [1, 2, 3, 4];
 
 function App() {
-  const [autoBreaksEnabledValue, setAutoBreaksEnabledValue] = React.useState(true);
-  const [breaksCountValue, setBreaksCountValue] = React.useState(3);
-  const [lineStyleValue, setLineStyleValue] = React.useState(lineStyles[0]);
+  const [autoBreaksEnabledValue, setAutoBreaksEnabledValue] = useState(true);
+  const [breaksCountValue, setBreaksCountValue] = useState(3);
+  const [lineStyleValue, setLineStyleValue] = useState(lineStyles[0]);
 
-  const changeBreaksCount = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const changeBreaksCount = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setBreaksCountValue(e.value);
   }, [setBreaksCountValue]);
 
-  const changeStyle = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const changeStyle = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setLineStyleValue(e.value);
   }, [setLineStyleValue]);
 
-  const changeBreaksEnabledState = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const changeBreaksEnabledState = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setAutoBreaksEnabledValue(e.value);
   }, [setAutoBreaksEnabledValue]);
 

--- a/JSDemos/Demos/Charts/ScaleBreaks/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/ScaleBreaks/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Chart, {
   Legend, Series, Tooltip, ValueAxis, BreakStyle,
 } from 'devextreme-react/chart';
@@ -9,22 +9,22 @@ import { dataSource, lineStyleLabel, maxCountLabel } from './data.js';
 const lineStyles = ['waved', 'straight'];
 const breaksCount = [1, 2, 3, 4];
 function App() {
-  const [autoBreaksEnabledValue, setAutoBreaksEnabledValue] = React.useState(true);
-  const [breaksCountValue, setBreaksCountValue] = React.useState(3);
-  const [lineStyleValue, setLineStyleValue] = React.useState(lineStyles[0]);
-  const changeBreaksCount = React.useCallback(
+  const [autoBreaksEnabledValue, setAutoBreaksEnabledValue] = useState(true);
+  const [breaksCountValue, setBreaksCountValue] = useState(3);
+  const [lineStyleValue, setLineStyleValue] = useState(lineStyles[0]);
+  const changeBreaksCount = useCallback(
     (e) => {
       setBreaksCountValue(e.value);
     },
     [setBreaksCountValue],
   );
-  const changeStyle = React.useCallback(
+  const changeStyle = useCallback(
     (e) => {
       setLineStyleValue(e.value);
     },
     [setLineStyleValue],
   );
-  const changeBreaksEnabledState = React.useCallback(
+  const changeBreaksEnabledState = useCallback(
     (e) => {
       setAutoBreaksEnabledValue(e.value);
     },

--- a/JSDemos/Demos/Charts/SignalRService/React/App.tsx
+++ b/JSDemos/Demos/Charts/SignalRService/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Chart, {
   ArgumentAxis,
   ValueAxis,
@@ -24,10 +24,10 @@ const minVisualRangeLength = { minutes: 10 };
 const defaultVisualRange: VisualRange = { length: 'hour' };
 
 function App() {
-  const [dataSource, setDataSource] = React.useState(null);
-  const chartRef = React.useRef(null);
+  const [dataSource, setDataSource] = useState(null);
+  const chartRef = useRef(null);
 
-  const customizePoint = React.useCallback((arg) => {
+  const customizePoint = useCallback((arg) => {
     if (arg.seriesName === 'Volume') {
       const point = chartRef.current.instance.getAllSeries()[0]
         .getPointsByArg(arg.argument)[0].data;
@@ -38,7 +38,7 @@ function App() {
     return null;
   }, []);
 
-  const calculateCandle = React.useCallback<IAggregationProps['calculate']>((e) => {
+  const calculateCandle = useCallback<IAggregationProps['calculate']>((e) => {
     const prices = e.data.map((d) => d.price);
     if (prices.length) {
       return {
@@ -52,7 +52,7 @@ function App() {
     return null;
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const hubConnection = new HubConnectionBuilder()
       .withUrl('https://js.devexpress.com/Demos/NetCore/stockTickDataHub', {
         skipNegotiation: true,

--- a/JSDemos/Demos/Charts/SignalRService/React/App.tsx
+++ b/JSDemos/Demos/Charts/SignalRService/React/App.tsx
@@ -1,4 +1,6 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback, useEffect, useRef, useState,
+} from 'react';
 import Chart, {
   ArgumentAxis,
   ValueAxis,

--- a/JSDemos/Demos/Charts/SignalRService/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/SignalRService/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Chart, {
   ArgumentAxis,
   ValueAxis,
@@ -21,9 +21,9 @@ import TooltipTemplate from './TooltipTemplate.js';
 const minVisualRangeLength = { minutes: 10 };
 const defaultVisualRange = { length: 'hour' };
 function App() {
-  const [dataSource, setDataSource] = React.useState(null);
-  const chartRef = React.useRef(null);
-  const customizePoint = React.useCallback((arg) => {
+  const [dataSource, setDataSource] = useState(null);
+  const chartRef = useRef(null);
+  const customizePoint = useCallback((arg) => {
     if (arg.seriesName === 'Volume') {
       const point = chartRef.current.instance
         .getAllSeries()[0]
@@ -34,7 +34,7 @@ function App() {
     }
     return null;
   }, []);
-  const calculateCandle = React.useCallback((e) => {
+  const calculateCandle = useCallback((e) => {
     const prices = e.data.map((d) => d.price);
     if (prices.length) {
       return {
@@ -47,7 +47,7 @@ function App() {
     }
     return null;
   }, []);
-  React.useEffect(() => {
+  useEffect(() => {
     const hubConnection = new HubConnectionBuilder()
       .withUrl('https://js.devexpress.com/Demos/NetCore/stockTickDataHub', {
         skipNegotiation: true,

--- a/JSDemos/Demos/Charts/SignalRService/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/SignalRService/ReactJs/App.js
@@ -1,4 +1,6 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback, useEffect, useRef, useState,
+} from 'react';
 import Chart, {
   ArgumentAxis,
   ValueAxis,

--- a/JSDemos/Demos/Charts/Spline/React/App.tsx
+++ b/JSDemos/Demos/Charts/Spline/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 import {
   Chart,
@@ -20,9 +20,9 @@ import { architectureSources, sharingStatisticsInfo, seriesTypeLabel } from './d
 const types: (ICommonSeriesSettingsProps['type'])[] = ['spline', 'stackedspline', 'fullstackedspline'];
 
 function App() {
-  const [type, setType] = React.useState(types[0]);
+  const [type, setType] = useState(types[0]);
 
-  const handleChange = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const handleChange = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setType(e.value);
   }, [setType]);
 

--- a/JSDemos/Demos/Charts/Spline/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/Spline/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import {
   Chart,
@@ -18,8 +18,8 @@ import { architectureSources, sharingStatisticsInfo, seriesTypeLabel } from './d
 
 const types = ['spline', 'stackedspline', 'fullstackedspline'];
 function App() {
-  const [type, setType] = React.useState(types[0]);
-  const handleChange = React.useCallback(
+  const [type, setType] = useState(types[0]);
+  const handleChange = useCallback(
     (e) => {
       setType(e.value);
     },

--- a/JSDemos/Demos/Charts/SplineArea/React/App.tsx
+++ b/JSDemos/Demos/Charts/SplineArea/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 import {
   Chart,
@@ -16,9 +16,9 @@ import { dataSource, seriesTypeLabel } from './data.ts';
 const types: (ICommonSeriesSettingsProps['type'])[] = ['splinearea', 'stackedsplinearea', 'fullstackedsplinearea'];
 
 function App() {
-  const [type, setType] = React.useState(types[0]);
+  const [type, setType] = useState(types[0]);
 
-  const handleChange = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const handleChange = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setType(e.value);
   }, [setType]);
 

--- a/JSDemos/Demos/Charts/SplineArea/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/SplineArea/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import {
   Chart,
@@ -13,8 +13,8 @@ import { dataSource, seriesTypeLabel } from './data.js';
 
 const types = ['splinearea', 'stackedsplinearea', 'fullstackedsplinearea'];
 function App() {
-  const [type, setType] = React.useState(types[0]);
-  const handleChange = React.useCallback(
+  const [type, setType] = useState(types[0]);
+  const handleChange = useCallback(
     (e) => {
       setType(e.value);
     },

--- a/JSDemos/Demos/Charts/TilingAlgorithms/React/App.tsx
+++ b/JSDemos/Demos/Charts/TilingAlgorithms/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TreeMap, {
   Colorizer, Tooltip, ITreeMapOptions, ITooltipProps,
 } from 'devextreme-react/tree-map';
@@ -9,13 +9,13 @@ import { populationByAge, algorithmLabel } from './data.ts';
 const algorithms: (TreeMapLayoutAlgorithm | 'custom')[] = ['sliceanddice', 'squarified', 'strip', 'custom'];
 
 function App() {
-  const [selectedAlgorithm, setSelectedAlgorithm] = React.useState(algorithms[2]);
+  const [selectedAlgorithm, setSelectedAlgorithm] = useState(algorithms[2]);
   const [
     currentAlgorithm,
     setCurrentAlgorithm,
-  ] = React.useState<ITreeMapOptions['layoutAlgorithm']>(getCurrentAlgorithm(algorithms[2]));
+  ] = useState<ITreeMapOptions['layoutAlgorithm']>(getCurrentAlgorithm(algorithms[2]));
 
-  const setAlgorithm = React.useCallback((data: SelectBoxTypes.ValueChangedEvent) => {
+  const setAlgorithm = useCallback((data: SelectBoxTypes.ValueChangedEvent) => {
     setSelectedAlgorithm(data.value);
     setCurrentAlgorithm(() => getCurrentAlgorithm(data.value));
   }, [setSelectedAlgorithm, setCurrentAlgorithm]);

--- a/JSDemos/Demos/Charts/TilingAlgorithms/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/TilingAlgorithms/ReactJs/App.js
@@ -6,9 +6,7 @@ import { populationByAge, algorithmLabel } from './data.js';
 const algorithms = ['sliceanddice', 'squarified', 'strip', 'custom'];
 function App() {
   const [selectedAlgorithm, setSelectedAlgorithm] = useState(algorithms[2]);
-  const [currentAlgorithm, setCurrentAlgorithm] = useState(
-    getCurrentAlgorithm(algorithms[2]),
-  );
+  const [currentAlgorithm, setCurrentAlgorithm] = useState(getCurrentAlgorithm(algorithms[2]));
   const setAlgorithm = useCallback(
     (data) => {
       setSelectedAlgorithm(data.value);

--- a/JSDemos/Demos/Charts/TilingAlgorithms/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/TilingAlgorithms/ReactJs/App.js
@@ -1,15 +1,15 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TreeMap, { Colorizer, Tooltip } from 'devextreme-react/tree-map';
 import SelectBox from 'devextreme-react/select-box';
 import { populationByAge, algorithmLabel } from './data.js';
 
 const algorithms = ['sliceanddice', 'squarified', 'strip', 'custom'];
 function App() {
-  const [selectedAlgorithm, setSelectedAlgorithm] = React.useState(algorithms[2]);
-  const [currentAlgorithm, setCurrentAlgorithm] = React.useState(
+  const [selectedAlgorithm, setSelectedAlgorithm] = useState(algorithms[2]);
+  const [currentAlgorithm, setCurrentAlgorithm] = useState(
     getCurrentAlgorithm(algorithms[2]),
   );
-  const setAlgorithm = React.useCallback(
+  const setAlgorithm = useCallback(
     (data) => {
       setSelectedAlgorithm(data.value);
       setCurrentAlgorithm(() => getCurrentAlgorithm(data.value));

--- a/JSDemos/Demos/Charts/WindRose/React/App.tsx
+++ b/JSDemos/Demos/Charts/WindRose/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import {
   PolarChart,
@@ -20,9 +20,9 @@ function onLegendClick({ target: series }) {
 }
 
 function App() {
-  const [periodValues, setPeriodValues] = React.useState(windRoseData[0].values);
+  const [periodValues, setPeriodValues] = useState(windRoseData[0].values);
 
-  const handleChange = React.useCallback(({ value }) => {
+  const handleChange = useCallback(({ value }) => {
     setPeriodValues(value);
   }, [setPeriodValues]);
 

--- a/JSDemos/Demos/Charts/WindRose/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/WindRose/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import {
   PolarChart,
@@ -19,8 +19,8 @@ function onLegendClick({ target: series }) {
   }
 }
 function App() {
-  const [periodValues, setPeriodValues] = React.useState(windRoseData[0].values);
-  const handleChange = React.useCallback(
+  const [periodValues, setPeriodValues] = useState(windRoseData[0].values);
+  const handleChange = useCallback(
     ({ value }) => {
       setPeriodValues(value);
     },

--- a/JSDemos/Demos/Charts/ZoomingAndScrollingAPI/React/App.tsx
+++ b/JSDemos/Demos/Charts/ZoomingAndScrollingAPI/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Chart, {
   Series,
   Legend,
@@ -18,9 +18,9 @@ import { VisualRange } from 'devextreme-react/common/charts';
 import { zoomingData } from './data.ts';
 
 function App() {
-  const [visualRange, setVisualRange] = React.useState<VisualRange>({ startValue: 10, endValue: 880 });
+  const [visualRange, setVisualRange] = useState<VisualRange>({ startValue: 10, endValue: 880 });
 
-  const updateVisualRange = React.useCallback((e: RangeSelectorTypes.ValueChangedEvent) => {
+  const updateVisualRange = useCallback((e: RangeSelectorTypes.ValueChangedEvent) => {
     setVisualRange(e.value);
   }, [setVisualRange]);
 

--- a/JSDemos/Demos/Charts/ZoomingAndScrollingAPI/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/ZoomingAndScrollingAPI/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Chart, {
   Series,
   Legend,
@@ -16,8 +16,8 @@ import RangeSelector, {
 import { zoomingData } from './data.js';
 
 function App() {
-  const [visualRange, setVisualRange] = React.useState({ startValue: 10, endValue: 880 });
-  const updateVisualRange = React.useCallback(
+  const [visualRange, setVisualRange] = useState({ startValue: 10, endValue: 880 });
+  const updateVisualRange = useCallback(
     (e) => {
       setVisualRange(e.value);
     },

--- a/JSDemos/Demos/Charts/ZoomingOnAreaSelection/React/App.tsx
+++ b/JSDemos/Demos/Charts/ZoomingOnAreaSelection/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import Chart, {
   ArgumentAxis,
   ValueAxis,
@@ -23,9 +23,9 @@ function customizeTooltip(pointInfo: { point: { data: { country: string, year: n
 }
 
 function App() {
-  const chartRef = React.useRef(null);
+  const chartRef = useRef(null);
 
-  const resetZoom = React.useCallback(() => {
+  const resetZoom = useCallback(() => {
     chartRef.current.instance.resetVisualRange();
   }, []);
 

--- a/JSDemos/Demos/Charts/ZoomingOnAreaSelection/ReactJs/App.js
+++ b/JSDemos/Demos/Charts/ZoomingOnAreaSelection/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import Chart, {
   ArgumentAxis,
   ValueAxis,
@@ -22,8 +22,8 @@ function customizeTooltip(pointInfo) {
   };
 }
 function App() {
-  const chartRef = React.useRef(null);
-  const resetZoom = React.useCallback(() => {
+  const chartRef = useRef(null);
+  const resetZoom = useCallback(() => {
     chartRef.current.instance.resetVisualRange();
   }, []);
   return (

--- a/JSDemos/Demos/CheckBox/Overview/React/App.tsx
+++ b/JSDemos/Demos/CheckBox/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { CheckBox, CheckBoxTypes } from 'devextreme-react/check-box';
 
 const checkedLabel = { 'aria-label': 'Checked' };
@@ -10,9 +10,9 @@ const disabledLabel = { 'aria-label': 'Disabled' };
 const customSizeLabel = { 'aria-label': 'Custom size' };
 
 function App() {
-  const [checkBoxValue, setCheckBoxValue] = React.useState(null);
+  const [checkBoxValue, setCheckBoxValue] = useState(null);
 
-  const onValueChanged = React.useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
+  const onValueChanged = useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
     setCheckBoxValue(args.value);
   }, []);
 

--- a/JSDemos/Demos/CheckBox/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/CheckBox/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { CheckBox } from 'devextreme-react/check-box';
 
 const checkedLabel = { 'aria-label': 'Checked' };
@@ -9,8 +9,8 @@ const handleValueChangeLabel = { 'aria-label': 'Handle value change' };
 const disabledLabel = { 'aria-label': 'Disabled' };
 const customSizeLabel = { 'aria-label': 'Custom size' };
 function App() {
-  const [checkBoxValue, setCheckBoxValue] = React.useState(null);
-  const onValueChanged = React.useCallback((args) => {
+  const [checkBoxValue, setCheckBoxValue] = useState(null);
+  const onValueChanged = useCallback((args) => {
     setCheckBoxValue(args.value);
   }, []);
   return (

--- a/JSDemos/Demos/ColorBox/Overview/React/App.tsx
+++ b/JSDemos/Demos/ColorBox/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import ColorBox, { ColorBoxTypes } from 'devextreme-react/color-box';
 
 const defaultModeLabel = { 'aria-label': 'Default mode' };
@@ -9,9 +9,9 @@ const disabledLabel = { 'aria-label': 'Disabled' };
 const eventHandlingLabel = { 'aria-label': 'Event Handling' };
 
 function App() {
-  const [color, setColor] = React.useState('#f05b41');
+  const [color, setColor] = useState('#f05b41');
 
-  const handleColorChange = React.useCallback(({ value }: ColorBoxTypes.ValueChangedEvent) => {
+  const handleColorChange = useCallback(({ value }: ColorBoxTypes.ValueChangedEvent) => {
     setColor(value);
   }, []);
 

--- a/JSDemos/Demos/ColorBox/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/ColorBox/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import ColorBox from 'devextreme-react/color-box';
 
 const defaultModeLabel = { 'aria-label': 'Default mode' };
@@ -8,8 +8,8 @@ const readOnlyLabel = { 'aria-label': 'Read only' };
 const disabledLabel = { 'aria-label': 'Disabled' };
 const eventHandlingLabel = { 'aria-label': 'Event Handling' };
 function App() {
-  const [color, setColor] = React.useState('#f05b41');
-  const handleColorChange = React.useCallback(({ value }) => {
+  const [color, setColor] = useState('#f05b41');
+  const handleColorChange = useCallback(({ value }) => {
     setColor(value);
   }, []);
   return (

--- a/JSDemos/Demos/Common/ActionAndListsOverview/React/App.tsx
+++ b/JSDemos/Demos/Common/ActionAndListsOverview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import ArrayStore from 'devextreme/data/array_store';
 import List, { ListTypes } from 'devextreme-react/list';
 import TileView from 'devextreme-react/tile-view';
@@ -50,10 +50,10 @@ const renderTile = (item: { FileName: string; }) => (
 );
 
 const App = () => {
-  const [currentHotel, setCurrentHotel] = React.useState(data[0]);
-  const [selectedItemKeys, setSelectedItemKeys] = React.useState([data[0].Id]);
+  const [currentHotel, setCurrentHotel] = useState(data[0]);
+  const [selectedItemKeys, setSelectedItemKeys] = useState([data[0].Id]);
 
-  const handleListSelectionChange = React.useCallback((e: ListTypes.SelectionChangedEvent) => {
+  const handleListSelectionChange = useCallback((e: ListTypes.SelectionChangedEvent) => {
     const hotel = e.addedItems[0];
     setCurrentHotel(hotel);
     setSelectedItemKeys([hotel.Id]);

--- a/JSDemos/Demos/Common/ActionAndListsOverview/ReactJs/App.js
+++ b/JSDemos/Demos/Common/ActionAndListsOverview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import ArrayStore from 'devextreme/data/array_store';
 import List from 'devextreme-react/list';
 import TileView from 'devextreme-react/tile-view';
@@ -47,9 +47,9 @@ const renderTile = (item) => (
   />
 );
 const App = () => {
-  const [currentHotel, setCurrentHotel] = React.useState(data[0]);
-  const [selectedItemKeys, setSelectedItemKeys] = React.useState([data[0].Id]);
-  const handleListSelectionChange = React.useCallback(
+  const [currentHotel, setCurrentHotel] = useState(data[0]);
+  const [selectedItemKeys, setSelectedItemKeys] = useState([data[0].Id]);
+  const handleListSelectionChange = useCallback(
     (e) => {
       const hotel = e.addedItems[0];
       setCurrentHotel(hotel);

--- a/JSDemos/Demos/Common/CustomTextEditorButtons/React/App.tsx
+++ b/JSDemos/Demos/Common/CustomTextEditorButtons/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import { TextBox, Button as TextBoxButton, TextBoxTypes } from 'devextreme-react/text-box';
 import { NumberBox, Button as NumberBoxButton, NumberBoxTypes } from 'devextreme-react/number-box';
@@ -11,12 +11,12 @@ const dateBoxLabel = { 'aria-label': 'Date' };
 const passwordLabel = { 'aria-label': 'Password' };
 
 function App() {
-  const [passwordMode, setPasswordMode] = React.useState<TextBoxTypes.TextBoxType>('password');
-  const [currencyFormat, setCurrencyFormat] = React.useState('$ #.##');
-  const [currencyValue, setCurrencyValue] = React.useState(14500.55);
-  const [dateValue, setDateValue] = React.useState(new Date().getTime());
+  const [passwordMode, setPasswordMode] = useState<TextBoxTypes.TextBoxType>('password');
+  const [currencyFormat, setCurrencyFormat] = useState('$ #.##');
+  const [currencyValue, setCurrencyValue] = useState(14500.55);
+  const [dateValue, setDateValue] = useState(new Date().getTime());
 
-  const passwordButton = React.useMemo<ButtonTypes.Properties>(
+  const passwordButton = useMemo<ButtonTypes.Properties>(
     () => ({
       icon: 'eyeopen',
       stylingMode: 'text',
@@ -28,7 +28,7 @@ function App() {
     [setPasswordMode],
   );
 
-  const currencyButton = React.useMemo<ButtonTypes.Properties>(
+  const currencyButton = useMemo<ButtonTypes.Properties>(
     () => ({
       text: '€',
       stylingMode: 'text',
@@ -51,7 +51,7 @@ function App() {
     [setCurrencyFormat, setCurrencyValue],
   );
 
-  const todayButton = React.useMemo<ButtonTypes.Properties>(
+  const todayButton = useMemo<ButtonTypes.Properties>(
     () => ({
       text: 'Today',
       stylingMode: 'text',
@@ -62,7 +62,7 @@ function App() {
     [setDateValue],
   );
 
-  const prevDateButton = React.useMemo<ButtonTypes.Properties>(
+  const prevDateButton = useMemo<ButtonTypes.Properties>(
     () => ({
       icon: 'spinprev',
       stylingMode: 'text',
@@ -73,7 +73,7 @@ function App() {
     [setDateValue],
   );
 
-  const nextDateButton = React.useMemo<ButtonTypes.Properties>(
+  const nextDateButton = useMemo<ButtonTypes.Properties>(
     () => ({
       icon: 'spinnext',
       stylingMode: 'text',
@@ -84,14 +84,14 @@ function App() {
     [setDateValue],
   );
 
-  const onDateChanged = React.useCallback(
+  const onDateChanged = useCallback(
     (e: DateBoxTypes.ValueChangedEvent) => {
       setDateValue(e.value);
     },
     [setDateValue],
   );
 
-  const changeCurrency = React.useCallback(
+  const changeCurrency = useCallback(
     (data: NumberBoxTypes.ValueChangedEvent) => {
       setCurrencyValue(data.value);
     },

--- a/JSDemos/Demos/Common/CustomTextEditorButtons/ReactJs/App.js
+++ b/JSDemos/Demos/Common/CustomTextEditorButtons/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { TextBox, Button as TextBoxButton } from 'devextreme-react/text-box';
 import { NumberBox, Button as NumberBoxButton } from 'devextreme-react/number-box';
 import { DateBox, Button as DateBoxButton } from 'devextreme-react/date-box';
@@ -8,11 +8,11 @@ const currencyLabel = { 'aria-label': 'Multi Currency' };
 const dateBoxLabel = { 'aria-label': 'Date' };
 const passwordLabel = { 'aria-label': 'Password' };
 function App() {
-  const [passwordMode, setPasswordMode] = React.useState('password');
-  const [currencyFormat, setCurrencyFormat] = React.useState('$ #.##');
-  const [currencyValue, setCurrencyValue] = React.useState(14500.55);
-  const [dateValue, setDateValue] = React.useState(new Date().getTime());
-  const passwordButton = React.useMemo(
+  const [passwordMode, setPasswordMode] = useState('password');
+  const [currencyFormat, setCurrencyFormat] = useState('$ #.##');
+  const [currencyValue, setCurrencyValue] = useState(14500.55);
+  const [dateValue, setDateValue] = useState(new Date().getTime());
+  const passwordButton = useMemo(
     () => ({
       icon: 'eyeopen',
       stylingMode: 'text',
@@ -22,7 +22,7 @@ function App() {
     }),
     [setPasswordMode],
   );
-  const currencyButton = React.useMemo(
+  const currencyButton = useMemo(
     () => ({
       text: '€',
       stylingMode: 'text',
@@ -44,7 +44,7 @@ function App() {
     }),
     [setCurrencyFormat, setCurrencyValue],
   );
-  const todayButton = React.useMemo(
+  const todayButton = useMemo(
     () => ({
       text: 'Today',
       stylingMode: 'text',
@@ -54,7 +54,7 @@ function App() {
     }),
     [setDateValue],
   );
-  const prevDateButton = React.useMemo(
+  const prevDateButton = useMemo(
     () => ({
       icon: 'spinprev',
       stylingMode: 'text',
@@ -64,7 +64,7 @@ function App() {
     }),
     [setDateValue],
   );
-  const nextDateButton = React.useMemo(
+  const nextDateButton = useMemo(
     () => ({
       icon: 'spinnext',
       stylingMode: 'text',
@@ -74,13 +74,13 @@ function App() {
     }),
     [setDateValue],
   );
-  const onDateChanged = React.useCallback(
+  const onDateChanged = useCallback(
     (e) => {
       setDateValue(e.value);
     },
     [setDateValue],
   );
-  const changeCurrency = React.useCallback(
+  const changeCurrency = useCallback(
     (data) => {
       setCurrencyValue(data.value);
     },

--- a/JSDemos/Demos/Common/DialogsAndNotificationsOverview/React/App.tsx
+++ b/JSDemos/Demos/Common/DialogsAndNotificationsOverview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import notify from 'devextreme/ui/notify';
 import Button from 'devextreme-react/button';
 import Popup from 'devextreme-react/popup';
@@ -20,11 +20,11 @@ const favButtonAttrs = {
 };
 
 export default function App() {
-  const [houses, setHouses] = React.useState(housesSource);
-  const [currentHouse, setCurrentHouse] = React.useState(housesSource[0]);
-  const [popupVisible, setPopupVisible] = React.useState(false);
+  const [houses, setHouses] = useState(housesSource);
+  const [currentHouse, setCurrentHouse] = useState(housesSource[0]);
+  const [popupVisible, setPopupVisible] = useState(false);
 
-  const changeFavoriteState = React.useCallback(() => {
+  const changeFavoriteState = useCallback(() => {
     const updatedHouses = [...houses];
     const updatedCurrentHouse = updatedHouses.find((house) => house === currentHouse);
     updatedCurrentHouse.Favorite = !updatedCurrentHouse.Favorite;
@@ -37,7 +37,7 @@ export default function App() {
     updatedCurrentHouse.Favorite ? 'success' : 'error', 2000);
   }, [houses, currentHouse, setHouses]);
 
-  const renderPopup = React.useCallback(() => (
+  const renderPopup = useCallback(() => (
     <div className="popup-property-details">
       <div className="large-text">{formatCurrency(currentHouse.Price)}</div>
       <div className="opacity">{currentHouse.Address}, {currentHouse.City}, {currentHouse.State}</div>
@@ -57,12 +57,12 @@ export default function App() {
     </div>
   ), [currentHouse, changeFavoriteState]);
 
-  const showHouse = React.useCallback((house) => {
+  const showHouse = useCallback((house) => {
     setCurrentHouse(house);
     setPopupVisible(true);
   }, [setCurrentHouse, setPopupVisible]);
 
-  const handlePopupHidden = React.useCallback(() => {
+  const handlePopupHidden = useCallback(() => {
     setPopupVisible(false);
   }, [setPopupVisible]);
 

--- a/JSDemos/Demos/Common/DialogsAndNotificationsOverview/React/House.tsx
+++ b/JSDemos/Demos/Common/DialogsAndNotificationsOverview/React/House.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import Popover, { IPositionProps } from 'devextreme-react/popover';
 
@@ -43,7 +43,7 @@ interface HouseProps {
 }
 
 export function House(props: HouseProps) {
-  const renderAgentDetails = React.useCallback(() => {
+  const renderAgentDetails = useCallback(() => {
     const agent = props.house.Agent;
     return (
       <div className="agent-details">
@@ -56,7 +56,7 @@ export function House(props: HouseProps) {
     );
   }, [props.house.Agent]);
 
-  const show = React.useCallback(() => {
+  const show = useCallback(() => {
     props.show(props.house);
   }, [props]);
 

--- a/JSDemos/Demos/Common/DialogsAndNotificationsOverview/ReactJs/App.js
+++ b/JSDemos/Demos/Common/DialogsAndNotificationsOverview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import notify from 'devextreme/ui/notify';
 import Button from 'devextreme-react/button';
 import Popup from 'devextreme-react/popup';
@@ -17,10 +17,10 @@ const favButtonAttrs = {
   class: 'favorites',
 };
 export default function App() {
-  const [houses, setHouses] = React.useState(housesSource);
-  const [currentHouse, setCurrentHouse] = React.useState(housesSource[0]);
-  const [popupVisible, setPopupVisible] = React.useState(false);
-  const changeFavoriteState = React.useCallback(() => {
+  const [houses, setHouses] = useState(housesSource);
+  const [currentHouse, setCurrentHouse] = useState(housesSource[0]);
+  const [popupVisible, setPopupVisible] = useState(false);
+  const changeFavoriteState = useCallback(() => {
     const updatedHouses = [...houses];
     const updatedCurrentHouse = updatedHouses.find((house) => house === currentHouse);
     updatedCurrentHouse.Favorite = !updatedCurrentHouse.Favorite;
@@ -36,7 +36,7 @@ export default function App() {
       2000,
     );
   }, [houses, currentHouse, setHouses]);
-  const renderPopup = React.useCallback(
+  const renderPopup = useCallback(
     () => (
       <div className="popup-property-details">
         <div className="large-text">{formatCurrency(currentHouse.Price)}</div>
@@ -66,14 +66,14 @@ export default function App() {
     ),
     [currentHouse, changeFavoriteState],
   );
-  const showHouse = React.useCallback(
+  const showHouse = useCallback(
     (house) => {
       setCurrentHouse(house);
       setPopupVisible(true);
     },
     [setCurrentHouse, setPopupVisible],
   );
-  const handlePopupHidden = React.useCallback(() => {
+  const handlePopupHidden = useCallback(() => {
     setPopupVisible(false);
   }, [setPopupVisible]);
   return (

--- a/JSDemos/Demos/Common/DialogsAndNotificationsOverview/ReactJs/House.js
+++ b/JSDemos/Demos/Common/DialogsAndNotificationsOverview/ReactJs/House.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import Popover from 'devextreme-react/popover';
 
 const formatCurrency = new Intl.NumberFormat('en-US', {
@@ -14,7 +14,7 @@ const position = {
   collision: 'fit flip',
 };
 export function House(props) {
-  const renderAgentDetails = React.useCallback(() => {
+  const renderAgentDetails = useCallback(() => {
     const agent = props.house.Agent;
     return (
       <div className="agent-details">
@@ -29,7 +29,7 @@ export function House(props) {
       </div>
     );
   }, [props.house.Agent]);
-  const show = React.useCallback(() => {
+  const show = useCallback(() => {
     props.show(props.house);
   }, [props]);
   return (

--- a/JSDemos/Demos/Common/EditorAppearanceVariants/React/App.tsx
+++ b/JSDemos/Demos/Common/EditorAppearanceVariants/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import TextBox from 'devextreme-react/text-box';
 import DateBox from 'devextreme-react/date-box';
@@ -38,15 +38,15 @@ function validateClick({ validationGroup }: ButtonTypes.ClickEvent) {
 
 export default function App() {
   const defaultStylingMode = 'outlined';
-  const [stylingMode, setStylingMode] = React.useState<EditorStyle>(defaultStylingMode);
-  const [labelMode, setLabelMode] = React.useState<LabelMode>('static');
-  const changeStylingMode = React.useCallback(
+  const [stylingMode, setStylingMode] = useState<EditorStyle>(defaultStylingMode);
+  const [labelMode, setLabelMode] = useState<LabelMode>('static');
+  const changeStylingMode = useCallback(
     ({ value }) => {
       setStylingMode(value);
     },
     [setStylingMode],
   );
-  const labelModeChange = React.useCallback(
+  const labelModeChange = useCallback(
     ({ value }) => {
       setLabelMode(value);
     },

--- a/JSDemos/Demos/Common/EditorAppearanceVariants/ReactJs/App.js
+++ b/JSDemos/Demos/Common/EditorAppearanceVariants/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import TextBox from 'devextreme-react/text-box';
 import DateBox from 'devextreme-react/date-box';
@@ -35,15 +35,15 @@ function validateClick({ validationGroup }) {
 }
 export default function App() {
   const defaultStylingMode = 'outlined';
-  const [stylingMode, setStylingMode] = React.useState(defaultStylingMode);
-  const [labelMode, setLabelMode] = React.useState('static');
-  const changeStylingMode = React.useCallback(
+  const [stylingMode, setStylingMode] = useState(defaultStylingMode);
+  const [labelMode, setLabelMode] = useState('static');
+  const changeStylingMode = useCallback(
     ({ value }) => {
       setStylingMode(value);
     },
     [setStylingMode],
   );
-  const labelModeChange = React.useCallback(
+  const labelModeChange = useCallback(
     ({ value }) => {
       setLabelMode(value);
     },

--- a/JSDemos/Demos/Common/EditorsOverview/React/App.tsx
+++ b/JSDemos/Demos/Common/EditorsOverview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import ColorBox, { ColorBoxTypes } from 'devextreme-react/color-box';
 import NumberBox, { NumberBoxTypes } from 'devextreme-react/number-box';
@@ -36,36 +36,36 @@ const transformations = [
 ];
 
 function App() {
-  const [text, setText] = React.useState('UI Superhero');
-  const [width, setWidth] = React.useState(370);
-  const [height, setHeight] = React.useState(260);
-  const [color, setColor] = React.useState('#f05b41');
-  const [transform, setTransform] = React.useState(noFlipTransform);
-  const [border, setBorder] = React.useState(false);
+  const [text, setText] = useState('UI Superhero');
+  const [width, setWidth] = useState(370);
+  const [height, setHeight] = useState(260);
+  const [color, setColor] = useState('#f05b41');
+  const [transform, setTransform] = useState(noFlipTransform);
+  const [border, setBorder] = useState(false);
 
-  const handleTextChange = React.useCallback((e: TextBoxTypes.ValueChangedEvent) => {
+  const handleTextChange = useCallback((e: TextBoxTypes.ValueChangedEvent) => {
     setText(e.value);
   }, []);
 
-  const handleColorChange = React.useCallback((e: ColorBoxTypes.ValueChangedEvent) => {
+  const handleColorChange = useCallback((e: ColorBoxTypes.ValueChangedEvent) => {
     setColor(e.value);
   }, []);
 
-  const handleHeightChange = React.useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
+  const handleHeightChange = useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
     setWidth((e.value * 37) / 26);
     setHeight(e.value);
   }, []);
 
-  const handleWidthChange = React.useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
+  const handleWidthChange = useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
     setWidth(e.value);
     setHeight((e.value * 26) / 37);
   }, []);
 
-  const handleTransformChange = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const handleTransformChange = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setTransform(e.value);
   }, []);
 
-  const handleBorderChange = React.useCallback((e: SwitchTypes.ValueChangedEvent) => {
+  const handleBorderChange = useCallback((e: SwitchTypes.ValueChangedEvent) => {
     setBorder(e.value);
   }, []);
 

--- a/JSDemos/Demos/Common/EditorsOverview/ReactJs/App.js
+++ b/JSDemos/Demos/Common/EditorsOverview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import ColorBox from 'devextreme-react/color-box';
 import NumberBox from 'devextreme-react/number-box';
 import SelectBox from 'devextreme-react/select-box';
@@ -32,30 +32,30 @@ const transformations = [
   },
 ];
 function App() {
-  const [text, setText] = React.useState('UI Superhero');
-  const [width, setWidth] = React.useState(370);
-  const [height, setHeight] = React.useState(260);
-  const [color, setColor] = React.useState('#f05b41');
-  const [transform, setTransform] = React.useState(noFlipTransform);
-  const [border, setBorder] = React.useState(false);
-  const handleTextChange = React.useCallback((e) => {
+  const [text, setText] = useState('UI Superhero');
+  const [width, setWidth] = useState(370);
+  const [height, setHeight] = useState(260);
+  const [color, setColor] = useState('#f05b41');
+  const [transform, setTransform] = useState(noFlipTransform);
+  const [border, setBorder] = useState(false);
+  const handleTextChange = useCallback((e) => {
     setText(e.value);
   }, []);
-  const handleColorChange = React.useCallback((e) => {
+  const handleColorChange = useCallback((e) => {
     setColor(e.value);
   }, []);
-  const handleHeightChange = React.useCallback((e) => {
+  const handleHeightChange = useCallback((e) => {
     setWidth((e.value * 37) / 26);
     setHeight(e.value);
   }, []);
-  const handleWidthChange = React.useCallback((e) => {
+  const handleWidthChange = useCallback((e) => {
     setWidth(e.value);
     setHeight((e.value * 26) / 37);
   }, []);
-  const handleTransformChange = React.useCallback((e) => {
+  const handleTransformChange = useCallback((e) => {
     setTransform(e.value);
   }, []);
-  const handleBorderChange = React.useCallback((e) => {
+  const handleBorderChange = useCallback((e) => {
     setBorder(e.value);
   }, []);
   return (

--- a/JSDemos/Demos/Common/EditorsRightToLeftSupport/React/App.tsx
+++ b/JSDemos/Demos/Common/EditorsRightToLeftSupport/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { NumberBox } from 'devextreme-react/number-box';
 import { SelectBox, SelectBoxTypes } from 'devextreme-react/select-box';
 import { Switch } from 'devextreme-react/switch';
@@ -22,11 +22,11 @@ const languages = ['Arabic: Right-to-Left direction', 'English: Left-to-Right di
 const tagBoxDefaultValue = [europeanUnion[0].id];
 
 function App() {
-  const [rtlEnabled, setRtlEnabled] = React.useState(false);
-  const [displayExpr, setDisplayExpr] = React.useState('nameEn');
-  const [textValue, setTextValue] = React.useState('text');
+  const [rtlEnabled, setRtlEnabled] = useState(false);
+  const [displayExpr, setDisplayExpr] = useState('nameEn');
+  const [textValue, setTextValue] = useState('text');
 
-  const onLanguageChanged = React.useCallback((args: SelectBoxTypes.ValueChangedEvent) => {
+  const onLanguageChanged = useCallback((args: SelectBoxTypes.ValueChangedEvent) => {
     const isRTL = args.value === languages[0];
 
     setDisplayExpr(isRTL ? 'nameAr' : 'nameEn');

--- a/JSDemos/Demos/Common/EditorsRightToLeftSupport/ReactJs/App.js
+++ b/JSDemos/Demos/Common/EditorsRightToLeftSupport/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { NumberBox } from 'devextreme-react/number-box';
 import { SelectBox } from 'devextreme-react/select-box';
 import { Switch } from 'devextreme-react/switch';
@@ -21,10 +21,10 @@ import {
 const languages = ['Arabic: Right-to-Left direction', 'English: Left-to-Right direction'];
 const tagBoxDefaultValue = [europeanUnion[0].id];
 function App() {
-  const [rtlEnabled, setRtlEnabled] = React.useState(false);
-  const [displayExpr, setDisplayExpr] = React.useState('nameEn');
-  const [textValue, setTextValue] = React.useState('text');
-  const onLanguageChanged = React.useCallback((args) => {
+  const [rtlEnabled, setRtlEnabled] = useState(false);
+  const [displayExpr, setDisplayExpr] = useState('nameEn');
+  const [textValue, setTextValue] = useState('text');
+  const onLanguageChanged = useCallback((args) => {
     const isRTL = args.value === languages[0];
     setDisplayExpr(isRTL ? 'nameAr' : 'nameEn');
     setRtlEnabled(isRTL);

--- a/JSDemos/Demos/Common/NavigationOverview/React/App.tsx
+++ b/JSDemos/Demos/Common/NavigationOverview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TreeView, { TreeViewTypes } from 'devextreme-react/tree-view';
 import TabPanel, { TabPanelTypes } from 'devextreme-react/tab-panel';
 import { continents } from './data.ts';
@@ -41,11 +41,11 @@ const renderPanelItem = (city) => (
   </React.Fragment>
 );
 function App() {
-  const [tabPanelIndex, setTabPanelIndex] = React.useState(0);
-  const [countryData, setCountryData] = React.useState(continents[0].items[0]);
-  const [citiesData, setCitiesData] = React.useState(continents[0].items[0].cities);
+  const [tabPanelIndex, setTabPanelIndex] = useState(0);
+  const [countryData, setCountryData] = useState(continents[0].items[0]);
+  const [citiesData, setCitiesData] = useState(continents[0].items[0].cities);
 
-  const handleTreeViewSelectionChange = React.useCallback((
+  const handleTreeViewSelectionChange = useCallback((
     e: TreeViewTypes.SelectionChangedEvent & { itemData: any },
   ) => {
     const selectedCountryData = e.itemData;
@@ -56,7 +56,7 @@ function App() {
     }
   }, [setTabPanelIndex, setCountryData, setCitiesData]);
 
-  const handleTabPanelSelectionChange = React.useCallback((
+  const handleTabPanelSelectionChange = useCallback((
     e: TabPanelTypes.SelectionChangedEvent & { value: any },
   ) => {
     setTabPanelIndex(e.value);

--- a/JSDemos/Demos/Common/NavigationOverview/ReactJs/App.js
+++ b/JSDemos/Demos/Common/NavigationOverview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TreeView from 'devextreme-react/tree-view';
 import TabPanel from 'devextreme-react/tab-panel';
 import { continents } from './data.js';
@@ -44,10 +44,10 @@ const renderPanelItem = (city) => (
   </React.Fragment>
 );
 function App() {
-  const [tabPanelIndex, setTabPanelIndex] = React.useState(0);
-  const [countryData, setCountryData] = React.useState(continents[0].items[0]);
-  const [citiesData, setCitiesData] = React.useState(continents[0].items[0].cities);
-  const handleTreeViewSelectionChange = React.useCallback(
+  const [tabPanelIndex, setTabPanelIndex] = useState(0);
+  const [countryData, setCountryData] = useState(continents[0].items[0]);
+  const [citiesData, setCitiesData] = useState(continents[0].items[0].cities);
+  const handleTreeViewSelectionChange = useCallback(
     (e) => {
       const selectedCountryData = e.itemData;
       if (selectedCountryData.cities) {
@@ -58,7 +58,7 @@ function App() {
     },
     [setTabPanelIndex, setCountryData, setCitiesData],
   );
-  const handleTabPanelSelectionChange = React.useCallback(
+  const handleTabPanelSelectionChange = useCallback(
     (e) => {
       setTabPanelIndex(e.value);
     },

--- a/JSDemos/Demos/Common/NavigationRightToLeftSupport/React/App.tsx
+++ b/JSDemos/Demos/Common/NavigationRightToLeftSupport/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import Menu from 'devextreme-react/menu';
 import TreeView from 'devextreme-react/tree-view';
@@ -31,9 +31,9 @@ const renderEnglish = (country) => (
 );
 
 const App = () => {
-  const [rtlEnabled, setRtl] = React.useState(false);
+  const [rtlEnabled, setRtl] = useState(false);
 
-  const selectLanguage = React.useCallback(({ value }) => {
+  const selectLanguage = useCallback(({ value }) => {
     setRtl(value === languages[0]);
   }, [setRtl]);
 

--- a/JSDemos/Demos/Common/NavigationRightToLeftSupport/ReactJs/App.js
+++ b/JSDemos/Demos/Common/NavigationRightToLeftSupport/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import Menu from 'devextreme-react/menu';
 import TreeView from 'devextreme-react/tree-view';
@@ -27,8 +27,8 @@ const renderEnglish = (country) => (
   </div>
 );
 const App = () => {
-  const [rtlEnabled, setRtl] = React.useState(false);
-  const selectLanguage = React.useCallback(
+  const [rtlEnabled, setRtl] = useState(false);
+  const selectLanguage = useCallback(
     ({ value }) => {
       setRtl(value === languages[0]);
     },

--- a/JSDemos/Demos/ContextMenu/Basics/React/App.tsx
+++ b/JSDemos/Demos/ContextMenu/Basics/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import ContextMenu, { ContextMenuTypes } from 'devextreme-react/context-menu';
 import notify from 'devextreme/ui/notify';
 import { contextMenuItems as items } from './data.ts';
@@ -10,7 +10,7 @@ function itemClick(e: ContextMenuTypes.ItemClickEvent) {
 }
 
 function App() {
-  React.useEffect(() => {
+  useEffect(() => {
     const image = document.getElementById('image');
     if (image) {
       image.addEventListener('contextmenu', (e) => {

--- a/JSDemos/Demos/ContextMenu/Basics/ReactJs/App.js
+++ b/JSDemos/Demos/ContextMenu/Basics/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import ContextMenu from 'devextreme-react/context-menu';
 import notify from 'devextreme/ui/notify';
 import { contextMenuItems as items } from './data.js';
@@ -9,7 +9,7 @@ function itemClick(e) {
   }
 }
 function App() {
-  React.useEffect(() => {
+  useEffect(() => {
     const image = document.getElementById('image');
     if (image) {
       image.addEventListener('contextmenu', (e) => {

--- a/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/React/MasterDetailView.tsx
+++ b/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/React/MasterDetailView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { TabPanel, Item } from 'devextreme-react/tab-panel';
 import { DataGridTypes } from 'devextreme-react/data-grid';
 
@@ -6,11 +6,11 @@ import AddressTab from './AddressTab.tsx';
 import OrdersTab from './OrdersTab.tsx';
 
 const MasterDetailView = (props: DataGridTypes.MasterDetailTemplateData) => {
-  const renderOrdersTab = React.useCallback(() => (
+  const renderOrdersTab = useCallback(() => (
     <OrdersTab supplierId={props.data.key} />
   ), [props.data.key]);
 
-  const renderAddressTab = React.useCallback(() => (
+  const renderAddressTab = useCallback(() => (
     <AddressTab data={props.data.data} />
   ), [props.data.data]);
 

--- a/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/React/OrderHistory.tsx
+++ b/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/React/OrderHistory.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import {
   Column, DataGrid, Paging, Summary, TotalItem, ValueFormat,
@@ -12,9 +12,9 @@ interface OrderHistoryProps {
 }
 
 const OrderHistory = ({ productId }: OrderHistoryProps) => {
-  const [orderHistoryStore, setOrderHistoryStore] = React.useState(null);
+  const [orderHistoryStore, setOrderHistoryStore] = useState(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (productId) {
       const newOrderHistoryStore = createStore({
         key: 'OrderID',

--- a/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/React/OrdersTab.tsx
+++ b/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/React/OrdersTab.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { Form, Item, Label } from 'devextreme-react/form';
 
 import ProductSelectBox from './ProductSelectBox.tsx';
@@ -9,16 +9,16 @@ interface OrdersTabProps {
 }
 
 const OrdersTab = (props: OrdersTabProps) => {
-  const [chosenProductId, setChosenProductId] = React.useState(null);
+  const [chosenProductId, setChosenProductId] = useState(null);
 
-  const renderSelectBox = React.useCallback(() => (
+  const renderSelectBox = useCallback(() => (
     <ProductSelectBox
       supplierId={props.supplierId}
       productId={chosenProductId}
       onProductChanged={setChosenProductId} />
   ), [chosenProductId, props.supplierId]);
 
-  const renderOrderHistory = React.useCallback(() => (
+  const renderOrderHistory = useCallback(() => (
     <OrderHistory productId={chosenProductId} />
   ), [chosenProductId]);
 

--- a/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/React/ProductSelectBox.tsx
+++ b/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/React/ProductSelectBox.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { SelectBox, SelectBoxTypes } from 'devextreme-react/select-box';
 import { createStore } from 'devextreme-aspnet-data-nojquery';
 
@@ -12,13 +12,13 @@ interface ProductSelectBoxProps {
 }
 
 const ProductSelectBox = (props: ProductSelectBoxProps) => {
-  const [productsData, setProductsData] = React.useState(null);
+  const [productsData, setProductsData] = useState(null);
 
-  const valueChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const valueChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     props.onProductChanged(e.value);
   }, [props]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const setDefaultValue = (items: any[]) => {
       const firstItem = items[0];
       if (firstItem && props.productId === null) {

--- a/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/ReactJs/MasterDetailView.js
+++ b/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/ReactJs/MasterDetailView.js
@@ -1,14 +1,14 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { TabPanel, Item } from 'devextreme-react/tab-panel';
 import AddressTab from './AddressTab.js';
 import OrdersTab from './OrdersTab.js';
 
 const MasterDetailView = (props) => {
-  const renderOrdersTab = React.useCallback(
+  const renderOrdersTab = useCallback(
     () => <OrdersTab supplierId={props.data.key} />,
     [props.data.key],
   );
-  const renderAddressTab = React.useCallback(
+  const renderAddressTab = useCallback(
     () => <AddressTab data={props.data.data} />,
     [props.data.data],
   );

--- a/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/ReactJs/OrderHistory.js
+++ b/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/ReactJs/OrderHistory.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Column,
   DataGrid,
@@ -11,8 +11,8 @@ import { createStore } from 'devextreme-aspnet-data-nojquery';
 
 const url = 'https://js.devexpress.com/Demos/Mvc/api/DataGridAdvancedMasterDetailView';
 const OrderHistory = ({ productId }) => {
-  const [orderHistoryStore, setOrderHistoryStore] = React.useState(null);
-  React.useEffect(() => {
+  const [orderHistoryStore, setOrderHistoryStore] = useState(null);
+  useEffect(() => {
     if (productId) {
       const newOrderHistoryStore = createStore({
         key: 'OrderID',

--- a/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/ReactJs/OrdersTab.js
+++ b/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/ReactJs/OrdersTab.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { Form, Item, Label } from 'devextreme-react/form';
 import ProductSelectBox from './ProductSelectBox.js';
 import OrderHistory from './OrderHistory.js';
 
 const OrdersTab = (props) => {
-  const [chosenProductId, setChosenProductId] = React.useState(null);
-  const renderSelectBox = React.useCallback(
+  const [chosenProductId, setChosenProductId] = useState(null);
+  const renderSelectBox = useCallback(
     () => (
       <ProductSelectBox
         supplierId={props.supplierId}
@@ -15,7 +15,7 @@ const OrdersTab = (props) => {
     ),
     [chosenProductId, props.supplierId],
   );
-  const renderOrderHistory = React.useCallback(
+  const renderOrderHistory = useCallback(
     () => <OrderHistory productId={chosenProductId} />,
     [chosenProductId],
   );

--- a/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/ReactJs/ProductSelectBox.js
+++ b/JSDemos/Demos/DataGrid/AdvancedMasterDetailView/ReactJs/ProductSelectBox.js
@@ -1,18 +1,18 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { SelectBox } from 'devextreme-react/select-box';
 import { createStore } from 'devextreme-aspnet-data-nojquery';
 
 const url = 'https://js.devexpress.com/Demos/Mvc/api/DataGridAdvancedMasterDetailView';
 const productLabel = { 'aria-label': 'Product' };
 const ProductSelectBox = (props) => {
-  const [productsData, setProductsData] = React.useState(null);
-  const valueChanged = React.useCallback(
+  const [productsData, setProductsData] = useState(null);
+  const valueChanged = useCallback(
     (e) => {
       props.onProductChanged(e.value);
     },
     [props],
   );
-  React.useEffect(() => {
+  useEffect(() => {
     const setDefaultValue = (items) => {
       const firstItem = items[0];
       if (firstItem && props.productId === null) {

--- a/JSDemos/Demos/DataGrid/Appearance/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/Appearance/React/App.tsx
@@ -1,28 +1,28 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, { Column } from 'devextreme-react/data-grid';
 import CheckBox, { CheckBoxTypes } from 'devextreme-react/check-box';
 
 import { employees } from './data.ts';
 
 const App = () => {
-  const [showColumnLines, setShowColumnLines] = React.useState(false);
-  const [showRowLines, setShowRowLines] = React.useState(true);
-  const [showBorders, setShowBorders] = React.useState(true);
-  const [rowAlternationEnabled, setRowAlternationEnabled] = React.useState(true);
+  const [showColumnLines, setShowColumnLines] = useState(false);
+  const [showRowLines, setShowRowLines] = useState(true);
+  const [showBorders, setShowBorders] = useState(true);
+  const [rowAlternationEnabled, setRowAlternationEnabled] = useState(true);
 
-  const onShowColumnLinesValueChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onShowColumnLinesValueChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setShowColumnLines(e.value);
   }, []);
 
-  const onShowRowLinesValueChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onShowRowLinesValueChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setShowRowLines(e.value);
   }, []);
 
-  const onShowBordersValueChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onShowBordersValueChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setShowBorders(e.value);
   }, []);
 
-  const onRowAlternationEnabledChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onRowAlternationEnabledChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setRowAlternationEnabled(e.value);
   }, []);
 

--- a/JSDemos/Demos/DataGrid/Appearance/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/Appearance/ReactJs/App.js
@@ -1,23 +1,23 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, { Column } from 'devextreme-react/data-grid';
 import CheckBox from 'devextreme-react/check-box';
 import { employees } from './data.js';
 
 const App = () => {
-  const [showColumnLines, setShowColumnLines] = React.useState(false);
-  const [showRowLines, setShowRowLines] = React.useState(true);
-  const [showBorders, setShowBorders] = React.useState(true);
-  const [rowAlternationEnabled, setRowAlternationEnabled] = React.useState(true);
-  const onShowColumnLinesValueChanged = React.useCallback((e) => {
+  const [showColumnLines, setShowColumnLines] = useState(false);
+  const [showRowLines, setShowRowLines] = useState(true);
+  const [showBorders, setShowBorders] = useState(true);
+  const [rowAlternationEnabled, setRowAlternationEnabled] = useState(true);
+  const onShowColumnLinesValueChanged = useCallback((e) => {
     setShowColumnLines(e.value);
   }, []);
-  const onShowRowLinesValueChanged = React.useCallback((e) => {
+  const onShowRowLinesValueChanged = useCallback((e) => {
     setShowRowLines(e.value);
   }, []);
-  const onShowBordersValueChanged = React.useCallback((e) => {
+  const onShowBordersValueChanged = useCallback((e) => {
     setShowBorders(e.value);
   }, []);
-  const onRowAlternationEnabledChanged = React.useCallback((e) => {
+  const onRowAlternationEnabledChanged = useCallback((e) => {
     setRowAlternationEnabled(e.value);
   }, []);
   return (

--- a/JSDemos/Demos/DataGrid/BatchEditing/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/BatchEditing/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Column,
   Editing,
@@ -14,14 +14,14 @@ const startEditActions = ['click', 'dblClick'];
 const actionLabel = { 'aria-label': 'Action' };
 
 const App = () => {
-  const [selectTextOnEditStart, setSelectTextOnEditStart] = React.useState(true);
-  const [startEditAction, setStartEditAction] = React.useState<DataGridTypes.StartEditAction>('click');
+  const [selectTextOnEditStart, setSelectTextOnEditStart] = useState(true);
+  const [startEditAction, setStartEditAction] = useState<DataGridTypes.StartEditAction>('click');
 
-  const onSelectTextOnEditStartChanged = React.useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
+  const onSelectTextOnEditStartChanged = useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
     setSelectTextOnEditStart(args.value);
   }, []);
 
-  const onStartEditActionChanged = React.useCallback((args: SelectBoxTypes.ValueChangedEvent) => {
+  const onStartEditActionChanged = useCallback((args: SelectBoxTypes.ValueChangedEvent) => {
     setStartEditAction(args.value);
   }, []);
 

--- a/JSDemos/Demos/DataGrid/BatchEditing/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/BatchEditing/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Column, Editing, Paging, Lookup,
 } from 'devextreme-react/data-grid';
@@ -9,12 +9,12 @@ import { employees, states } from './data.js';
 const startEditActions = ['click', 'dblClick'];
 const actionLabel = { 'aria-label': 'Action' };
 const App = () => {
-  const [selectTextOnEditStart, setSelectTextOnEditStart] = React.useState(true);
-  const [startEditAction, setStartEditAction] = React.useState('click');
-  const onSelectTextOnEditStartChanged = React.useCallback((args) => {
+  const [selectTextOnEditStart, setSelectTextOnEditStart] = useState(true);
+  const [startEditAction, setStartEditAction] = useState('click');
+  const onSelectTextOnEditStartChanged = useCallback((args) => {
     setSelectTextOnEditStart(args.value);
   }, []);
-  const onStartEditActionChanged = React.useCallback((args) => {
+  const onStartEditActionChanged = useCallback((args) => {
     setStartEditAction(args.value);
   }, []);
   return (

--- a/JSDemos/Demos/DataGrid/CRUDOperations/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/CRUDOperations/React/App.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 /* global RequestInit */
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   DataGrid, Column, Editing, Scrolling, Lookup, Summary, TotalItem, DataGridTypes,
 } from 'devextreme-react/data-grid';
@@ -17,7 +17,7 @@ const URL = 'https://js.devexpress.com/Demos/Mvc/api/DataGridWebApi';
 const REFRESH_MODES = ['full', 'reshape', 'repaint'];
 
 const App = () => {
-  const [ordersData] = React.useState(new CustomStore({
+  const [ordersData] = useState(new CustomStore({
     key: 'OrderID',
     load: () => sendRequest(`${URL}/Orders`),
     insert: (values) => sendRequest(`${URL}/InsertOrder`, 'POST', {
@@ -31,29 +31,29 @@ const App = () => {
       key,
     }),
   }));
-  const [customersData] = React.useState(new CustomStore({
+  const [customersData] = useState(new CustomStore({
     key: 'Value',
     loadMode: 'raw',
     load: () => sendRequest(`${URL}/CustomersLookup`),
   }));
-  const [shippersData] = React.useState(new CustomStore({
+  const [shippersData] = useState(new CustomStore({
     key: 'Value',
     loadMode: 'raw',
     load: () => sendRequest(`${URL}/ShippersLookup`),
   }));
 
-  const [requests, setRequests] = React.useState([]);
-  const [refreshMode, setRefreshMode] = React.useState<DataGridTypes.GridsEditRefreshMode>('reshape');
+  const [requests, setRequests] = useState([]);
+  const [refreshMode, setRefreshMode] = useState<DataGridTypes.GridsEditRefreshMode>('reshape');
 
-  const handleRefreshModeChange = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const handleRefreshModeChange = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setRefreshMode(e.value);
   }, []);
 
-  const clearRequests = React.useCallback(() => {
+  const clearRequests = useCallback(() => {
     setRequests([]);
   }, []);
 
-  const logRequest = React.useCallback((method, url: string, data: Record<string, any>) => {
+  const logRequest = useCallback((method, url: string, data: Record<string, any>) => {
     const args = Object.keys(data || {}).map((key) => `${key}=${data[key]}`).join(' ');
 
     const time = formatDate(new Date(), 'HH:mm:ss');
@@ -63,7 +63,7 @@ const App = () => {
   }, []);
 
   // eslint-disable-next-line consistent-return, space-before-function-paren
-  const sendRequest = React.useCallback(async (url: string, method = 'GET', data = {}) => {
+  const sendRequest = useCallback(async (url: string, method = 'GET', data = {}) => {
     logRequest(method, url, data);
 
     const request: RequestInit = {

--- a/JSDemos/Demos/DataGrid/CRUDOperations/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/CRUDOperations/ReactJs/App.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 /* global RequestInit */
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   DataGrid,
   Column,
@@ -20,7 +20,7 @@ const refreshModeLabel = { 'aria-label': 'Refresh Mode' };
 const URL = 'https://js.devexpress.com/Demos/Mvc/api/DataGridWebApi';
 const REFRESH_MODES = ['full', 'reshape', 'repaint'];
 const App = () => {
-  const [ordersData] = React.useState(
+  const [ordersData] = useState(
     new CustomStore({
       key: 'OrderID',
       load: () => sendRequest(`${URL}/Orders`),
@@ -39,29 +39,29 @@ const App = () => {
         }),
     }),
   );
-  const [customersData] = React.useState(
+  const [customersData] = useState(
     new CustomStore({
       key: 'Value',
       loadMode: 'raw',
       load: () => sendRequest(`${URL}/CustomersLookup`),
     }),
   );
-  const [shippersData] = React.useState(
+  const [shippersData] = useState(
     new CustomStore({
       key: 'Value',
       loadMode: 'raw',
       load: () => sendRequest(`${URL}/ShippersLookup`),
     }),
   );
-  const [requests, setRequests] = React.useState([]);
-  const [refreshMode, setRefreshMode] = React.useState('reshape');
-  const handleRefreshModeChange = React.useCallback((e) => {
+  const [requests, setRequests] = useState([]);
+  const [refreshMode, setRefreshMode] = useState('reshape');
+  const handleRefreshModeChange = useCallback((e) => {
     setRefreshMode(e.value);
   }, []);
-  const clearRequests = React.useCallback(() => {
+  const clearRequests = useCallback(() => {
     setRequests([]);
   }, []);
-  const logRequest = React.useCallback((method, url, data) => {
+  const logRequest = useCallback((method, url, data) => {
     const args = Object.keys(data || {})
       .map((key) => `${key}=${data[key]}`)
       .join(' ');
@@ -70,7 +70,7 @@ const App = () => {
     setRequests((prevRequests) => [request].concat(prevRequests));
   }, []);
   // eslint-disable-next-line consistent-return, space-before-function-paren
-  const sendRequest = React.useCallback(
+  const sendRequest = useCallback(
     async(url, method = 'GET', data = {}) => {
       logRequest(method, url, data);
       const request = {

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Column, Editing, Paging, Selection, Lookup, Toolbar, Item, DataGridTypes,
 } from 'devextreme-react/data-grid';
@@ -15,9 +15,9 @@ const dataSource = new DataSource({
 });
 
 const App = () => {
-  const [selectedItemKeys, setSelectedItemKeys] = React.useState([]);
+  const [selectedItemKeys, setSelectedItemKeys] = useState([]);
 
-  const deleteRecords = React.useCallback(() => {
+  const deleteRecords = useCallback(() => {
     selectedItemKeys.forEach((key) => {
       dataSource.store().remove(key);
     });
@@ -25,7 +25,7 @@ const App = () => {
     dataSource.reload();
   }, [selectedItemKeys]);
 
-  const onSelectionChanged = React.useCallback((data: DataGridTypes.SelectionChangedEvent) => {
+  const onSelectionChanged = useCallback((data: DataGridTypes.SelectionChangedEvent) => {
     setSelectedItemKeys(data.selectedRowKeys);
   }, []);
 

--- a/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/CellEditingAndEditingAPI/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Column,
   Editing,
@@ -20,15 +20,15 @@ const dataSource = new DataSource({
   }),
 });
 const App = () => {
-  const [selectedItemKeys, setSelectedItemKeys] = React.useState([]);
-  const deleteRecords = React.useCallback(() => {
+  const [selectedItemKeys, setSelectedItemKeys] = useState([]);
+  const deleteRecords = useCallback(() => {
     selectedItemKeys.forEach((key) => {
       dataSource.store().remove(key);
     });
     setSelectedItemKeys([]);
     dataSource.reload();
   }, [selectedItemKeys]);
-  const onSelectionChanged = React.useCallback((data) => {
+  const onSelectionChanged = useCallback((data) => {
     setSelectedItemKeys(data.selectedRowKeys);
   }, []);
   return (

--- a/JSDemos/Demos/DataGrid/CollaborativeEditing/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/CollaborativeEditing/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { HubConnectionBuilder, HttpTransportType } from '@aspnet/signalr';
 import * as AspNetData from 'devextreme-aspnet-data-nojquery';
@@ -37,7 +37,7 @@ const updateStores = (events: Change[]) => {
 };
 
 const App = () => {
-  React.useEffect(() => {
+  useEffect(() => {
     const hubUrl = `${BASE_PATH}dataGridCollaborativeEditingHub?GroupId=${groupId}`;
     const connection = new HubConnectionBuilder()
       .withUrl(hubUrl, {

--- a/JSDemos/Demos/DataGrid/CollaborativeEditing/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/CollaborativeEditing/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { HubConnectionBuilder, HttpTransportType } from '@aspnet/signalr';
 import * as AspNetData from 'devextreme-aspnet-data-nojquery';
 import Guid from 'devextreme/core/guid';
@@ -25,7 +25,7 @@ const updateStores = (events) => {
   store2.push(events);
 };
 const App = () => {
-  React.useEffect(() => {
+  useEffect(() => {
     const hubUrl = `${BASE_PATH}dataGridCollaborativeEditingHub?GroupId=${groupId}`;
     const connection = new HubConnectionBuilder()
       .withUrl(hubUrl, {

--- a/JSDemos/Demos/DataGrid/ColumnChooser/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/ColumnChooser/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   DataGrid, Column, ColumnChooser, ColumnChooserSearch, ColumnChooserSelection, Position,
 } from 'devextreme-react/data-grid';
@@ -21,31 +21,31 @@ const searchEditorOptions = { placeholder: 'Search column' };
 const columnChooserModeLabel = { 'aria-label': 'Column Chooser Mode' };
 
 const App = () => {
-  const [mode, setMode] = React.useState(columnChooserModes[1].key);
-  const [searchEnabled, setSearchEnabled] = React.useState(true);
-  const [allowSelectAll, setAllowSelectAll] = React.useState(true);
-  const [selectByClick, setSelectByClick] = React.useState(true);
-  const [recursive, setRecursive] = React.useState(true);
+  const [mode, setMode] = useState(columnChooserModes[1].key);
+  const [searchEnabled, setSearchEnabled] = useState(true);
+  const [allowSelectAll, setAllowSelectAll] = useState(true);
+  const [selectByClick, setSelectByClick] = useState(true);
+  const [recursive, setRecursive] = useState(true);
 
   const isDragMode = mode === columnChooserModes[0].key;
 
-  const onModeValueChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const onModeValueChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setMode(e.value);
   }, []);
 
-  const onSearchEnabledValueChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onSearchEnabledValueChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setSearchEnabled(e.value);
   }, []);
 
-  const onAllowSelectAllValueChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onAllowSelectAllValueChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setAllowSelectAll(e.value);
   }, []);
 
-  const onSelectByClickValueChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onSelectByClickValueChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setSelectByClick(e.value);
   }, []);
 
-  const onRecursiveValueChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onRecursiveValueChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setRecursive(e.value);
   }, []);
 

--- a/JSDemos/Demos/DataGrid/ColumnChooser/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/ColumnChooser/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   DataGrid,
   Column,
@@ -24,25 +24,25 @@ const columnChooserModes = [
 const searchEditorOptions = { placeholder: 'Search column' };
 const columnChooserModeLabel = { 'aria-label': 'Column Chooser Mode' };
 const App = () => {
-  const [mode, setMode] = React.useState(columnChooserModes[1].key);
-  const [searchEnabled, setSearchEnabled] = React.useState(true);
-  const [allowSelectAll, setAllowSelectAll] = React.useState(true);
-  const [selectByClick, setSelectByClick] = React.useState(true);
-  const [recursive, setRecursive] = React.useState(true);
+  const [mode, setMode] = useState(columnChooserModes[1].key);
+  const [searchEnabled, setSearchEnabled] = useState(true);
+  const [allowSelectAll, setAllowSelectAll] = useState(true);
+  const [selectByClick, setSelectByClick] = useState(true);
+  const [recursive, setRecursive] = useState(true);
   const isDragMode = mode === columnChooserModes[0].key;
-  const onModeValueChanged = React.useCallback((e) => {
+  const onModeValueChanged = useCallback((e) => {
     setMode(e.value);
   }, []);
-  const onSearchEnabledValueChanged = React.useCallback((e) => {
+  const onSearchEnabledValueChanged = useCallback((e) => {
     setSearchEnabled(e.value);
   }, []);
-  const onAllowSelectAllValueChanged = React.useCallback((e) => {
+  const onAllowSelectAllValueChanged = useCallback((e) => {
     setAllowSelectAll(e.value);
   }, []);
-  const onSelectByClickValueChanged = React.useCallback((e) => {
+  const onSelectByClickValueChanged = useCallback((e) => {
     setSelectByClick(e.value);
   }, []);
-  const onRecursiveValueChanged = React.useCallback((e) => {
+  const onRecursiveValueChanged = useCallback((e) => {
     setRecursive(e.value);
   }, []);
   return (

--- a/JSDemos/Demos/DataGrid/ColumnResizing/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/ColumnResizing/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid from 'devextreme-react/data-grid';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 import { ColumnResizeMode } from 'devextreme/common/grids';
@@ -10,9 +10,9 @@ const resizingModes: ColumnResizeMode[] = ['nextColumn', 'widget'];
 const columnResizingModeLabel = { 'aria-label': 'Column Resizing Mode' };
 
 const App = () => {
-  const [mode, setMode] = React.useState(resizingModes[0]);
+  const [mode, setMode] = useState(resizingModes[0]);
 
-  const changeResizingMode = React.useCallback((data: SelectBoxTypes.ValueChangedEvent) => {
+  const changeResizingMode = useCallback((data: SelectBoxTypes.ValueChangedEvent) => {
     setMode(data.value);
   }, []);
 

--- a/JSDemos/Demos/DataGrid/ColumnResizing/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/ColumnResizing/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid from 'devextreme-react/data-grid';
 import SelectBox from 'devextreme-react/select-box';
 import { orders } from './data.js';
@@ -7,8 +7,8 @@ const columns = ['CompanyName', 'City', 'State', 'Phone', 'Fax'];
 const resizingModes = ['nextColumn', 'widget'];
 const columnResizingModeLabel = { 'aria-label': 'Column Resizing Mode' };
 const App = () => {
-  const [mode, setMode] = React.useState(resizingModes[0]);
-  const changeResizingMode = React.useCallback((data) => {
+  const [mode, setMode] = useState(resizingModes[0]);
+  const changeResizingMode = useCallback((data) => {
     setMode(data.value);
   }, []);
   return (

--- a/JSDemos/Demos/DataGrid/CommandColumnCustomization/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/CommandColumnCustomization/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Button, Column, DataGridTypes, Editing, Lookup,
 } from 'devextreme-react/data-grid';
@@ -29,9 +29,9 @@ const onEditorPreparing = (e: DataGridTypes.EditorPreparingEvent) => {
 };
 
 const App = () => {
-  const [employees, setEmployees] = React.useState(defaultEmployees);
+  const [employees, setEmployees] = useState(defaultEmployees);
 
-  const onCloneIconClick = React.useCallback((e) => {
+  const onCloneIconClick = useCallback((e) => {
     const clonedItem = { ...e.row.data, ID: getMaxID() };
 
     setEmployees((prevState) => {

--- a/JSDemos/Demos/DataGrid/CommandColumnCustomization/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/CommandColumnCustomization/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Button, Column, Editing, Lookup,
 } from 'devextreme-react/data-grid';
@@ -22,8 +22,8 @@ const onEditorPreparing = (e) => {
   }
 };
 const App = () => {
-  const [employees, setEmployees] = React.useState(defaultEmployees);
-  const onCloneIconClick = React.useCallback((e) => {
+  const [employees, setEmployees] = useState(defaultEmployees);
+  const onCloneIconClick = useCallback((e) => {
     const clonedItem = { ...e.row.data, ID: getMaxID() };
     setEmployees((prevState) => {
       const updatedEmployees = [...prevState];

--- a/JSDemos/Demos/DataGrid/CustomEditors/React/EmployeeDropDownBoxComponent.tsx
+++ b/JSDemos/Demos/DataGrid/CustomEditors/React/EmployeeDropDownBoxComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Column,
   DataGridTypes,
@@ -12,16 +12,16 @@ const dropDownOptions = { width: 500 };
 const ownerLabel = { 'aria-label': 'Owner' };
 
 const EmployeeDropDownBoxComponent = (props) => {
-  const [selectedRowKeys, setSelectedRowKeys] = React.useState([props.data.value]);
-  const [isDropDownOpened, setDropDownOpened] = React.useState(false);
+  const [selectedRowKeys, setSelectedRowKeys] = useState([props.data.value]);
+  const [isDropDownOpened, setDropDownOpened] = useState(false);
 
-  const boxOptionChanged = React.useCallback((e: DropDownBoxTypes.OptionChangedEvent) => {
+  const boxOptionChanged = useCallback((e: DropDownBoxTypes.OptionChangedEvent) => {
     if (e.name === 'opened') {
       setDropDownOpened(e.value);
     }
   }, []);
 
-  const contentRender = React.useCallback(() => {
+  const contentRender = useCallback(() => {
     const onSelectionChanged = (args: DataGridTypes.SelectionChangedEvent) => {
       setSelectedRowKeys(args.selectedRowKeys);
       setDropDownOpened(false);

--- a/JSDemos/Demos/DataGrid/CustomEditors/React/EmployeeTagBoxComponent.tsx
+++ b/JSDemos/Demos/DataGrid/CustomEditors/React/EmployeeTagBoxComponent.tsx
@@ -1,14 +1,14 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import TagBox, { TagBoxTypes } from 'devextreme-react/tag-box';
 
 const nameLabel = { 'aria-label': 'Name' };
 
 const EmployeeTagBoxComponent = (props) => {
-  const onValueChanged = React.useCallback((e: TagBoxTypes.ValueChangedEvent) => {
+  const onValueChanged = useCallback((e: TagBoxTypes.ValueChangedEvent) => {
     props.data.setValue(e.value);
   }, [props]);
 
-  const onSelectionChanged = React.useCallback(() => {
+  const onSelectionChanged = useCallback(() => {
     props.data.component.updateDimensions();
   }, [props]);
 

--- a/JSDemos/Demos/DataGrid/CustomEditors/ReactJs/EmployeeDropDownBoxComponent.js
+++ b/JSDemos/Demos/DataGrid/CustomEditors/ReactJs/EmployeeDropDownBoxComponent.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Column, Paging, Scrolling, Selection,
 } from 'devextreme-react/data-grid';
@@ -7,14 +7,14 @@ import DropDownBox from 'devextreme-react/drop-down-box';
 const dropDownOptions = { width: 500 };
 const ownerLabel = { 'aria-label': 'Owner' };
 const EmployeeDropDownBoxComponent = (props) => {
-  const [selectedRowKeys, setSelectedRowKeys] = React.useState([props.data.value]);
-  const [isDropDownOpened, setDropDownOpened] = React.useState(false);
-  const boxOptionChanged = React.useCallback((e) => {
+  const [selectedRowKeys, setSelectedRowKeys] = useState([props.data.value]);
+  const [isDropDownOpened, setDropDownOpened] = useState(false);
+  const boxOptionChanged = useCallback((e) => {
     if (e.name === 'opened') {
       setDropDownOpened(e.value);
     }
   }, []);
-  const contentRender = React.useCallback(() => {
+  const contentRender = useCallback(() => {
     const onSelectionChanged = (args) => {
       setSelectedRowKeys(args.selectedRowKeys);
       setDropDownOpened(false);

--- a/JSDemos/Demos/DataGrid/CustomEditors/ReactJs/EmployeeTagBoxComponent.js
+++ b/JSDemos/Demos/DataGrid/CustomEditors/ReactJs/EmployeeTagBoxComponent.js
@@ -1,15 +1,15 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import TagBox from 'devextreme-react/tag-box';
 
 const nameLabel = { 'aria-label': 'Name' };
 const EmployeeTagBoxComponent = (props) => {
-  const onValueChanged = React.useCallback(
+  const onValueChanged = useCallback(
     (e) => {
       props.data.setValue(e.value);
     },
     [props],
   );
-  const onSelectionChanged = React.useCallback(() => {
+  const onSelectionChanged = useCallback(() => {
     props.data.component.updateDimensions();
   }, [props]);
   return (

--- a/JSDemos/Demos/DataGrid/CustomNewRecordPosition/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/CustomNewRecordPosition/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Column, Editing, ValidationRule, Button, IButtonProps, Toolbar, Item, Scrolling, DataGridTypes,
 } from 'devextreme-react/data-grid';
@@ -16,12 +16,12 @@ const onRowInserted = (e: DataGridTypes.RowInsertedEvent) => {
 };
 
 const App = () => {
-  const [newRowPosition, setNewRowPosition] = React.useState<DataGridTypes.NewRowPosition>('viewportTop');
-  const [scrollingMode, setScrollingMode] = React.useState<DataGridTypes.DataGridScrollMode>('standard');
-  const [changes, setChanges] = React.useState([]);
-  const [editRowKey, setEditRowKey] = React.useState(null);
+  const [newRowPosition, setNewRowPosition] = useState<DataGridTypes.NewRowPosition>('viewportTop');
+  const [scrollingMode, setScrollingMode] = useState<DataGridTypes.DataGridScrollMode>('standard');
+  const [changes, setChanges] = useState([]);
+  const [editRowKey, setEditRowKey] = useState(null);
 
-  const onAddButtonClick = React.useCallback<IButtonProps['onClick']>((e) => {
+  const onAddButtonClick = useCallback<IButtonProps['onClick']>((e) => {
     const key = new Guid().toString();
     setChanges([{
       key,

--- a/JSDemos/Demos/DataGrid/CustomNewRecordPosition/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/CustomNewRecordPosition/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Column,
   Editing,
@@ -26,11 +26,11 @@ const onRowInserted = (e) => {
   e.component.navigateToRow(e.key);
 };
 const App = () => {
-  const [newRowPosition, setNewRowPosition] = React.useState('viewportTop');
-  const [scrollingMode, setScrollingMode] = React.useState('standard');
-  const [changes, setChanges] = React.useState([]);
-  const [editRowKey, setEditRowKey] = React.useState(null);
-  const onAddButtonClick = React.useCallback((e) => {
+  const [newRowPosition, setNewRowPosition] = useState('viewportTop');
+  const [scrollingMode, setScrollingMode] = useState('standard');
+  const [changes, setChanges] = useState([]);
+  const [editRowKey, setEditRowKey] = useState(null);
+  const onAddButtonClick = useCallback((e) => {
     const key = new Guid().toString();
     setChanges([
       {

--- a/JSDemos/Demos/DataGrid/CustomizeKeyboardNavigation/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/CustomizeKeyboardNavigation/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Column,
   Editing,
@@ -24,19 +24,19 @@ const onFocusedCellChanging = (e: { isHighlighted: boolean; }) => {
 };
 
 const App = () => {
-  const [editOnKeyPress, setEditOnKeyPress] = React.useState(true);
-  const [enterKeyAction, setEnterKeyAction] = React.useState<DataGridTypes.EnterKeyAction>('moveFocus');
-  const [enterKeyDirection, setEnterKeyDirection] = React.useState<DataGridTypes.EnterKeyDirection>('column');
+  const [editOnKeyPress, setEditOnKeyPress] = useState(true);
+  const [enterKeyAction, setEnterKeyAction] = useState<DataGridTypes.EnterKeyAction>('moveFocus');
+  const [enterKeyDirection, setEnterKeyDirection] = useState<DataGridTypes.EnterKeyDirection>('column');
 
-  const editOnKeyPressChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const editOnKeyPressChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setEditOnKeyPress(e.value);
   }, []);
 
-  const enterKeyActionChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const enterKeyActionChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setEnterKeyAction(e.value);
   }, []);
 
-  const enterKeyDirectionChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const enterKeyDirectionChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setEnterKeyDirection(e.value);
   }, []);
 

--- a/JSDemos/Demos/DataGrid/CustomizeKeyboardNavigation/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/CustomizeKeyboardNavigation/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Column,
   Editing,
@@ -18,16 +18,16 @@ const onFocusedCellChanging = (e) => {
   e.isHighlighted = true;
 };
 const App = () => {
-  const [editOnKeyPress, setEditOnKeyPress] = React.useState(true);
-  const [enterKeyAction, setEnterKeyAction] = React.useState('moveFocus');
-  const [enterKeyDirection, setEnterKeyDirection] = React.useState('column');
-  const editOnKeyPressChanged = React.useCallback((e) => {
+  const [editOnKeyPress, setEditOnKeyPress] = useState(true);
+  const [enterKeyAction, setEnterKeyAction] = useState('moveFocus');
+  const [enterKeyDirection, setEnterKeyDirection] = useState('column');
+  const editOnKeyPressChanged = useCallback((e) => {
     setEditOnKeyPress(e.value);
   }, []);
-  const enterKeyActionChanged = React.useCallback((e) => {
+  const enterKeyActionChanged = useCallback((e) => {
     setEnterKeyAction(e.value);
   }, []);
-  const enterKeyDirectionChanged = React.useCallback((e) => {
+  const enterKeyDirectionChanged = useCallback((e) => {
     setEnterKeyDirection(e.value);
   }, []);
   return (

--- a/JSDemos/Demos/DataGrid/DeferredSelection/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/DeferredSelection/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Column, DataGridTypes, FilterRow, Selection,
 } from 'devextreme-react/data-grid';
@@ -28,12 +28,12 @@ const selectionFilter = ['Task_Status', '=', 'Completed'];
 let dataGrid;
 
 const App = () => {
-  const [taskCount, setTaskCount] = React.useState(0);
-  const [peopleCount, setPeopleCount] = React.useState(0);
-  const [avgDuration, setAvgDuration] = React.useState(0);
+  const [taskCount, setTaskCount] = useState(0);
+  const [peopleCount, setPeopleCount] = useState(0);
+  const [avgDuration, setAvgDuration] = useState(0);
 
   // eslint-disable-next-line space-before-function-paren
-  const calculateStatistics = React.useCallback(async () => {
+  const calculateStatistics = useCallback(async () => {
     const selectedItems = await dataGrid.getSelectedRowsData();
 
     const totalDuration = selectedItems.reduce((currentValue: number, item: { Task_Due_Date: number; Task_Start_Date: number; }) => {
@@ -52,7 +52,7 @@ const App = () => {
     setAvgDuration(Math.round(averageDurationInDays) || 0);
   }, []);
 
-  const onInitialized = React.useCallback((e: DataGridTypes.InitializedEvent) => {
+  const onInitialized = useCallback((e: DataGridTypes.InitializedEvent) => {
     dataGrid = e.component;
 
     calculateStatistics();

--- a/JSDemos/Demos/DataGrid/DeferredSelection/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/DeferredSelection/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, { Column, FilterRow, Selection } from 'devextreme-react/data-grid';
 import Button from 'devextreme-react/button';
 import query from 'devextreme/data/query';
@@ -25,11 +25,11 @@ const dataSource = {
 const selectionFilter = ['Task_Status', '=', 'Completed'];
 let dataGrid;
 const App = () => {
-  const [taskCount, setTaskCount] = React.useState(0);
-  const [peopleCount, setPeopleCount] = React.useState(0);
-  const [avgDuration, setAvgDuration] = React.useState(0);
+  const [taskCount, setTaskCount] = useState(0);
+  const [peopleCount, setPeopleCount] = useState(0);
+  const [avgDuration, setAvgDuration] = useState(0);
   // eslint-disable-next-line space-before-function-paren
-  const calculateStatistics = React.useCallback(async () => {
+  const calculateStatistics = useCallback(async () => {
     const selectedItems = await dataGrid.getSelectedRowsData();
     const totalDuration = selectedItems.reduce((currentValue, item) => {
       const duration = item.Task_Due_Date - item.Task_Start_Date;
@@ -42,7 +42,7 @@ const App = () => {
     );
     setAvgDuration(Math.round(averageDurationInDays) || 0);
   }, []);
-  const onInitialized = React.useCallback(
+  const onInitialized = useCallback(
     (e) => {
       dataGrid = e.component;
       calculateStatistics();

--- a/JSDemos/Demos/DataGrid/DnDBetweenGrids/React/Grid.tsx
+++ b/JSDemos/Demos/DataGrid/DnDBetweenGrids/React/Grid.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Column, RowDragging, Scrolling, Lookup,
 } from 'devextreme-react/data-grid';
@@ -14,13 +14,13 @@ const priorities = [{
 }];
 
 const Grid = ({ tasksStore, status }) => {
-  const [filterExpr] = React.useState(['Status', '=', status]);
-  const [dataSource] = React.useState({
+  const [filterExpr] = useState(['Status', '=', status]);
+  const [dataSource] = useState({
     store: tasksStore,
     reshapeOnPush: true,
   });
 
-  const onAdd = React.useCallback((e) => {
+  const onAdd = useCallback((e) => {
     const key = e.itemData.ID;
     const values = { Status: e.toData };
 

--- a/JSDemos/Demos/DataGrid/DnDBetweenGrids/ReactJs/Grid.js
+++ b/JSDemos/Demos/DataGrid/DnDBetweenGrids/ReactJs/Grid.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Column, RowDragging, Scrolling, Lookup,
 } from 'devextreme-react/data-grid';
@@ -22,12 +22,12 @@ const priorities = [
   },
 ];
 const Grid = ({ tasksStore, status }) => {
-  const [filterExpr] = React.useState(['Status', '=', status]);
-  const [dataSource] = React.useState({
+  const [filterExpr] = useState(['Status', '=', status]);
+  const [dataSource] = useState({
     store: tasksStore,
     reshapeOnPush: true,
   });
-  const onAdd = React.useCallback(
+  const onAdd = useCallback(
     (e) => {
       const key = e.itemData.ID;
       const values = { Status: e.toData };

--- a/JSDemos/Demos/DataGrid/EditStateManagement/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/EditStateManagement/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useEffect, useMemo, useReducer } from 'react';
 import DataGrid, {
   Column, DataGridTypes, Editing,
 } from 'devextreme-react/data-grid';
@@ -20,28 +20,28 @@ const initialState: State = {
 const loadPanelPosition = { of: '#gridContainer' };
 
 const App = () => {
-  const [state, dispatch] = React.useReducer(reducer, initialState);
+  const [state, dispatch] = useReducer(reducer, initialState);
 
-  const changesText = React.useMemo(() => JSON.stringify(state.changes.map((change) => ({
+  const changesText = useMemo(() => JSON.stringify(state.changes.map((change) => ({
     type: change.type,
     key: change.type !== 'insert' ? change.key : undefined,
     data: change.data,
   })), null, ' '), [state.changes]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     loadOrders(dispatch);
   }, []);
 
-  const onSaving = React.useCallback((e: DataGridTypes.SavingEvent) => {
+  const onSaving = useCallback((e: DataGridTypes.SavingEvent) => {
     e.cancel = true;
     e.promise = saveChange(dispatch, e.changes[0]);
   }, []);
 
-  const onChangesChange = React.useCallback((changes: DataGridTypes.DataChange[]) => {
+  const onChangesChange = useCallback((changes: DataGridTypes.DataChange[]) => {
     setChanges(dispatch, changes);
   }, []);
 
-  const onEditRowKeyChange = React.useCallback((editRowKey) => {
+  const onEditRowKeyChange = useCallback((editRowKey) => {
     setEditRowKey(dispatch, editRowKey);
   }, []);
 

--- a/JSDemos/Demos/DataGrid/EditStateManagement/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/EditStateManagement/React/App.tsx
@@ -1,4 +1,6 @@
-import React, { useCallback, useEffect, useMemo, useReducer } from 'react';
+import React, {
+  useCallback, useEffect, useMemo, useReducer,
+} from 'react';
 import DataGrid, {
   Column, DataGridTypes, Editing,
 } from 'devextreme-react/data-grid';

--- a/JSDemos/Demos/DataGrid/EditStateManagement/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/EditStateManagement/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useEffect, useMemo, useReducer } from 'react';
 import DataGrid, { Column, Editing } from 'devextreme-react/data-grid';
 import { LoadPanel } from 'devextreme-react/load-panel';
 import 'whatwg-fetch';
@@ -15,8 +15,8 @@ const initialState = {
 };
 const loadPanelPosition = { of: '#gridContainer' };
 const App = () => {
-  const [state, dispatch] = React.useReducer(reducer, initialState);
-  const changesText = React.useMemo(
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const changesText = useMemo(
     () =>
       JSON.stringify(
         state.changes.map((change) => ({
@@ -29,17 +29,17 @@ const App = () => {
       ),
     [state.changes],
   );
-  React.useEffect(() => {
+  useEffect(() => {
     loadOrders(dispatch);
   }, []);
-  const onSaving = React.useCallback((e) => {
+  const onSaving = useCallback((e) => {
     e.cancel = true;
     e.promise = saveChange(dispatch, e.changes[0]);
   }, []);
-  const onChangesChange = React.useCallback((changes) => {
+  const onChangesChange = useCallback((changes) => {
     setChanges(dispatch, changes);
   }, []);
-  const onEditRowKeyChange = React.useCallback((editRowKey) => {
+  const onEditRowKeyChange = useCallback((editRowKey) => {
     setEditRowKey(dispatch, editRowKey);
   }, []);
   return (

--- a/JSDemos/Demos/DataGrid/EditStateManagement/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/EditStateManagement/ReactJs/App.js
@@ -1,4 +1,6 @@
-import React, { useCallback, useEffect, useMemo, useReducer } from 'react';
+import React, {
+  useCallback, useEffect, useMemo, useReducer,
+} from 'react';
 import DataGrid, { Column, Editing } from 'devextreme-react/data-grid';
 import { LoadPanel } from 'devextreme-react/load-panel';
 import 'whatwg-fetch';

--- a/JSDemos/Demos/DataGrid/ExcelJSExportMultipleGrids/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportMultipleGrids/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import Button from 'devextreme-react/button';
 import TabPanel, { Item } from 'devextreme-react/tab-panel';
 import DataGrid, { Column } from 'devextreme-react/data-grid';
@@ -39,10 +39,10 @@ const setAlternatingRowsBackground = (gridCell, excelCell) => {
 };
 
 const App = () => {
-  const priceGridRef = React.useRef<DataGrid>(null);
-  const ratingGridRef = React.useRef<DataGrid>(null);
+  const priceGridRef = useRef<DataGrid>(null);
+  const ratingGridRef = useRef<DataGrid>(null);
 
-  const exportGrids = React.useCallback(() => {
+  const exportGrids = useCallback(() => {
     const workbook = new Workbook();
     const priceSheet = workbook.addWorksheet('Price');
     const ratingSheet = workbook.addWorksheet('Rating');

--- a/JSDemos/Demos/DataGrid/ExcelJSExportMultipleGrids/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/ExcelJSExportMultipleGrids/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import Button from 'devextreme-react/button';
 import TabPanel, { Item } from 'devextreme-react/tab-panel';
 import DataGrid, { Column } from 'devextreme-react/data-grid';
@@ -40,9 +40,9 @@ const setAlternatingRowsBackground = (gridCell, excelCell) => {
   }
 };
 const App = () => {
-  const priceGridRef = React.useRef(null);
-  const ratingGridRef = React.useRef(null);
-  const exportGrids = React.useCallback(() => {
+  const priceGridRef = useRef(null);
+  const ratingGridRef = useRef(null);
+  const exportGrids = useCallback(() => {
     const workbook = new Workbook();
     const priceSheet = workbook.addWorksheet('Price');
     const ratingSheet = workbook.addWorksheet('Rating');

--- a/JSDemos/Demos/DataGrid/Filtering/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/Filtering/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import DataGrid, {
   Column, FilterRow, HeaderFilter, Search, SearchPanel,
 } from 'devextreme-react/data-grid';
@@ -68,26 +68,26 @@ const orderHeaderFilter = (data) => {
 };
 
 const App = () => {
-  const [showFilterRow, setShowFilterRow] = React.useState(true);
-  const [showHeaderFilter, setShowHeaderFilter] = React.useState(true);
-  const [currentFilter, setCurrentFilter] = React.useState(applyFilterTypes[0].key);
-  const dataGridRef = React.useRef(null);
+  const [showFilterRow, setShowFilterRow] = useState(true);
+  const [showHeaderFilter, setShowHeaderFilter] = useState(true);
+  const [currentFilter, setCurrentFilter] = useState(applyFilterTypes[0].key);
+  const dataGridRef = useRef(null);
 
-  const clearFilter = React.useCallback(() => {
+  const clearFilter = useCallback(() => {
     dataGridRef.current.instance.clearFilter();
   }, []);
 
-  const onShowFilterRowChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onShowFilterRowChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setShowFilterRow(e.value);
     clearFilter();
   }, [clearFilter]);
 
-  const onShowHeaderFilterChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onShowHeaderFilterChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setShowHeaderFilter(e.value);
     clearFilter();
   }, [clearFilter]);
 
-  const onCurrentFilterChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const onCurrentFilterChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setCurrentFilter(e.value);
   }, []);
 

--- a/JSDemos/Demos/DataGrid/Filtering/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/Filtering/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import DataGrid, {
   Column,
   FilterRow,
@@ -71,28 +71,28 @@ const orderHeaderFilter = (data) => {
   };
 };
 const App = () => {
-  const [showFilterRow, setShowFilterRow] = React.useState(true);
-  const [showHeaderFilter, setShowHeaderFilter] = React.useState(true);
-  const [currentFilter, setCurrentFilter] = React.useState(applyFilterTypes[0].key);
-  const dataGridRef = React.useRef(null);
-  const clearFilter = React.useCallback(() => {
+  const [showFilterRow, setShowFilterRow] = useState(true);
+  const [showHeaderFilter, setShowHeaderFilter] = useState(true);
+  const [currentFilter, setCurrentFilter] = useState(applyFilterTypes[0].key);
+  const dataGridRef = useRef(null);
+  const clearFilter = useCallback(() => {
     dataGridRef.current.instance.clearFilter();
   }, []);
-  const onShowFilterRowChanged = React.useCallback(
+  const onShowFilterRowChanged = useCallback(
     (e) => {
       setShowFilterRow(e.value);
       clearFilter();
     },
     [clearFilter],
   );
-  const onShowHeaderFilterChanged = React.useCallback(
+  const onShowHeaderFilterChanged = useCallback(
     (e) => {
       setShowHeaderFilter(e.value);
       clearFilter();
     },
     [clearFilter],
   );
-  const onCurrentFilterChanged = React.useCallback((e) => {
+  const onCurrentFilterChanged = useCallback((e) => {
     setCurrentFilter(e.value);
   }, []);
   return (

--- a/JSDemos/Demos/DataGrid/FilteringAPI/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/FilteringAPI/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import DataGrid, { Column } from 'devextreme-react/data-grid';
 import SelectBox from 'devextreme-react/select-box';
 import 'devextreme/data/odata/store';
@@ -24,10 +24,10 @@ const statuses = ['All', 'Not Started', 'In Progress', 'Need Assistance', 'Defer
 const statusLabel = { 'aria-label': 'Status' };
 
 const App = () => {
-  const [filterStatus, setFilterStatus] = React.useState(statuses[0]);
-  const dataGridRef = React.useRef<DataGrid>(null);
+  const [filterStatus, setFilterStatus] = useState(statuses[0]);
+  const dataGridRef = useRef<DataGrid>(null);
 
-  const onValueChanged = React.useCallback(({ value }) => {
+  const onValueChanged = useCallback(({ value }) => {
     const dataGrid = dataGridRef.current.instance;
 
     if (value === 'All') {

--- a/JSDemos/Demos/DataGrid/FilteringAPI/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/FilteringAPI/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import DataGrid, { Column } from 'devextreme-react/data-grid';
 import SelectBox from 'devextreme-react/select-box';
 import 'devextreme/data/odata/store';
@@ -22,9 +22,9 @@ const dataSourceOptions = {
 const statuses = ['All', 'Not Started', 'In Progress', 'Need Assistance', 'Deferred', 'Completed'];
 const statusLabel = { 'aria-label': 'Status' };
 const App = () => {
-  const [filterStatus, setFilterStatus] = React.useState(statuses[0]);
-  const dataGridRef = React.useRef(null);
-  const onValueChanged = React.useCallback(({ value }) => {
+  const [filterStatus, setFilterStatus] = useState(statuses[0]);
+  const dataGridRef = useRef(null);
+  const onValueChanged = useCallback(({ value }) => {
     const dataGrid = dataGridRef.current.instance;
     if (value === 'All') {
       dataGrid.clearFilter();

--- a/JSDemos/Demos/DataGrid/FocusedRow/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/FocusedRow/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   DataGrid, Column, Paging, DataGridTypes,
 } from 'devextreme-react/data-grid';
@@ -28,21 +28,21 @@ const dataSourceOptions = {
 };
 
 const App = () => {
-  const [taskSubject, setTaskSubject] = React.useState('');
-  const [taskDetails, setTaskDetails] = React.useState('');
-  const [taskStatus, setTaskStatus] = React.useState('');
-  const [taskProgress, setTaskProgress] = React.useState('');
-  const [focusedRowKey, setFocusedRowKey] = React.useState(117);
-  const [autoNavigateToFocusedRow, setAutoNavigateToFocusedRow] = React.useState(true);
+  const [taskSubject, setTaskSubject] = useState('');
+  const [taskDetails, setTaskDetails] = useState('');
+  const [taskStatus, setTaskStatus] = useState('');
+  const [taskProgress, setTaskProgress] = useState('');
+  const [focusedRowKey, setFocusedRowKey] = useState(117);
+  const [autoNavigateToFocusedRow, setAutoNavigateToFocusedRow] = useState(true);
 
-  const onTaskIdChanged = React.useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
+  const onTaskIdChanged = useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
     if (e.event && e.value > 0) {
       setFocusedRowKey(e.value);
     }
   }, []);
 
   // eslint-disable-next-line @typescript-eslint/space-before-function-paren
-  const onFocusedRowChanging = React.useCallback(async(e: DataGridTypes.FocusedRowChangingEvent) => {
+  const onFocusedRowChanging = useCallback(async(e: DataGridTypes.FocusedRowChangingEvent) => {
     const rowsCount = e.component.getVisibleRows().length;
     const pageCount = e.component.pageCount();
     const pageIndex = e.component.pageIndex();
@@ -60,7 +60,7 @@ const App = () => {
     }
   }, []);
 
-  const onFocusedRowChanged = React.useCallback((e: DataGridTypes.FocusedRowChangedEvent) => {
+  const onFocusedRowChanged = useCallback((e: DataGridTypes.FocusedRowChangedEvent) => {
     const data = e.row.data;
     const progress = data.Task_Completion ? `${data.Task_Completion}%` : '';
 
@@ -71,7 +71,7 @@ const App = () => {
     setFocusedRowKey(e.component.option('focusedRowKey'));
   }, []);
 
-  const onAutoNavigateToFocusedRowChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onAutoNavigateToFocusedRowChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setAutoNavigateToFocusedRow(e.value);
   }, []);
 

--- a/JSDemos/Demos/DataGrid/FocusedRow/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/FocusedRow/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { DataGrid, Column, Paging } from 'devextreme-react/data-grid';
 import { NumberBox } from 'devextreme-react/number-box';
 import { CheckBox } from 'devextreme-react/check-box';
@@ -24,19 +24,19 @@ const dataSourceOptions = {
   ],
 };
 const App = () => {
-  const [taskSubject, setTaskSubject] = React.useState('');
-  const [taskDetails, setTaskDetails] = React.useState('');
-  const [taskStatus, setTaskStatus] = React.useState('');
-  const [taskProgress, setTaskProgress] = React.useState('');
-  const [focusedRowKey, setFocusedRowKey] = React.useState(117);
-  const [autoNavigateToFocusedRow, setAutoNavigateToFocusedRow] = React.useState(true);
-  const onTaskIdChanged = React.useCallback((e) => {
+  const [taskSubject, setTaskSubject] = useState('');
+  const [taskDetails, setTaskDetails] = useState('');
+  const [taskStatus, setTaskStatus] = useState('');
+  const [taskProgress, setTaskProgress] = useState('');
+  const [focusedRowKey, setFocusedRowKey] = useState(117);
+  const [autoNavigateToFocusedRow, setAutoNavigateToFocusedRow] = useState(true);
+  const onTaskIdChanged = useCallback((e) => {
     if (e.event && e.value > 0) {
       setFocusedRowKey(e.value);
     }
   }, []);
   // eslint-disable-next-line @typescript-eslint/space-before-function-paren
-  const onFocusedRowChanging = React.useCallback(async(e) => {
+  const onFocusedRowChanging = useCallback(async(e) => {
     const rowsCount = e.component.getVisibleRows().length;
     const pageCount = e.component.pageCount();
     const pageIndex = e.component.pageIndex();
@@ -52,7 +52,7 @@ const App = () => {
       }
     }
   }, []);
-  const onFocusedRowChanged = React.useCallback((e) => {
+  const onFocusedRowChanged = useCallback((e) => {
     const data = e.row.data;
     const progress = data.Task_Completion ? `${data.Task_Completion}%` : '';
     setTaskSubject(data.Task_Subject);
@@ -61,7 +61,7 @@ const App = () => {
     setTaskProgress(progress);
     setFocusedRowKey(e.component.option('focusedRowKey'));
   }, []);
-  const onAutoNavigateToFocusedRowChanged = React.useCallback((e) => {
+  const onAutoNavigateToFocusedRowChanged = useCallback((e) => {
     setAutoNavigateToFocusedRow(e.value);
   }, []);
   return (

--- a/JSDemos/Demos/DataGrid/LocalReordering/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/LocalReordering/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Column, RowDragging, Scrolling, Lookup, Sorting,
 } from 'devextreme-react/data-grid';
@@ -6,10 +6,10 @@ import { CheckBox, CheckBoxTypes } from 'devextreme-react/check-box';
 import { tasks as defaultTasks, employees } from './data.ts';
 
 const App = () => {
-  const [tasks, setTasks] = React.useState(defaultTasks);
-  const [showDragIcons, setShowDragIcons] = React.useState(true);
+  const [tasks, setTasks] = useState(defaultTasks);
+  const [showDragIcons, setShowDragIcons] = useState(true);
 
-  const onReorder = React.useCallback((e) => {
+  const onReorder = useCallback((e) => {
     const visibleRows = e.component.getVisibleRows();
     const newTasks = [...tasks];
 
@@ -22,7 +22,7 @@ const App = () => {
     setTasks(newTasks);
   }, [tasks]);
 
-  const onShowDragIconsChanged = React.useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
+  const onShowDragIconsChanged = useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
     setShowDragIcons(args.value);
   }, []);
 

--- a/JSDemos/Demos/DataGrid/LocalReordering/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/LocalReordering/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Column,
   RowDragging,
@@ -10,9 +10,9 @@ import { CheckBox } from 'devextreme-react/check-box';
 import { tasks as defaultTasks, employees } from './data.js';
 
 const App = () => {
-  const [tasks, setTasks] = React.useState(defaultTasks);
-  const [showDragIcons, setShowDragIcons] = React.useState(true);
-  const onReorder = React.useCallback(
+  const [tasks, setTasks] = useState(defaultTasks);
+  const [showDragIcons, setShowDragIcons] = useState(true);
+  const onReorder = useCallback(
     (e) => {
       const visibleRows = e.component.getVisibleRows();
       const newTasks = [...tasks];
@@ -24,7 +24,7 @@ const App = () => {
     },
     [tasks],
   );
-  const onShowDragIconsChanged = React.useCallback((args) => {
+  const onShowDragIconsChanged = useCallback((args) => {
     setShowDragIcons(args.value);
   }, []);
   return (

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import DataGrid, {
   Column,
   Selection,
@@ -14,17 +14,17 @@ const getEmployeeName = (row: Employee) => `${row.FirstName} ${row.LastName}`;
 const getEmployeeNames = (selectedRowsData: Employee[]) => (selectedRowsData.length ? selectedRowsData.map(getEmployeeName).join(', ') : 'Nobody has been selected');
 
 const App = () => {
-  const [prefix, setPrefix] = React.useState('');
-  const [selectedRowKeys, setSelectedRowKeys] = React.useState([]);
-  const [selectedEmployeeNames, setSelectedEmployeeNames] = React.useState('Nobody has been selected');
+  const [prefix, setPrefix] = useState('');
+  const [selectedRowKeys, setSelectedRowKeys] = useState([]);
+  const [selectedEmployeeNames, setSelectedEmployeeNames] = useState('Nobody has been selected');
 
-  const dataGridRef = React.useRef<DataGrid>(null);
+  const dataGridRef = useRef<DataGrid>(null);
 
-  const onClearButtonClicked = React.useCallback(() => {
+  const onClearButtonClicked = useCallback(() => {
     dataGridRef.current.instance.clearSelection();
   }, []);
 
-  const onSelectionChanged = React.useCallback(
+  const onSelectionChanged = useCallback(
     ({ selectedRowKeys: changedRowKeys, selectedRowsData }) => {
       setPrefix(null);
       setSelectedRowKeys(changedRowKeys);
@@ -32,7 +32,7 @@ const App = () => {
     }, [],
   );
 
-  const onSelectionFilterChanged = React.useCallback(({ value }) => {
+  const onSelectionFilterChanged = useCallback(({ value }) => {
     const newPrefix = value;
 
     if (newPrefix) {

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import DataGrid, {
   Column, Selection, Toolbar, Item,
 } from 'devextreme-react/data-grid';
@@ -13,16 +13,16 @@ const getEmployeeNames = (selectedRowsData) =>
     ? selectedRowsData.map(getEmployeeName).join(', ')
     : 'Nobody has been selected');
 const App = () => {
-  const [prefix, setPrefix] = React.useState('');
-  const [selectedRowKeys, setSelectedRowKeys] = React.useState([]);
-  const [selectedEmployeeNames, setSelectedEmployeeNames] = React.useState(
+  const [prefix, setPrefix] = useState('');
+  const [selectedRowKeys, setSelectedRowKeys] = useState([]);
+  const [selectedEmployeeNames, setSelectedEmployeeNames] = useState(
     'Nobody has been selected',
   );
-  const dataGridRef = React.useRef(null);
-  const onClearButtonClicked = React.useCallback(() => {
+  const dataGridRef = useRef(null);
+  const onClearButtonClicked = useCallback(() => {
     dataGridRef.current.instance.clearSelection();
   }, []);
-  const onSelectionChanged = React.useCallback(
+  const onSelectionChanged = useCallback(
     ({ selectedRowKeys: changedRowKeys, selectedRowsData }) => {
       setPrefix(null);
       setSelectedRowKeys(changedRowKeys);
@@ -30,7 +30,7 @@ const App = () => {
     },
     [],
   );
-  const onSelectionFilterChanged = React.useCallback(({ value }) => {
+  const onSelectionFilterChanged = useCallback(({ value }) => {
     const newPrefix = value;
     if (newPrefix) {
       const filteredEmployees = newPrefix === 'All'

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionAPI/ReactJs/App.js
@@ -15,9 +15,7 @@ const getEmployeeNames = (selectedRowsData) =>
 const App = () => {
   const [prefix, setPrefix] = useState('');
   const [selectedRowKeys, setSelectedRowKeys] = useState([]);
-  const [selectedEmployeeNames, setSelectedEmployeeNames] = useState(
-    'Nobody has been selected',
-  );
+  const [selectedEmployeeNames, setSelectedEmployeeNames] = useState('Nobody has been selected');
   const dataGridRef = useRef(null);
   const onClearButtonClicked = useCallback(() => {
     dataGridRef.current.instance.clearSelection();

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionModes/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionModes/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Column,
   Selection,
@@ -17,16 +17,16 @@ const showCheckBoxesModes = ['none', 'onClick', 'onLongTap', 'always'];
 const selectAllModes = ['allPages', 'page'];
 
 const App = () => {
-  const [allMode, setAllMode] = React.useState<DataGridTypes.SelectAllMode>('allPages');
-  const [checkBoxesMode, setCheckBoxesMode] = React.useState<DataGridTypes.SelectionColumnDisplayMode>(
+  const [allMode, setAllMode] = useState<DataGridTypes.SelectAllMode>('allPages');
+  const [checkBoxesMode, setCheckBoxesMode] = useState<DataGridTypes.SelectionColumnDisplayMode>(
     themes.current().startsWith('material') ? 'always' : 'onClick',
   );
 
-  const onCheckBoxesModeChanged = React.useCallback(({ value }) => {
+  const onCheckBoxesModeChanged = useCallback(({ value }) => {
     setCheckBoxesMode(value);
   }, []);
 
-  const onAllModeChanged = React.useCallback(({ value }) => {
+  const onAllModeChanged = useCallback(({ value }) => {
     setAllMode(value);
   }, []);
 

--- a/JSDemos/Demos/DataGrid/MultipleRecordSelectionModes/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/MultipleRecordSelectionModes/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Column, Selection, FilterRow, Paging,
 } from 'devextreme-react/data-grid';
@@ -11,14 +11,14 @@ const showCheckboxesFieldLabel = { 'aria-label': 'Show Checkboxes Mode' };
 const showCheckBoxesModes = ['none', 'onClick', 'onLongTap', 'always'];
 const selectAllModes = ['allPages', 'page'];
 const App = () => {
-  const [allMode, setAllMode] = React.useState('allPages');
-  const [checkBoxesMode, setCheckBoxesMode] = React.useState(
+  const [allMode, setAllMode] = useState('allPages');
+  const [checkBoxesMode, setCheckBoxesMode] = useState(
     themes.current().startsWith('material') ? 'always' : 'onClick',
   );
-  const onCheckBoxesModeChanged = React.useCallback(({ value }) => {
+  const onCheckBoxesModeChanged = useCallback(({ value }) => {
     setCheckBoxesMode(value);
   }, []);
-  const onAllModeChanged = React.useCallback(({ value }) => {
+  const onAllModeChanged = useCallback(({ value }) => {
     setAllMode(value);
   }, []);
   return (

--- a/JSDemos/Demos/DataGrid/MultipleSorting/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/MultipleSorting/React/App.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import DataGrid, { Column, Sorting } from 'devextreme-react/data-grid';
 import CheckBox from 'devextreme-react/check-box';
 import { employees } from './data.ts';
 
 const App = () => {
-  const [positionDisableSorting, setPositionDisableSorting] = React.useState(false);
-  const dataGridRef = React.useRef(null);
+  const [positionDisableSorting, setPositionDisableSorting] = useState(false);
+  const dataGridRef = useRef(null);
 
-  const onPositionSortingChanged = React.useCallback(() => {
+  const onPositionSortingChanged = useCallback(() => {
     setPositionDisableSorting((previousPositionDisableSorting) => !previousPositionDisableSorting);
     dataGridRef.current.instance.columnOption(5, 'sortOrder', undefined);
   }, []);

--- a/JSDemos/Demos/DataGrid/MultipleSorting/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/MultipleSorting/ReactJs/App.js
@@ -1,12 +1,12 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import DataGrid, { Column, Sorting } from 'devextreme-react/data-grid';
 import CheckBox from 'devextreme-react/check-box';
 import { employees } from './data.js';
 
 const App = () => {
-  const [positionDisableSorting, setPositionDisableSorting] = React.useState(false);
-  const dataGridRef = React.useRef(null);
-  const onPositionSortingChanged = React.useCallback(() => {
+  const [positionDisableSorting, setPositionDisableSorting] = useState(false);
+  const dataGridRef = useRef(null);
+  const onPositionSortingChanged = useCallback(() => {
     setPositionDisableSorting((previousPositionDisableSorting) => !previousPositionDisableSorting);
     dataGridRef.current.instance.columnOption(5, 'sortOrder', undefined);
   }, []);

--- a/JSDemos/Demos/DataGrid/Overview/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import ODataStore from 'devextreme/data/odata/store';
 import DataGrid, {
   Column,
@@ -27,9 +27,9 @@ const dataSourceOptions = {
 };
 
 const App = () => {
-  const [collapsed, setCollapsed] = React.useState(true);
+  const [collapsed, setCollapsed] = useState(true);
 
-  const onContentReady = React.useCallback((e: DataGridTypes.ContentReadyEvent) => {
+  const onContentReady = useCallback((e: DataGridTypes.ContentReadyEvent) => {
     if (collapsed) {
       e.component.expandRow(['EnviroCare']);
       setCollapsed(false);

--- a/JSDemos/Demos/DataGrid/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import ODataStore from 'devextreme/data/odata/store';
 import DataGrid, {
   Column,
@@ -24,8 +24,8 @@ const dataSourceOptions = {
   }),
 };
 const App = () => {
-  const [collapsed, setCollapsed] = React.useState(true);
-  const onContentReady = React.useCallback(
+  const [collapsed, setCollapsed] = useState(true);
+  const onContentReady = useCallback(
     (e) => {
       if (collapsed) {
         e.component.expandRow(['EnviroCare']);

--- a/JSDemos/Demos/DataGrid/PDFExportMultipleGrids/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/PDFExportMultipleGrids/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import Button from 'devextreme-react/button';
 import TabPanel, { Item } from 'devextreme-react/tab-panel';
 import DataGrid, { Column } from 'devextreme-react/data-grid';
@@ -38,10 +38,10 @@ const setAlternatingRowsBackground = (dataGrid: DataGrid['instance'], gridCell, 
 };
 
 const App = () => {
-  const priceGridRef = React.useRef(null);
-  const ratingGridRef = React.useRef(null);
+  const priceGridRef = useRef(null);
+  const ratingGridRef = useRef(null);
 
-  const exportGrids = React.useCallback(() => {
+  const exportGrids = useCallback(() => {
     // eslint-disable-next-line new-cap
     const doc = new jsPDF();
 

--- a/JSDemos/Demos/DataGrid/PDFExportMultipleGrids/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/PDFExportMultipleGrids/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import Button from 'devextreme-react/button';
 import TabPanel, { Item } from 'devextreme-react/tab-panel';
 import DataGrid, { Column } from 'devextreme-react/data-grid';
@@ -35,9 +35,9 @@ const setAlternatingRowsBackground = (dataGrid, gridCell, pdfCell) => {
   }
 };
 const App = () => {
-  const priceGridRef = React.useRef(null);
-  const ratingGridRef = React.useRef(null);
-  const exportGrids = React.useCallback(() => {
+  const priceGridRef = useRef(null);
+  const ratingGridRef = useRef(null);
+  const exportGrids = useCallback(() => {
     // eslint-disable-next-line new-cap
     const doc = new jsPDF();
     exportDataGrid({

--- a/JSDemos/Demos/DataGrid/RealTimeUpdates/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/RealTimeUpdates/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import DataGrid, {
   Column, Summary, TotalItem, MasterDetail, Paging, DataGridTypes,
 } from 'devextreme-react/data-grid';
@@ -60,9 +60,9 @@ const detailRender = (detail: DataGridTypes.MasterDetailTemplateData) => (
 );
 
 const App = () => {
-  const [updateFrequency, setUpdateFrequency] = React.useState(100);
+  const [updateFrequency, setUpdateFrequency] = useState(100);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const interval = setInterval(() => {
       if (getOrderCount() > 500000) {
         return;

--- a/JSDemos/Demos/DataGrid/RealTimeUpdates/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/RealTimeUpdates/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import DataGrid, {
   Column,
   Summary,
@@ -79,8 +79,8 @@ const detailRender = (detail) => (
   </DataGrid>
 );
 const App = () => {
-  const [updateFrequency, setUpdateFrequency] = React.useState(100);
-  React.useEffect(() => {
+  const [updateFrequency, setUpdateFrequency] = useState(100);
+  useEffect(() => {
     const interval = setInterval(() => {
       if (getOrderCount() > 500000) {
         return;

--- a/JSDemos/Demos/DataGrid/RecordGrouping/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/RecordGrouping/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Column,
   Grouping,
@@ -10,9 +10,9 @@ import CheckBox from 'devextreme-react/check-box';
 import { customers } from './data.ts';
 
 const App = () => {
-  const [autoExpandAll, setAutoExpandAll] = React.useState(true);
+  const [autoExpandAll, setAutoExpandAll] = useState(true);
 
-  const onAutoExpandAllChanged = React.useCallback(() => {
+  const onAutoExpandAllChanged = useCallback(() => {
     setAutoExpandAll((previousAutoExpandAll) => !previousAutoExpandAll);
   }, []);
 

--- a/JSDemos/Demos/DataGrid/RecordGrouping/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/RecordGrouping/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Column,
   Grouping,
@@ -10,8 +10,8 @@ import CheckBox from 'devextreme-react/check-box';
 import { customers } from './data.js';
 
 const App = () => {
-  const [autoExpandAll, setAutoExpandAll] = React.useState(true);
-  const onAutoExpandAllChanged = React.useCallback(() => {
+  const [autoExpandAll, setAutoExpandAll] = useState(true);
+  const onAutoExpandAllChanged = useCallback(() => {
     setAutoExpandAll((previousAutoExpandAll) => !previousAutoExpandAll);
   }, []);
   return (

--- a/JSDemos/Demos/DataGrid/RecordPaging/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/RecordPaging/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Scrolling, Pager, Paging, DataGridTypes,
 } from 'devextreme-react/data-grid';
@@ -13,28 +13,28 @@ const data = generateData(100000);
 const customizeColumns = (columns: DataGridTypes.Column[]) => { columns[0].width = 70; };
 
 const App = () => {
-  const [displayMode, setDisplayMode] = React.useState<DataGridTypes.PagerDisplayMode>('full');
-  const [showPageSizeSelector, setShowPageSizeSelector] = React.useState(true);
-  const [showInfo, setShowInfo] = React.useState(true);
-  const [showNavButtons, setShowNavButtons] = React.useState(true);
+  const [displayMode, setDisplayMode] = useState<DataGridTypes.PagerDisplayMode>('full');
+  const [showPageSizeSelector, setShowPageSizeSelector] = useState(true);
+  const [showInfo, setShowInfo] = useState(true);
+  const [showNavButtons, setShowNavButtons] = useState(true);
 
-  const displayModeChange = React.useCallback((value) => {
+  const displayModeChange = useCallback((value) => {
     setDisplayMode(value);
   }, []);
 
-  const showPageSizeSelectorChange = React.useCallback((value) => {
+  const showPageSizeSelectorChange = useCallback((value) => {
     setShowPageSizeSelector(value);
   }, []);
 
-  const showInfoChange = React.useCallback((value) => {
+  const showInfoChange = useCallback((value) => {
     setShowInfo(value);
   }, []);
 
-  const showNavButtonsChange = React.useCallback((value) => {
+  const showNavButtonsChange = useCallback((value) => {
     setShowNavButtons(value);
   }, []);
 
-  const isCompactMode = React.useCallback(() => displayMode === 'compact', [displayMode]);
+  const isCompactMode = useCallback(() => displayMode === 'compact', [displayMode]);
 
   return (
     <div>

--- a/JSDemos/Demos/DataGrid/RecordPaging/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/RecordPaging/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, { Scrolling, Pager, Paging } from 'devextreme-react/data-grid';
 import SelectBox from 'devextreme-react/select-box';
 import CheckBox from 'devextreme-react/check-box';
@@ -14,23 +14,23 @@ const customizeColumns = (columns) => {
   columns[0].width = 70;
 };
 const App = () => {
-  const [displayMode, setDisplayMode] = React.useState('full');
-  const [showPageSizeSelector, setShowPageSizeSelector] = React.useState(true);
-  const [showInfo, setShowInfo] = React.useState(true);
-  const [showNavButtons, setShowNavButtons] = React.useState(true);
-  const displayModeChange = React.useCallback((value) => {
+  const [displayMode, setDisplayMode] = useState('full');
+  const [showPageSizeSelector, setShowPageSizeSelector] = useState(true);
+  const [showInfo, setShowInfo] = useState(true);
+  const [showNavButtons, setShowNavButtons] = useState(true);
+  const displayModeChange = useCallback((value) => {
     setDisplayMode(value);
   }, []);
-  const showPageSizeSelectorChange = React.useCallback((value) => {
+  const showPageSizeSelectorChange = useCallback((value) => {
     setShowPageSizeSelector(value);
   }, []);
-  const showInfoChange = React.useCallback((value) => {
+  const showInfoChange = useCallback((value) => {
     setShowInfo(value);
   }, []);
-  const showNavButtonsChange = React.useCallback((value) => {
+  const showNavButtonsChange = useCallback((value) => {
     setShowNavButtons(value);
   }, []);
-  const isCompactMode = React.useCallback(() => displayMode === 'compact', [displayMode]);
+  const isCompactMode = useCallback(() => displayMode === 'compact', [displayMode]);
   return (
     <div>
       <DataGrid

--- a/JSDemos/Demos/DataGrid/RightToLeftSupport/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/RightToLeftSupport/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, { Column, Paging, SearchPanel } from 'devextreme-react/data-grid';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 
@@ -10,11 +10,11 @@ const languageLabel = { 'aria-label': 'Language' };
 const languages = ['Arabic (Right-to-Left direction)', 'English (Left-to-Right direction)'];
 
 const App = () => {
-  const [placeholder, setPlaceholder] = React.useState('Search...');
-  const [rtlEnabled, setRtlEnabled] = React.useState(false);
-  const [selectedValue, setSelectedValue] = React.useState(languages[1]);
+  const [placeholder, setPlaceholder] = useState('Search...');
+  const [rtlEnabled, setRtlEnabled] = useState(false);
+  const [selectedValue, setSelectedValue] = useState(languages[1]);
 
-  const onSelectLanguage = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const onSelectLanguage = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     const newRtlEnabled = e.value === languages[0];
 
     setRtlEnabled(newRtlEnabled);
@@ -22,7 +22,7 @@ const App = () => {
     setSelectedValue(e.value);
   }, []);
 
-  const headerCellRender = React.useCallback(() => (
+  const headerCellRender = useCallback(() => (
     <div>
       {rtlEnabled ? (
         <div>المساحة (كم<sup>2</sup>)</div>

--- a/JSDemos/Demos/DataGrid/RightToLeftSupport/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/RightToLeftSupport/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, { Column, Paging, SearchPanel } from 'devextreme-react/data-grid';
 import SelectBox from 'devextreme-react/select-box';
 import { europeanUnion } from './data.js';
@@ -8,16 +8,16 @@ const areaFormat = { type: 'fixedPoint', precision: 0 };
 const languageLabel = { 'aria-label': 'Language' };
 const languages = ['Arabic (Right-to-Left direction)', 'English (Left-to-Right direction)'];
 const App = () => {
-  const [placeholder, setPlaceholder] = React.useState('Search...');
-  const [rtlEnabled, setRtlEnabled] = React.useState(false);
-  const [selectedValue, setSelectedValue] = React.useState(languages[1]);
-  const onSelectLanguage = React.useCallback((e) => {
+  const [placeholder, setPlaceholder] = useState('Search...');
+  const [rtlEnabled, setRtlEnabled] = useState(false);
+  const [selectedValue, setSelectedValue] = useState(languages[1]);
+  const onSelectLanguage = useCallback((e) => {
     const newRtlEnabled = e.value === languages[0];
     setRtlEnabled(newRtlEnabled);
     setPlaceholder(newRtlEnabled ? 'بحث' : 'Search...');
     setSelectedValue(e.value);
   }, []);
-  const headerCellRender = React.useCallback(
+  const headerCellRender = useCallback(
     () => (
       <div>
         {rtlEnabled ? (

--- a/JSDemos/Demos/DataGrid/RowEditingAndEditingEvents/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/RowEditingAndEditingEvents/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Button from 'devextreme-react/button';
 import DataGrid, {
   Column, Editing, Paging, Lookup,
@@ -7,13 +7,13 @@ import DataGrid, {
 import { employees, states } from './data.ts';
 
 const App = () => {
-  const [events, setEvents] = React.useState([]);
+  const [events, setEvents] = useState([]);
 
-  const logEvent = React.useCallback((eventName: string) => {
+  const logEvent = useCallback((eventName: string) => {
     setEvents((previousEvents) => [eventName, ...previousEvents]);
   }, []);
 
-  const clearEvents = React.useCallback(() => {
+  const clearEvents = useCallback(() => {
     setEvents([]);
   }, []);
 

--- a/JSDemos/Demos/DataGrid/RowEditingAndEditingEvents/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/RowEditingAndEditingEvents/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Button from 'devextreme-react/button';
 import DataGrid, {
   Column, Editing, Paging, Lookup,
@@ -6,11 +6,11 @@ import DataGrid, {
 import { employees, states } from './data.js';
 
 const App = () => {
-  const [events, setEvents] = React.useState([]);
-  const logEvent = React.useCallback((eventName) => {
+  const [events, setEvents] = useState([]);
+  const logEvent = useCallback((eventName) => {
     setEvents((previousEvents) => [eventName, ...previousEvents]);
   }, []);
-  const clearEvents = React.useCallback(() => {
+  const clearEvents = useCallback(() => {
     setEvents([]);
   }, []);
   return (

--- a/JSDemos/Demos/DataGrid/RowSelection/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/RowSelection/React/App.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, { Column, DataGridTypes, Selection } from 'devextreme-react/data-grid';
 import { employees } from './data.ts';
 
 const App = () => {
-  const [showEmployeeInfo, setShowEmployeeInfo] = React.useState(false);
-  const [selectedRowPicture, setSelectedRowPicture] = React.useState('');
-  const [selectedRowNotes, setSelectedRowNotes] = React.useState('');
+  const [showEmployeeInfo, setShowEmployeeInfo] = useState(false);
+  const [selectedRowPicture, setSelectedRowPicture] = useState('');
+  const [selectedRowNotes, setSelectedRowNotes] = useState('');
 
-  const onSelectionChanged = React.useCallback(({ selectedRowsData }: DataGridTypes.SelectionChangedEvent) => {
+  const onSelectionChanged = useCallback(({ selectedRowsData }: DataGridTypes.SelectionChangedEvent) => {
     const data = selectedRowsData[0];
 
     setShowEmployeeInfo(!!data);

--- a/JSDemos/Demos/DataGrid/RowSelection/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/RowSelection/ReactJs/App.js
@@ -1,12 +1,12 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, { Column, Selection } from 'devextreme-react/data-grid';
 import { employees } from './data.js';
 
 const App = () => {
-  const [showEmployeeInfo, setShowEmployeeInfo] = React.useState(false);
-  const [selectedRowPicture, setSelectedRowPicture] = React.useState('');
-  const [selectedRowNotes, setSelectedRowNotes] = React.useState('');
-  const onSelectionChanged = React.useCallback(({ selectedRowsData }) => {
+  const [showEmployeeInfo, setShowEmployeeInfo] = useState(false);
+  const [selectedRowPicture, setSelectedRowPicture] = useState('');
+  const [selectedRowNotes, setSelectedRowNotes] = useState('');
+  const onSelectionChanged = useCallback(({ selectedRowsData }) => {
     const data = selectedRowsData[0];
     setShowEmployeeInfo(!!data);
     setSelectedRowNotes(data && data.Notes);

--- a/JSDemos/Demos/DataGrid/SignalRService/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/SignalRService/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import DataGrid, {
   Column,
 } from 'devextreme-react/data-grid';
@@ -9,10 +9,10 @@ import PriceCell from './PriceCell.tsx';
 import ChangeCell from './ChangeCell.tsx';
 
 const App = () => {
-  const [connectionStarted, setConnectionStarted] = React.useState(false);
-  const [dataSource, setDataSource] = React.useState(null);
+  const [connectionStarted, setConnectionStarted] = useState(false);
+  const [dataSource, setDataSource] = useState(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const hubConnection = new HubConnectionBuilder()
       .withUrl('https://js.devexpress.com/Demos/NetCore/liveUpdateSignalRHub', {
         skipNegotiation: true,

--- a/JSDemos/Demos/DataGrid/SignalRService/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/SignalRService/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import DataGrid, { Column } from 'devextreme-react/data-grid';
 import CustomStore from 'devextreme/data/custom_store';
 import { HubConnectionBuilder, HttpTransportType } from '@aspnet/signalr';
@@ -6,9 +6,9 @@ import PriceCell from './PriceCell.js';
 import ChangeCell from './ChangeCell.js';
 
 const App = () => {
-  const [connectionStarted, setConnectionStarted] = React.useState(false);
-  const [dataSource, setDataSource] = React.useState(null);
-  React.useEffect(() => {
+  const [connectionStarted, setConnectionStarted] = useState(false);
+  const [dataSource, setDataSource] = useState(null);
+  useEffect(() => {
     const hubConnection = new HubConnectionBuilder()
       .withUrl('https://js.devexpress.com/Demos/NetCore/liveUpdateSignalRHub', {
         skipNegotiation: true,

--- a/JSDemos/Demos/DataGrid/StatePersistence/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/StatePersistence/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import DataGrid, {
   Selection, FilterRow, GroupPanel, StateStoring, Pager, Column,
 } from 'devextreme-react/data-grid';
@@ -11,9 +11,9 @@ const onRefreshClick = () => {
 };
 
 const App = () => {
-  const dataGridRef = React.useRef<DataGrid>(null);
+  const dataGridRef = useRef<DataGrid>(null);
 
-  const onStateResetClick = React.useCallback(() => {
+  const onStateResetClick = useCallback(() => {
     dataGridRef.current.instance.state(null);
   }, []);
 

--- a/JSDemos/Demos/DataGrid/StatePersistence/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/StatePersistence/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import DataGrid, {
   Selection,
   FilterRow,
@@ -14,8 +14,8 @@ const onRefreshClick = () => {
   window.location.reload();
 };
 const App = () => {
-  const dataGridRef = React.useRef(null);
-  const onStateResetClick = React.useCallback(() => {
+  const dataGridRef = useRef(null);
+  const onStateResetClick = useCallback(() => {
     dataGridRef.current.instance.state(null);
   }, []);
   return (

--- a/JSDemos/Demos/DataGrid/ToolbarCustomization/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/ToolbarCustomization/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import Button from 'devextreme-react/button';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 import DataGrid, {
@@ -20,12 +20,12 @@ const groupingValues = [{
 const getGroupCount = (groupField: string) => query(orders).groupBy(groupField).toArray().length;
 
 const App = () => {
-  const [expandAll, setExpandAll] = React.useState(true);
-  const [totalCount, setTotalCount] = React.useState(getGroupCount('CustomerStoreState'));
-  const [groupColumn, setGroupColumn] = React.useState('CustomerStoreState');
-  const dataGridRef = React.useRef<DataGrid>(null);
+  const [expandAll, setExpandAll] = useState(true);
+  const [totalCount, setTotalCount] = useState(getGroupCount('CustomerStoreState'));
+  const [groupColumn, setGroupColumn] = useState('CustomerStoreState');
+  const dataGridRef = useRef<DataGrid>(null);
 
-  const toggleGroupColumn = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const toggleGroupColumn = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     const newGrouping = e.value;
 
     dataGridRef.current.instance.clearGrouping();
@@ -35,11 +35,11 @@ const App = () => {
     setGroupColumn(newGrouping);
   }, []);
 
-  const toggleExpandAll = React.useCallback(() => {
+  const toggleExpandAll = useCallback(() => {
     setExpandAll(!expandAll);
   }, [expandAll]);
 
-  const refreshDataGrid = React.useCallback(() => {
+  const refreshDataGrid = useCallback(() => {
     dataGridRef.current.instance.refresh();
   }, []);
 

--- a/JSDemos/Demos/DataGrid/ToolbarCustomization/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/ToolbarCustomization/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import Button from 'devextreme-react/button';
 import SelectBox from 'devextreme-react/select-box';
 import DataGrid, {
@@ -25,21 +25,21 @@ const groupingValues = [
 ];
 const getGroupCount = (groupField) => query(orders).groupBy(groupField).toArray().length;
 const App = () => {
-  const [expandAll, setExpandAll] = React.useState(true);
-  const [totalCount, setTotalCount] = React.useState(getGroupCount('CustomerStoreState'));
-  const [groupColumn, setGroupColumn] = React.useState('CustomerStoreState');
-  const dataGridRef = React.useRef(null);
-  const toggleGroupColumn = React.useCallback((e) => {
+  const [expandAll, setExpandAll] = useState(true);
+  const [totalCount, setTotalCount] = useState(getGroupCount('CustomerStoreState'));
+  const [groupColumn, setGroupColumn] = useState('CustomerStoreState');
+  const dataGridRef = useRef(null);
+  const toggleGroupColumn = useCallback((e) => {
     const newGrouping = e.value;
     dataGridRef.current.instance.clearGrouping();
     dataGridRef.current.instance.columnOption(newGrouping, 'groupIndex', 0);
     setTotalCount(getGroupCount(newGrouping));
     setGroupColumn(newGrouping);
   }, []);
-  const toggleExpandAll = React.useCallback(() => {
+  const toggleExpandAll = useCallback(() => {
     setExpandAll(!expandAll);
   }, [expandAll]);
-  const refreshDataGrid = React.useCallback(() => {
+  const refreshDataGrid = useCallback(() => {
     dataGridRef.current.instance.refresh();
   }, []);
   return (

--- a/JSDemos/Demos/DataGrid/VirtualScrolling/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/VirtualScrolling/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, {
   Scrolling, Sorting, LoadPanel, DataGridTypes,
 } from 'devextreme-react/data-grid';
@@ -10,9 +10,9 @@ const customizeColumns = (columns: DataGridTypes.Column[]) => {
   columns[0].width = 70;
 };
 const App = () => {
-  const [loadPanelEnabled, setLoadPanelEnabled] = React.useState(true);
+  const [loadPanelEnabled, setLoadPanelEnabled] = useState(true);
 
-  const onContentReady = React.useCallback(() => {
+  const onContentReady = useCallback(() => {
     setLoadPanelEnabled(false);
   }, []);
 

--- a/JSDemos/Demos/DataGrid/VirtualScrolling/ReactJs/App.js
+++ b/JSDemos/Demos/DataGrid/VirtualScrolling/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, { Scrolling, Sorting, LoadPanel } from 'devextreme-react/data-grid';
 import { generateData } from './data.js';
 
@@ -7,8 +7,8 @@ const customizeColumns = (columns) => {
   columns[0].width = 70;
 };
 const App = () => {
-  const [loadPanelEnabled, setLoadPanelEnabled] = React.useState(true);
-  const onContentReady = React.useCallback(() => {
+  const [loadPanelEnabled, setLoadPanelEnabled] = useState(true);
+  const onContentReady = useCallback(() => {
     setLoadPanelEnabled(false);
   }, []);
   return (

--- a/JSDemos/Demos/DataGrid/WebAPIService/React/MasterDetailGrid.tsx
+++ b/JSDemos/Demos/DataGrid/WebAPIService/React/MasterDetailGrid.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import DataGrid, { DataGridTypes } from 'devextreme-react/data-grid';
 
 import { createStore } from 'devextreme-aspnet-data-nojquery';
@@ -16,9 +16,9 @@ const getMasterDetailGridDataSource = (id) => ({
 });
 
 const MasterDetailGrid = (props: DataGridTypes.MasterDetailTemplateData) => {
-  const [dataSource, setDataSource] = React.useState(null);
+  const [dataSource, setDataSource] = useState(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const masterDetailDataSource = getMasterDetailGridDataSource(props.data.key);
     setDataSource(masterDetailDataSource);
   }, [props.data.key]);

--- a/JSDemos/Demos/DataGrid/WebAPIService/ReactJs/MasterDetailGrid.js
+++ b/JSDemos/Demos/DataGrid/WebAPIService/ReactJs/MasterDetailGrid.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import DataGrid from 'devextreme-react/data-grid';
 import { createStore } from 'devextreme-aspnet-data-nojquery';
 
@@ -13,8 +13,8 @@ const getMasterDetailGridDataSource = (id) => ({
   }),
 });
 const MasterDetailGrid = (props) => {
-  const [dataSource, setDataSource] = React.useState(null);
-  React.useEffect(() => {
+  const [dataSource, setDataSource] = useState(null);
+  useEffect(() => {
     const masterDetailDataSource = getMasterDetailGridDataSource(props.data.key);
     setDataSource(masterDetailDataSource);
   }, [props.data.key]);

--- a/JSDemos/Demos/DateBox/Overview/React/App.tsx
+++ b/JSDemos/Demos/DateBox/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import DateBox, { DateBoxTypes } from 'devextreme-react/date-box';
 
 import service from './data.ts';
@@ -13,14 +13,14 @@ const customFormatLabel = { 'aria-label': 'Custom Format' };
 const birthDateLabel = { 'aria-label': 'Birth Date' };
 
 function App() {
-  const [value, setValue] = React.useState(new Date(1981, 3, 27));
+  const [value, setValue] = useState(new Date(1981, 3, 27));
   const now = new Date();
   const firstWorkDay2017 = new Date(2017, 0, 3);
   const min = new Date(1900, 0, 1);
   const dateClear = new Date(2015, 11, 1, 6);
   const disabledDates = service.getFederalHolidays();
 
-  const diffInDay = React.useMemo(
+  const diffInDay = useMemo(
     () =>
       `${Math.floor(
         Math.abs((new Date().getTime() - value.getTime()) / (24 * 60 * 60 * 1000)),
@@ -28,7 +28,7 @@ function App() {
     [value],
   );
 
-  const onValueChanged = React.useCallback((e: DateBoxTypes.ValueChangedEvent) => {
+  const onValueChanged = useCallback((e: DateBoxTypes.ValueChangedEvent) => {
     setValue(e.value);
   }, []);
 

--- a/JSDemos/Demos/DateBox/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/DateBox/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import DateBox from 'devextreme-react/date-box';
 import service from './data.js';
 
@@ -11,20 +11,20 @@ const clearLabel = { 'aria-label': 'Clear' };
 const customFormatLabel = { 'aria-label': 'Custom Format' };
 const birthDateLabel = { 'aria-label': 'Birth Date' };
 function App() {
-  const [value, setValue] = React.useState(new Date(1981, 3, 27));
+  const [value, setValue] = useState(new Date(1981, 3, 27));
   const now = new Date();
   const firstWorkDay2017 = new Date(2017, 0, 3);
   const min = new Date(1900, 0, 1);
   const dateClear = new Date(2015, 11, 1, 6);
   const disabledDates = service.getFederalHolidays();
-  const diffInDay = React.useMemo(
+  const diffInDay = useMemo(
     () =>
       `${Math.floor(
         Math.abs((new Date().getTime() - value.getTime()) / (24 * 60 * 60 * 1000)),
       )} days`,
     [value],
   );
-  const onValueChanged = React.useCallback((e) => {
+  const onValueChanged = useCallback((e) => {
     setValue(e.value);
   }, []);
   return (

--- a/JSDemos/Demos/DateRangeBox/Overview/React/App.tsx
+++ b/JSDemos/Demos/DateRangeBox/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DateRangeBox from 'devextreme-react/date-range-box';
 
 const msInDay = 1000 * 60 * 60 * 24;
@@ -18,9 +18,9 @@ function convertRangeToDays([startDate, endDate]: [Date, Date]) {
 }
 
 export default function App() {
-  const [selectedDays, setSelectedDays] = React.useState(convertRangeToDays(initialValue));
+  const [selectedDays, setSelectedDays] = useState(convertRangeToDays(initialValue));
 
-  const onCurrentValueChange = React.useCallback(
+  const onCurrentValueChange = useCallback(
     ({ value: [startDate, endDate] }) => {
       let daysCount = 0;
 

--- a/JSDemos/Demos/DateRangeBox/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/DateRangeBox/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DateRangeBox from 'devextreme-react/date-range-box';
 
 const msInDay = 1000 * 60 * 60 * 24;
@@ -12,8 +12,8 @@ function convertRangeToDays([startDate, endDate]) {
   return diffInDay + 1;
 }
 export default function App() {
-  const [selectedDays, setSelectedDays] = React.useState(convertRangeToDays(initialValue));
-  const onCurrentValueChange = React.useCallback(
+  const [selectedDays, setSelectedDays] = useState(convertRangeToDays(initialValue));
+  const onCurrentValueChange = useCallback(
     ({ value: [startDate, endDate] }) => {
       let daysCount = 0;
       if (startDate && endDate) {

--- a/JSDemos/Demos/Diagram/Adaptability/React/App.tsx
+++ b/JSDemos/Demos/Diagram/Adaptability/React/App.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Diagram from 'devextreme-react/diagram';
 import 'whatwg-fetch';
 
 export default function App() {
-  const diagramRef = React.useRef<Diagram>();
+  const diagramRef = useRef<Diagram>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     const diagram = diagramRef.current.instance;
     fetch('../../../../data/diagram-flow.json')
       .then((response) => response.json())

--- a/JSDemos/Demos/Diagram/Adaptability/ReactJs/App.js
+++ b/JSDemos/Demos/Diagram/Adaptability/ReactJs/App.js
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Diagram from 'devextreme-react/diagram';
 import 'whatwg-fetch';
 
 export default function App() {
-  const diagramRef = React.useRef();
-  React.useEffect(() => {
+  const diagramRef = useRef();
+  useEffect(() => {
     const diagram = diagramRef.current.instance;
     fetch('../../../../data/diagram-flow.json')
       .then((response) => response.json())

--- a/JSDemos/Demos/Diagram/Containers/React/App.tsx
+++ b/JSDemos/Demos/Diagram/Containers/React/App.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Diagram, { Group, Toolbox } from 'devextreme-react/diagram';
 import 'whatwg-fetch';
 
 export default function App() {
-  const diagramRef = React.useRef<Diagram>();
+  const diagramRef = useRef<Diagram>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     const diagram = diagramRef.current.instance;
     fetch('../../../../data/diagram-structure.json')
       .then((response) => response.json())

--- a/JSDemos/Demos/Diagram/Containers/ReactJs/App.js
+++ b/JSDemos/Demos/Diagram/Containers/ReactJs/App.js
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Diagram, { Group, Toolbox } from 'devextreme-react/diagram';
 import 'whatwg-fetch';
 
 export default function App() {
-  const diagramRef = React.useRef();
-  React.useEffect(() => {
+  const diagramRef = useRef();
+  useEffect(() => {
     const diagram = diagramRef.current.instance;
     fetch('../../../../data/diagram-structure.json')
       .then((response) => response.json())

--- a/JSDemos/Demos/Diagram/CustomShapesWithIcons/React/App.tsx
+++ b/JSDemos/Demos/Diagram/CustomShapesWithIcons/React/App.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Diagram, {
   CustomShape, ConnectionPoint, Group, Toolbox,
 } from 'devextreme-react/diagram';
 import 'whatwg-fetch';
 
 export default function App() {
-  const diagramRef = React.useRef<Diagram>(null);
+  const diagramRef = useRef<Diagram>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const diagram = diagramRef.current?.instance;
     fetch('../../../../data/diagram-hardware.json')
       .then((response) => response.json())

--- a/JSDemos/Demos/Diagram/CustomShapesWithIcons/ReactJs/App.js
+++ b/JSDemos/Demos/Diagram/CustomShapesWithIcons/ReactJs/App.js
@@ -1,12 +1,12 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Diagram, {
   CustomShape, ConnectionPoint, Group, Toolbox,
 } from 'devextreme-react/diagram';
 import 'whatwg-fetch';
 
 export default function App() {
-  const diagramRef = React.useRef(null);
-  React.useEffect(() => {
+  const diagramRef = useRef(null);
+  useEffect(() => {
     const diagram = diagramRef.current?.instance;
     fetch('../../../../data/diagram-hardware.json')
       .then((response) => response.json())

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplates/React/App.tsx
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplates/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Diagram, { CustomShape, Nodes, AutoLayout } from 'devextreme-react/diagram';
 import { Popup } from 'devextreme-react/popup';
 import ArrayStore from 'devextreme/data/array_store';
@@ -16,20 +16,20 @@ function itemTypeExpr(obj: { ID: number; }) {
 }
 
 export default function App() {
-  const [currentEmployee, setCurrentEmployee] = React.useState<Partial<EmployeeType>>({});
-  const [popupVisible, setPopupVisible] = React.useState(false);
+  const [currentEmployee, setCurrentEmployee] = useState<Partial<EmployeeType>>({});
+  const [popupVisible, setPopupVisible] = useState(false);
 
-  const showInfo = React.useCallback((employee) => {
+  const showInfo = useCallback((employee) => {
     setCurrentEmployee(employee);
     setPopupVisible(true);
   }, [setCurrentEmployee, setPopupVisible]);
 
-  const hideInfo = React.useCallback(() => {
+  const hideInfo = useCallback(() => {
     setCurrentEmployee({});
     setPopupVisible(false);
   }, [setCurrentEmployee, setPopupVisible]);
 
-  const customShapeTemplate = React.useCallback((item) => (CustomShapeTemplate(item.dataItem,
+  const customShapeTemplate = useCallback((item) => (CustomShapeTemplate(item.dataItem,
     () => { showInfo(item.dataItem); })), [showInfo]);
 
   return (

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplates/ReactJs/App.js
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplates/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Diagram, { CustomShape, Nodes, AutoLayout } from 'devextreme-react/diagram';
 import { Popup } from 'devextreme-react/popup';
 import ArrayStore from 'devextreme/data/array_store';
@@ -14,20 +14,20 @@ function itemTypeExpr(obj) {
   return `employee${obj.ID}`;
 }
 export default function App() {
-  const [currentEmployee, setCurrentEmployee] = React.useState({});
-  const [popupVisible, setPopupVisible] = React.useState(false);
-  const showInfo = React.useCallback(
+  const [currentEmployee, setCurrentEmployee] = useState({});
+  const [popupVisible, setPopupVisible] = useState(false);
+  const showInfo = useCallback(
     (employee) => {
       setCurrentEmployee(employee);
       setPopupVisible(true);
     },
     [setCurrentEmployee, setPopupVisible],
   );
-  const hideInfo = React.useCallback(() => {
+  const hideInfo = useCallback(() => {
     setCurrentEmployee({});
     setPopupVisible(false);
   }, [setCurrentEmployee, setPopupVisible]);
-  const customShapeTemplate = React.useCallback(
+  const customShapeTemplate = useCallback(
     (item) =>
       CustomShapeTemplate(item.dataItem, () => {
         showInfo(item.dataItem);

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/React/App.tsx
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import Diagram, {
   CustomShape, ContextToolbox, PropertiesPanel, Group, Tab, Toolbox, Nodes, AutoLayout, DiagramTypes,
 } from 'devextreme-react/diagram';
@@ -78,17 +78,17 @@ function itemCustomDataExpr(obj: Employee, value: Employee) {
 }
 
 export default function App() {
-  const [currentEmployee, setCurrentEmployee] = React.useState<Partial<Employee>>({});
-  const [popupVisible, setPopupVisible] = React.useState(false);
+  const [currentEmployee, setCurrentEmployee] = useState<Partial<Employee>>({});
+  const [popupVisible, setPopupVisible] = useState(false);
 
-  const diagramRef = React.useRef<Diagram>(null);
+  const diagramRef = useRef<Diagram>(null);
 
-  const editEmployee = React.useCallback((employee) => {
+  const editEmployee = useCallback((employee) => {
     setCurrentEmployee({ ...employee });
     setPopupVisible(true);
   }, []);
 
-  const updateEmployee = React.useCallback(() => {
+  const updateEmployee = useCallback(() => {
     dataSource.push([{
       type: 'update',
       key: currentEmployee.ID,
@@ -106,54 +106,54 @@ export default function App() {
     setPopupVisible(false);
   }, [currentEmployee, setCurrentEmployee, setPopupVisible]);
 
-  const customShapeTemplate = React.useCallback((item) => (CustomShapeTemplate(item.dataItem,
+  const customShapeTemplate = useCallback((item) => (CustomShapeTemplate(item.dataItem,
     () => { editEmployee(item.dataItem); },
     () => { deleteEmployee(item.dataItem); })
   ), [editEmployee]);
 
-  const customShapeToolboxTemplate = React.useCallback(() => CustomShapeToolboxTemplate(), []);
+  const customShapeToolboxTemplate = useCallback(() => CustomShapeToolboxTemplate(), []);
 
-  const cancelEditEmployee = React.useCallback(() => {
+  const cancelEditEmployee = useCallback(() => {
     setCurrentEmployee({});
     setPopupVisible(false);
   }, [setCurrentEmployee, setPopupVisible]);
 
-  const handleChange = React.useCallback((field, value) => {
+  const handleChange = useCallback((field, value) => {
     setCurrentEmployee((prevState) => ({
       ...prevState,
       [field]: value,
     }));
   }, [setCurrentEmployee]);
 
-  const handleNameChange = React.useCallback((e: { value: any; }) => {
+  const handleNameChange = useCallback((e: { value: any; }) => {
     handleChange('Full_Name', e.value);
   }, [handleChange]);
 
-  const handleTitleChange = React.useCallback((e: { value: any; }) => {
+  const handleTitleChange = useCallback((e: { value: any; }) => {
     handleChange('Title', e.value);
   }, [handleChange]);
 
-  const handleCityChange = React.useCallback((e: { value: any; }) => {
+  const handleCityChange = useCallback((e: { value: any; }) => {
     handleChange('City', e.value);
   }, [handleChange]);
 
-  const handleStateChange = React.useCallback((e: { value: any; }) => {
+  const handleStateChange = useCallback((e: { value: any; }) => {
     handleChange('State', e.value);
   }, [handleChange]);
 
-  const handleEmailChange = React.useCallback((e: { value: any; }) => {
+  const handleEmailChange = useCallback((e: { value: any; }) => {
     handleChange('Email', e.value);
   }, [handleChange]);
 
-  const handleSkypeChange = React.useCallback((e: { value: any; }) => {
+  const handleSkypeChange = useCallback((e: { value: any; }) => {
     handleChange('Skype', e.value);
   }, [handleChange]);
 
-  const handlePhoneChange = React.useCallback((e: { value: any; }) => {
+  const handlePhoneChange = useCallback((e: { value: any; }) => {
     handleChange('Mobile_Phone', e.value);
   }, [handleChange]);
 
-  const popupContentRender = React.useCallback(() => (
+  const popupContentRender = useCallback(() => (
     <PopupContentFunc
       currentEmployee={currentEmployee}
       handleNameChange={handleNameChange}

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/ReactJs/App.js
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import Diagram, {
   CustomShape,
   ContextToolbox,
@@ -77,14 +77,14 @@ function itemCustomDataExpr(obj, value) {
   return null;
 }
 export default function App() {
-  const [currentEmployee, setCurrentEmployee] = React.useState({});
-  const [popupVisible, setPopupVisible] = React.useState(false);
-  const diagramRef = React.useRef(null);
-  const editEmployee = React.useCallback((employee) => {
+  const [currentEmployee, setCurrentEmployee] = useState({});
+  const [popupVisible, setPopupVisible] = useState(false);
+  const diagramRef = useRef(null);
+  const editEmployee = useCallback((employee) => {
     setCurrentEmployee({ ...employee });
     setPopupVisible(true);
   }, []);
-  const updateEmployee = React.useCallback(() => {
+  const updateEmployee = useCallback(() => {
     dataSource.push([
       {
         type: 'update',
@@ -103,7 +103,7 @@ export default function App() {
     setCurrentEmployee({});
     setPopupVisible(false);
   }, [currentEmployee, setCurrentEmployee, setPopupVisible]);
-  const customShapeTemplate = React.useCallback(
+  const customShapeTemplate = useCallback(
     (item) =>
       CustomShapeTemplate(
         item.dataItem,
@@ -116,12 +116,12 @@ export default function App() {
       ),
     [editEmployee],
   );
-  const customShapeToolboxTemplate = React.useCallback(() => CustomShapeToolboxTemplate(), []);
-  const cancelEditEmployee = React.useCallback(() => {
+  const customShapeToolboxTemplate = useCallback(() => CustomShapeToolboxTemplate(), []);
+  const cancelEditEmployee = useCallback(() => {
     setCurrentEmployee({});
     setPopupVisible(false);
   }, [setCurrentEmployee, setPopupVisible]);
-  const handleChange = React.useCallback(
+  const handleChange = useCallback(
     (field, value) => {
       setCurrentEmployee((prevState) => ({
         ...prevState,
@@ -130,49 +130,49 @@ export default function App() {
     },
     [setCurrentEmployee],
   );
-  const handleNameChange = React.useCallback(
+  const handleNameChange = useCallback(
     (e) => {
       handleChange('Full_Name', e.value);
     },
     [handleChange],
   );
-  const handleTitleChange = React.useCallback(
+  const handleTitleChange = useCallback(
     (e) => {
       handleChange('Title', e.value);
     },
     [handleChange],
   );
-  const handleCityChange = React.useCallback(
+  const handleCityChange = useCallback(
     (e) => {
       handleChange('City', e.value);
     },
     [handleChange],
   );
-  const handleStateChange = React.useCallback(
+  const handleStateChange = useCallback(
     (e) => {
       handleChange('State', e.value);
     },
     [handleChange],
   );
-  const handleEmailChange = React.useCallback(
+  const handleEmailChange = useCallback(
     (e) => {
       handleChange('Email', e.value);
     },
     [handleChange],
   );
-  const handleSkypeChange = React.useCallback(
+  const handleSkypeChange = useCallback(
     (e) => {
       handleChange('Skype', e.value);
     },
     [handleChange],
   );
-  const handlePhoneChange = React.useCallback(
+  const handlePhoneChange = useCallback(
     (e) => {
       handleChange('Mobile_Phone', e.value);
     },
     [handleChange],
   );
-  const popupContentRender = React.useCallback(
+  const popupContentRender = useCallback(
     () => (
       <PopupContentFunc
         currentEmployee={currentEmployee}

--- a/JSDemos/Demos/Diagram/CustomShapesWithTexts/React/App.tsx
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTexts/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Diagram, { CustomShape, Group, Toolbox } from 'devextreme-react/diagram';
 import service from './data.ts';
 import 'whatwg-fetch';
@@ -6,9 +6,9 @@ import 'whatwg-fetch';
 const employees = service.getEmployees();
 
 export default function App() {
-  const diagramRef = React.useRef<Diagram>();
+  const diagramRef = useRef<Diagram>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     const diagram = diagramRef.current.instance;
     fetch('../../../../data/diagram-employees.json')
       .then((response) => response.json())

--- a/JSDemos/Demos/Diagram/CustomShapesWithTexts/ReactJs/App.js
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTexts/ReactJs/App.js
@@ -1,12 +1,12 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Diagram, { CustomShape, Group, Toolbox } from 'devextreme-react/diagram';
 import service from './data.js';
 import 'whatwg-fetch';
 
 const employees = service.getEmployees();
 export default function App() {
-  const diagramRef = React.useRef();
-  React.useEffect(() => {
+  const diagramRef = useRef();
+  useEffect(() => {
     const diagram = diagramRef.current.instance;
     fetch('../../../../data/diagram-employees.json')
       .then((response) => response.json())

--- a/JSDemos/Demos/Diagram/ItemSelection/React/App.tsx
+++ b/JSDemos/Demos/Diagram/ItemSelection/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Diagram, {
   Nodes, AutoLayout, Toolbox, PropertiesPanel, DiagramTypes,
 } from 'devextreme-react/diagram';
@@ -26,9 +26,9 @@ function onContentReady(e: DiagramTypes.ContentReadyEvent) {
 }
 
 export default function App() {
-  const [selectedItemNames, setSelectedItemNames] = React.useState('Nobody has been selected');
+  const [selectedItemNames, setSelectedItemNames] = useState('Nobody has been selected');
 
-  const onSelectionChanged = React.useCallback(({ items }) => {
+  const onSelectionChanged = useCallback(({ items }) => {
     let selectedItems = 'Nobody has been selected';
     const filteredItems = items
       .filter((item) => item.itemType === 'shape')

--- a/JSDemos/Demos/Diagram/ItemSelection/ReactJs/App.js
+++ b/JSDemos/Demos/Diagram/ItemSelection/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Diagram, {
   Nodes, AutoLayout, Toolbox, PropertiesPanel,
 } from 'devextreme-react/diagram';
@@ -23,8 +23,8 @@ function onContentReady(e) {
   }
 }
 export default function App() {
-  const [selectedItemNames, setSelectedItemNames] = React.useState('Nobody has been selected');
-  const onSelectionChanged = React.useCallback(
+  const [selectedItemNames, setSelectedItemNames] = useState('Nobody has been selected');
+  const onSelectionChanged = useCallback(
     ({ items }) => {
       let selectedItems = 'Nobody has been selected';
       const filteredItems = items

--- a/JSDemos/Demos/Diagram/OperationRestrictions/React/App.tsx
+++ b/JSDemos/Demos/Diagram/OperationRestrictions/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import Diagram, {
   CustomShape, Nodes, AutoLayout, ContextToolbox, Toolbox, PropertiesPanel, Group, DiagramTypes,
 } from 'devextreme-react/diagram';
@@ -47,9 +47,9 @@ function itemStyleExpr(obj: { Type: string; }) {
 }
 
 export default function App() {
-  const diagramRef = React.useRef(null);
+  const diagramRef = useRef(null);
 
-  const onRequestEditOperation = React.useCallback((e) => {
+  const onRequestEditOperation = useCallback((e) => {
     const diagram = diagramRef.current.instance;
     if (e.operation === 'addShape') {
       if (e.args.shape.type !== 'employee' && e.args.shape.type !== 'team') {

--- a/JSDemos/Demos/Diagram/OperationRestrictions/ReactJs/App.js
+++ b/JSDemos/Demos/Diagram/OperationRestrictions/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import Diagram, {
   CustomShape,
   Nodes,
@@ -49,8 +49,8 @@ function itemStyleExpr(obj) {
   return { fill: '#bbefcb' };
 }
 export default function App() {
-  const diagramRef = React.useRef(null);
-  const onRequestEditOperation = React.useCallback((e) => {
+  const diagramRef = useRef(null);
+  const onRequestEditOperation = useCallback((e) => {
     const diagram = diagramRef.current.instance;
     if (e.operation === 'addShape') {
       if (e.args.shape.type !== 'employee' && e.args.shape.type !== 'team') {

--- a/JSDemos/Demos/Diagram/Overview/React/App.tsx
+++ b/JSDemos/Demos/Diagram/Overview/React/App.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Diagram from 'devextreme-react/diagram';
 import 'whatwg-fetch';
 
 export default function App() {
-  const diagramRef = React.useRef<Diagram>();
+  const diagramRef = useRef<Diagram>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     const diagram = diagramRef.current.instance;
     fetch('../../../../data/diagram-flow.json')
       .then((response) => response.json())

--- a/JSDemos/Demos/Diagram/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/Diagram/Overview/ReactJs/App.js
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Diagram from 'devextreme-react/diagram';
 import 'whatwg-fetch';
 
 export default function App() {
-  const diagramRef = React.useRef();
-  React.useEffect(() => {
+  const diagramRef = useRef();
+  useEffect(() => {
     const diagram = diagramRef.current.instance;
     fetch('../../../../data/diagram-flow.json')
       .then((response) => response.json())

--- a/JSDemos/Demos/Diagram/ReadOnly/React/App.tsx
+++ b/JSDemos/Demos/Diagram/ReadOnly/React/App.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Diagram from 'devextreme-react/diagram';
 import 'whatwg-fetch';
 
 export default function App() {
-  const diagramRef = React.useRef<Diagram>(null);
+  const diagramRef = useRef<Diagram>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const diagram = diagramRef.current.instance;
     fetch('../../../../data/diagram-structure.json')
       .then((response) => response.json())

--- a/JSDemos/Demos/Diagram/ReadOnly/ReactJs/App.js
+++ b/JSDemos/Demos/Diagram/ReadOnly/ReactJs/App.js
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Diagram from 'devextreme-react/diagram';
 import 'whatwg-fetch';
 
 export default function App() {
-  const diagramRef = React.useRef(null);
-  React.useEffect(() => {
+  const diagramRef = useRef(null);
+  useEffect(() => {
     const diagram = diagramRef.current.instance;
     fetch('../../../../data/diagram-structure.json')
       .then((response) => response.json())

--- a/JSDemos/Demos/Diagram/UICustomization/React/App.tsx
+++ b/JSDemos/Demos/Diagram/UICustomization/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Diagram, {
   ContextMenu,
   ContextToolbox,
@@ -32,9 +32,9 @@ function onCustomCommand(e: DiagramTypes.CustomCommandEvent) {
 }
 
 export default function App() {
-  const diagramRef = React.useRef(null);
+  const diagramRef = useRef(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const diagram = diagramRef.current.instance;
     fetch('../../../../data/diagram-flow.json')
       .then((response) => response.json())

--- a/JSDemos/Demos/Diagram/UICustomization/ReactJs/App.js
+++ b/JSDemos/Demos/Diagram/UICustomization/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Diagram, {
   ContextMenu,
   ContextToolbox,
@@ -30,8 +30,8 @@ function onCustomCommand(e) {
   }
 }
 export default function App() {
-  const diagramRef = React.useRef(null);
-  React.useEffect(() => {
+  const diagramRef = useRef(null);
+  useEffect(() => {
     const diagram = diagramRef.current.instance;
     fetch('../../../../data/diagram-flow.json')
       .then((response) => response.json())

--- a/JSDemos/Demos/Drawer/LeftOrRightPosition/React/App.tsx
+++ b/JSDemos/Demos/Drawer/LeftOrRightPosition/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import Drawer, { DrawerTypes } from 'devextreme-react/drawer';
 import RadioGroup from 'devextreme-react/radio-group';
 import Toolbar from 'devextreme-react/toolbar';
@@ -11,12 +11,12 @@ const positions = ['left', 'right'];
 const revealModes = ['slide', 'expand'];
 
 const App = () => {
-  const [opened, setOpened] = React.useState(true);
-  const [openedStateMode, setOpenedStateMode] = React.useState<DrawerTypes.OpenedStateMode>('shrink');
-  const [revealMode, setRevealMode] = React.useState<DrawerTypes.RevealMode>('slide');
-  const [position, setPosition] = React.useState<DrawerTypes.PanelLocation>('left');
+  const [opened, setOpened] = useState(true);
+  const [openedStateMode, setOpenedStateMode] = useState<DrawerTypes.OpenedStateMode>('shrink');
+  const [revealMode, setRevealMode] = useState<DrawerTypes.RevealMode>('slide');
+  const [position, setPosition] = useState<DrawerTypes.PanelLocation>('left');
 
-  const toolbarItems = React.useMemo(() => [{
+  const toolbarItems = useMemo(() => [{
     widget: 'dxButton',
     location: 'before',
     options: {
@@ -26,19 +26,19 @@ const App = () => {
     },
   }], [opened, setOpened]);
 
-  const onOpenedStateModeChanged = React.useCallback(({ value }) => {
+  const onOpenedStateModeChanged = useCallback(({ value }) => {
     setOpenedStateMode(value);
   }, [setOpenedStateMode]);
 
-  const onRevealModeChanged = React.useCallback(({ value }) => {
+  const onRevealModeChanged = useCallback(({ value }) => {
     setRevealMode(value);
   }, [setRevealMode]);
 
-  const onPositionChanged = React.useCallback(({ value }) => {
+  const onPositionChanged = useCallback(({ value }) => {
     setPosition(value);
   }, [setPosition]);
 
-  const onOutsideClick = React.useCallback(() => {
+  const onOutsideClick = useCallback(() => {
     setOpened(false);
     return false;
   }, [setOpened]);

--- a/JSDemos/Demos/Drawer/LeftOrRightPosition/ReactJs/App.js
+++ b/JSDemos/Demos/Drawer/LeftOrRightPosition/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import Drawer from 'devextreme-react/drawer';
 import RadioGroup from 'devextreme-react/radio-group';
 import Toolbar from 'devextreme-react/toolbar';
@@ -10,11 +10,11 @@ const openedStateModes = ['push', 'shrink', 'overlap'];
 const positions = ['left', 'right'];
 const revealModes = ['slide', 'expand'];
 const App = () => {
-  const [opened, setOpened] = React.useState(true);
-  const [openedStateMode, setOpenedStateMode] = React.useState('shrink');
-  const [revealMode, setRevealMode] = React.useState('slide');
-  const [position, setPosition] = React.useState('left');
-  const toolbarItems = React.useMemo(
+  const [opened, setOpened] = useState(true);
+  const [openedStateMode, setOpenedStateMode] = useState('shrink');
+  const [revealMode, setRevealMode] = useState('slide');
+  const [position, setPosition] = useState('left');
+  const toolbarItems = useMemo(
     () => [
       {
         widget: 'dxButton',
@@ -28,25 +28,25 @@ const App = () => {
     ],
     [opened, setOpened],
   );
-  const onOpenedStateModeChanged = React.useCallback(
+  const onOpenedStateModeChanged = useCallback(
     ({ value }) => {
       setOpenedStateMode(value);
     },
     [setOpenedStateMode],
   );
-  const onRevealModeChanged = React.useCallback(
+  const onRevealModeChanged = useCallback(
     ({ value }) => {
       setRevealMode(value);
     },
     [setRevealMode],
   );
-  const onPositionChanged = React.useCallback(
+  const onPositionChanged = useCallback(
     ({ value }) => {
       setPosition(value);
     },
     [setPosition],
   );
-  const onOutsideClick = React.useCallback(() => {
+  const onOutsideClick = useCallback(() => {
     setOpened(false);
     return false;
   }, [setOpened]);

--- a/JSDemos/Demos/Drawer/TopOrBottomPosition/React/App.tsx
+++ b/JSDemos/Demos/Drawer/TopOrBottomPosition/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import Drawer, { DrawerTypes } from 'devextreme-react/drawer';
 import RadioGroup from 'devextreme-react/radio-group';
 import Toolbar from 'devextreme-react/toolbar';
@@ -11,12 +11,12 @@ const RadioGroupPositionOptions = ['top', 'bottom'];
 const RadioGroupRevealOptions = ['slide', 'expand'];
 
 const App = () => {
-  const [opened, setOpened] = React.useState(false);
-  const [openedStateMode, setOpenedStateMode] = React.useState<DrawerTypes.OpenedStateMode>('shrink');
-  const [revealMode, setRevealMode] = React.useState<DrawerTypes.RevealMode>('expand');
-  const [position, setPosition] = React.useState<DrawerTypes.PanelLocation>('top');
+  const [opened, setOpened] = useState(false);
+  const [openedStateMode, setOpenedStateMode] = useState<DrawerTypes.OpenedStateMode>('shrink');
+  const [revealMode, setRevealMode] = useState<DrawerTypes.RevealMode>('expand');
+  const [position, setPosition] = useState<DrawerTypes.PanelLocation>('top');
 
-  const toolbarItems = React.useMemo(() => [{
+  const toolbarItems = useMemo(() => [{
     widget: 'dxButton',
     location: 'before',
     options: {
@@ -26,19 +26,19 @@ const App = () => {
     },
   }], [opened, setOpened]);
 
-  const onOpenedStateModeChanged = React.useCallback(({ value }) => {
+  const onOpenedStateModeChanged = useCallback(({ value }) => {
     setOpenedStateMode(value);
   }, [setOpenedStateMode]);
 
-  const onRevealModeChanged = React.useCallback(({ value }) => {
+  const onRevealModeChanged = useCallback(({ value }) => {
     setRevealMode(value);
   }, [setRevealMode]);
 
-  const onPositionChanged = React.useCallback(({ value }) => {
+  const onPositionChanged = useCallback(({ value }) => {
     setPosition(value);
   }, [setPosition]);
 
-  const onOutsideClick = React.useCallback(() => {
+  const onOutsideClick = useCallback(() => {
     setOpened(false);
     return false;
   }, [setOpened]);

--- a/JSDemos/Demos/Drawer/TopOrBottomPosition/ReactJs/App.js
+++ b/JSDemos/Demos/Drawer/TopOrBottomPosition/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import Drawer from 'devextreme-react/drawer';
 import RadioGroup from 'devextreme-react/radio-group';
 import Toolbar from 'devextreme-react/toolbar';
@@ -10,11 +10,11 @@ const RadioGroupOpenedOptions = ['push', 'shrink', 'overlap'];
 const RadioGroupPositionOptions = ['top', 'bottom'];
 const RadioGroupRevealOptions = ['slide', 'expand'];
 const App = () => {
-  const [opened, setOpened] = React.useState(false);
-  const [openedStateMode, setOpenedStateMode] = React.useState('shrink');
-  const [revealMode, setRevealMode] = React.useState('expand');
-  const [position, setPosition] = React.useState('top');
-  const toolbarItems = React.useMemo(
+  const [opened, setOpened] = useState(false);
+  const [openedStateMode, setOpenedStateMode] = useState('shrink');
+  const [revealMode, setRevealMode] = useState('expand');
+  const [position, setPosition] = useState('top');
+  const toolbarItems = useMemo(
     () => [
       {
         widget: 'dxButton',
@@ -28,25 +28,25 @@ const App = () => {
     ],
     [opened, setOpened],
   );
-  const onOpenedStateModeChanged = React.useCallback(
+  const onOpenedStateModeChanged = useCallback(
     ({ value }) => {
       setOpenedStateMode(value);
     },
     [setOpenedStateMode],
   );
-  const onRevealModeChanged = React.useCallback(
+  const onRevealModeChanged = useCallback(
     ({ value }) => {
       setRevealMode(value);
     },
     [setRevealMode],
   );
-  const onPositionChanged = React.useCallback(
+  const onPositionChanged = useCallback(
     ({ value }) => {
       setPosition(value);
     },
     [setPosition],
   );
-  const onOutsideClick = React.useCallback(() => {
+  const onOutsideClick = useCallback(() => {
     setOpened(false);
     return false;
   }, [setOpened]);

--- a/JSDemos/Demos/DropDownBox/MultipleSelection/React/App.tsx
+++ b/JSDemos/Demos/DropDownBox/MultipleSelection/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import DropDownBox, { DropDownBoxTypes } from 'devextreme-react/drop-down-box';
 import TreeView from 'devextreme-react/tree-view';
 import DataGrid, {
@@ -27,11 +27,11 @@ const treeDataSource = makeAsyncDataSource('treeProducts.json');
 const gridDataSource = makeAsyncDataSource('customers.json');
 
 function App() {
-  const [treeBoxValue, setTreeBoxValue] = React.useState(['1_1']);
-  const [gridBoxValue, setGridBoxValue] = React.useState([3]);
-  const treeViewRef = React.useRef<TreeView<any>>();
+  const [treeBoxValue, setTreeBoxValue] = useState(['1_1']);
+  const [gridBoxValue, setGridBoxValue] = useState([3]);
+  const treeViewRef = useRef<TreeView<any>>();
 
-  const treeViewRender = React.useCallback(
+  const treeViewRender = useCallback(
     () => (
       <TreeView
         dataSource={treeDataSource}
@@ -51,7 +51,7 @@ function App() {
     [treeDataSource],
   );
 
-  const dataGridRender = React.useCallback(
+  const dataGridRender = useCallback(
     () => (
       <DataGrid
         height={345}
@@ -73,7 +73,7 @@ function App() {
     [gridDataSource, gridBoxValue],
   );
 
-  const syncTreeViewSelection = React.useCallback(
+  const syncTreeViewSelection = useCallback(
     (e: DropDownBoxTypes.ValueChangedEvent | any) => {
       const treeView = (e.component.selectItem && e.component)
         || (treeViewRef.current && treeViewRef.current.instance);
@@ -96,18 +96,18 @@ function App() {
     [treeBoxValue],
   );
 
-  const syncDataGridSelection = React.useCallback((e: DropDownBoxTypes.ValueChangedEvent) => {
+  const syncDataGridSelection = useCallback((e: DropDownBoxTypes.ValueChangedEvent) => {
     setGridBoxValue(e.value || []);
   }, []);
 
-  const treeViewItemSelectionChanged = React.useCallback(
+  const treeViewItemSelectionChanged = useCallback(
     (e: { component: { getSelectedNodeKeys: () => any } }) => {
       setTreeBoxValue(e.component.getSelectedNodeKeys());
     },
     [],
   );
 
-  const dataGridOnSelectionChanged = React.useCallback((e: DataGridTypes.SelectionChangedEvent) => {
+  const dataGridOnSelectionChanged = useCallback((e: DataGridTypes.SelectionChangedEvent) => {
     setGridBoxValue((e.selectedRowKeys.length && e.selectedRowKeys) || []);
   }, []);
 

--- a/JSDemos/Demos/DropDownBox/MultipleSelection/ReactJs/App.js
+++ b/JSDemos/Demos/DropDownBox/MultipleSelection/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import DropDownBox from 'devextreme-react/drop-down-box';
 import TreeView from 'devextreme-react/tree-view';
 import DataGrid, {
@@ -20,10 +20,10 @@ const makeAsyncDataSource = (jsonFile) =>
 const treeDataSource = makeAsyncDataSource('treeProducts.json');
 const gridDataSource = makeAsyncDataSource('customers.json');
 function App() {
-  const [treeBoxValue, setTreeBoxValue] = React.useState(['1_1']);
-  const [gridBoxValue, setGridBoxValue] = React.useState([3]);
-  const treeViewRef = React.useRef();
-  const treeViewRender = React.useCallback(
+  const [treeBoxValue, setTreeBoxValue] = useState(['1_1']);
+  const [gridBoxValue, setGridBoxValue] = useState([3]);
+  const treeViewRef = useRef();
+  const treeViewRender = useCallback(
     () => (
       <TreeView
         dataSource={treeDataSource}
@@ -42,7 +42,7 @@ function App() {
     ),
     [treeDataSource],
   );
-  const dataGridRender = React.useCallback(
+  const dataGridRender = useCallback(
     () => (
       <DataGrid
         height={345}
@@ -63,7 +63,7 @@ function App() {
     ),
     [gridDataSource, gridBoxValue],
   );
-  const syncTreeViewSelection = React.useCallback(
+  const syncTreeViewSelection = useCallback(
     (e) => {
       const treeView = (e.component.selectItem && e.component)
         || (treeViewRef.current && treeViewRef.current.instance);
@@ -84,13 +84,13 @@ function App() {
     },
     [treeBoxValue],
   );
-  const syncDataGridSelection = React.useCallback((e) => {
+  const syncDataGridSelection = useCallback((e) => {
     setGridBoxValue(e.value || []);
   }, []);
-  const treeViewItemSelectionChanged = React.useCallback((e) => {
+  const treeViewItemSelectionChanged = useCallback((e) => {
     setTreeBoxValue(e.component.getSelectedNodeKeys());
   }, []);
-  const dataGridOnSelectionChanged = React.useCallback((e) => {
+  const dataGridOnSelectionChanged = useCallback((e) => {
     setGridBoxValue((e.selectedRowKeys.length && e.selectedRowKeys) || []);
   }, []);
   return (

--- a/JSDemos/Demos/DropDownBox/SingleSelection/React/App.tsx
+++ b/JSDemos/Demos/DropDownBox/SingleSelection/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import DropDownBox, { DropDownBoxTypes } from 'devextreme-react/drop-down-box';
 import TreeView, { TreeViewTypes } from 'devextreme-react/tree-view';
 import DataGrid, {
@@ -26,36 +26,36 @@ const gridBoxDisplayExpr = (item: { CompanyName: any; Phone: any }) =>
   item && `${item.CompanyName} <${item.Phone}>`;
 
 function App() {
-  const treeViewRef = React.useRef(null);
-  const [treeBoxValue, setTreeBoxValue] = React.useState('1_1');
-  const [gridBoxValue, setGridBoxValue] = React.useState([3]);
-  const [isGridBoxOpened, setIsGridBoxOpened] = React.useState(false);
-  const [isTreeBoxOpened, setIsTreeBoxOpened] = React.useState(false);
+  const treeViewRef = useRef(null);
+  const [treeBoxValue, setTreeBoxValue] = useState('1_1');
+  const [gridBoxValue, setGridBoxValue] = useState([3]);
+  const [isGridBoxOpened, setIsGridBoxOpened] = useState(false);
+  const [isTreeBoxOpened, setIsTreeBoxOpened] = useState(false);
 
-  const treeViewItemSelectionChanged = React.useCallback(
+  const treeViewItemSelectionChanged = useCallback(
     (e: { component: { getSelectedNodeKeys: () => any } }) => {
       setTreeBoxValue(e.component.getSelectedNodeKeys());
     },
     [],
   );
 
-  const dataGridOnSelectionChanged = React.useCallback((e: { selectedRowKeys: any }) => {
+  const dataGridOnSelectionChanged = useCallback((e: { selectedRowKeys: any }) => {
     setGridBoxValue(e.selectedRowKeys);
     setIsGridBoxOpened(false);
   }, []);
 
-  const treeViewOnContentReady = React.useCallback(
+  const treeViewOnContentReady = useCallback(
     (e: TreeViewTypes.ContentReadyEvent) => {
       e.component.selectItem(treeBoxValue);
     },
     [treeBoxValue],
   );
 
-  const onTreeItemClick = React.useCallback(() => {
+  const onTreeItemClick = useCallback(() => {
     setIsTreeBoxOpened(false);
   }, []);
 
-  const treeViewRender = React.useCallback(
+  const treeViewRender = useCallback(
     () => (
       <TreeView
         dataSource={treeDataSource}
@@ -74,7 +74,7 @@ function App() {
     [treeViewRef, treeViewOnContentReady, onTreeItemClick, treeViewItemSelectionChanged],
   );
 
-  const dataGridRender = React.useCallback(
+  const dataGridRender = useCallback(
     () => (
       <DataGrid
         dataSource={gridDataSource}
@@ -97,7 +97,7 @@ function App() {
     [gridBoxValue, dataGridOnSelectionChanged],
   );
 
-  const syncTreeViewSelection = React.useCallback((e: DropDownBoxTypes.ValueChangedEvent) => {
+  const syncTreeViewSelection = useCallback((e: DropDownBoxTypes.ValueChangedEvent) => {
     setTreeBoxValue(e.value);
     if (!treeViewRef.current) return;
 
@@ -108,17 +108,17 @@ function App() {
     }
   }, []);
 
-  const syncDataGridSelection = React.useCallback((e: DropDownBoxTypes.ValueChangedEvent) => {
+  const syncDataGridSelection = useCallback((e: DropDownBoxTypes.ValueChangedEvent) => {
     setGridBoxValue(e.value);
   }, []);
 
-  const onGridBoxOpened = React.useCallback((e: DropDownBoxTypes.OptionChangedEvent) => {
+  const onGridBoxOpened = useCallback((e: DropDownBoxTypes.OptionChangedEvent) => {
     if (e.name === 'opened') {
       setIsGridBoxOpened(e.value);
     }
   }, []);
 
-  const onTreeBoxOpened = React.useCallback((e: DropDownBoxTypes.OptionChangedEvent) => {
+  const onTreeBoxOpened = useCallback((e: DropDownBoxTypes.OptionChangedEvent) => {
     if (e.name === 'opened') {
       setIsTreeBoxOpened(e.value);
     }

--- a/JSDemos/Demos/DropDownBox/SingleSelection/ReactJs/App.js
+++ b/JSDemos/Demos/DropDownBox/SingleSelection/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import DropDownBox from 'devextreme-react/drop-down-box';
 import TreeView from 'devextreme-react/tree-view';
 import DataGrid, {
@@ -21,28 +21,28 @@ const treeDataSource = makeAsyncDataSource('treeProducts.json');
 const gridDataSource = makeAsyncDataSource('customers.json');
 const gridBoxDisplayExpr = (item) => item && `${item.CompanyName} <${item.Phone}>`;
 function App() {
-  const treeViewRef = React.useRef(null);
-  const [treeBoxValue, setTreeBoxValue] = React.useState('1_1');
-  const [gridBoxValue, setGridBoxValue] = React.useState([3]);
-  const [isGridBoxOpened, setIsGridBoxOpened] = React.useState(false);
-  const [isTreeBoxOpened, setIsTreeBoxOpened] = React.useState(false);
-  const treeViewItemSelectionChanged = React.useCallback((e) => {
+  const treeViewRef = useRef(null);
+  const [treeBoxValue, setTreeBoxValue] = useState('1_1');
+  const [gridBoxValue, setGridBoxValue] = useState([3]);
+  const [isGridBoxOpened, setIsGridBoxOpened] = useState(false);
+  const [isTreeBoxOpened, setIsTreeBoxOpened] = useState(false);
+  const treeViewItemSelectionChanged = useCallback((e) => {
     setTreeBoxValue(e.component.getSelectedNodeKeys());
   }, []);
-  const dataGridOnSelectionChanged = React.useCallback((e) => {
+  const dataGridOnSelectionChanged = useCallback((e) => {
     setGridBoxValue(e.selectedRowKeys);
     setIsGridBoxOpened(false);
   }, []);
-  const treeViewOnContentReady = React.useCallback(
+  const treeViewOnContentReady = useCallback(
     (e) => {
       e.component.selectItem(treeBoxValue);
     },
     [treeBoxValue],
   );
-  const onTreeItemClick = React.useCallback(() => {
+  const onTreeItemClick = useCallback(() => {
     setIsTreeBoxOpened(false);
   }, []);
-  const treeViewRender = React.useCallback(
+  const treeViewRender = useCallback(
     () => (
       <TreeView
         dataSource={treeDataSource}
@@ -60,7 +60,7 @@ function App() {
     ),
     [treeViewRef, treeViewOnContentReady, onTreeItemClick, treeViewItemSelectionChanged],
   );
-  const dataGridRender = React.useCallback(
+  const dataGridRender = useCallback(
     () => (
       <DataGrid
         dataSource={gridDataSource}
@@ -82,7 +82,7 @@ function App() {
     ),
     [gridBoxValue, dataGridOnSelectionChanged],
   );
-  const syncTreeViewSelection = React.useCallback((e) => {
+  const syncTreeViewSelection = useCallback((e) => {
     setTreeBoxValue(e.value);
     if (!treeViewRef.current) return;
     if (!e.value) {
@@ -91,15 +91,15 @@ function App() {
       treeViewRef.current.instance.selectItem(e.value);
     }
   }, []);
-  const syncDataGridSelection = React.useCallback((e) => {
+  const syncDataGridSelection = useCallback((e) => {
     setGridBoxValue(e.value);
   }, []);
-  const onGridBoxOpened = React.useCallback((e) => {
+  const onGridBoxOpened = useCallback((e) => {
     if (e.name === 'opened') {
       setIsGridBoxOpened(e.value);
     }
   }, []);
-  const onTreeBoxOpened = React.useCallback((e) => {
+  const onTreeBoxOpened = useCallback((e) => {
     if (e.name === 'opened') {
       setIsTreeBoxOpened(e.value);
     }

--- a/JSDemos/Demos/DropDownButton/Overview/React/App.tsx
+++ b/JSDemos/Demos/DropDownButton/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import DropDownButton, { DropDownButtonTypes } from 'devextreme-react/drop-down-button';
 import Toolbar from 'devextreme-react/toolbar';
 import { Template } from 'devextreme-react/core/template';
@@ -21,32 +21,32 @@ const itemTemplateRender = (item) => (
 );
 
 const App = () => {
-  const [alignment, setAlignment] = React.useState<TextAlign>('left');
-  const [color, setColor] = React.useState(null);
-  const [fontSize, setFontSize] = React.useState(14);
-  const [lineHeight, setLineHeight] = React.useState(1.35);
-  const [colorPicker, setColorPicker] = React.useState(null);
+  const [alignment, setAlignment] = useState<TextAlign>('left');
+  const [color, setColor] = useState(null);
+  const [fontSize, setFontSize] = useState(14);
+  const [lineHeight, setLineHeight] = useState(1.35);
+  const [colorPicker, setColorPicker] = useState(null);
 
-  const onButtonClick = React.useCallback((e: ButtonTypes.ClickEvent) => {
+  const onButtonClick = useCallback((e: ButtonTypes.ClickEvent) => {
     notify(`Go to ${e.component.option('text')}'s profile`, 'success', 600);
   }, []);
 
-  const onItemClick = React.useCallback((e: DropDownButtonTypes.ItemClickEvent) => {
+  const onItemClick = useCallback((e: DropDownButtonTypes.ItemClickEvent) => {
     notify(e.itemData.name || e.itemData, 'success', 600);
   }, []);
 
-  const onColorClick = React.useCallback((selectedColor) => {
+  const onColorClick = useCallback((selectedColor) => {
     setColor(selectedColor);
     const squareIcon = colorPicker.element().getElementsByClassName('dx-icon-square')[0];
     squareIcon.style.color = selectedColor;
     colorPicker.close();
   }, [colorPicker]);
 
-  const onInitialized = React.useCallback((e: DropDownButtonTypes.InitializedEvent) => {
+  const onInitialized = useCallback((e: DropDownButtonTypes.InitializedEvent) => {
     setColorPicker(e.component);
   }, [setColorPicker]);
 
-  const toolbarItems = React.useMemo(() => [
+  const toolbarItems = useMemo(() => [
     {
       location: 'before',
       widget: 'dxDropDownButton',

--- a/JSDemos/Demos/DropDownButton/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/DropDownButton/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import DropDownButton from 'devextreme-react/drop-down-button';
 import Toolbar from 'devextreme-react/toolbar';
 import { Template } from 'devextreme-react/core/template';
@@ -11,18 +11,18 @@ const buttonDropDownOptions = { width: 230 };
 const data = service.getData();
 const itemTemplateRender = (item) => <div style={{ fontSize: `${item.size}px` }}>{item.text}</div>;
 const App = () => {
-  const [alignment, setAlignment] = React.useState('left');
-  const [color, setColor] = React.useState(null);
-  const [fontSize, setFontSize] = React.useState(14);
-  const [lineHeight, setLineHeight] = React.useState(1.35);
-  const [colorPicker, setColorPicker] = React.useState(null);
-  const onButtonClick = React.useCallback((e) => {
+  const [alignment, setAlignment] = useState('left');
+  const [color, setColor] = useState(null);
+  const [fontSize, setFontSize] = useState(14);
+  const [lineHeight, setLineHeight] = useState(1.35);
+  const [colorPicker, setColorPicker] = useState(null);
+  const onButtonClick = useCallback((e) => {
     notify(`Go to ${e.component.option('text')}'s profile`, 'success', 600);
   }, []);
-  const onItemClick = React.useCallback((e) => {
+  const onItemClick = useCallback((e) => {
     notify(e.itemData.name || e.itemData, 'success', 600);
   }, []);
-  const onColorClick = React.useCallback(
+  const onColorClick = useCallback(
     (selectedColor) => {
       setColor(selectedColor);
       const squareIcon = colorPicker.element().getElementsByClassName('dx-icon-square')[0];
@@ -31,13 +31,13 @@ const App = () => {
     },
     [colorPicker],
   );
-  const onInitialized = React.useCallback(
+  const onInitialized = useCallback(
     (e) => {
       setColorPicker(e.component);
     },
     [setColorPicker],
   );
-  const toolbarItems = React.useMemo(
+  const toolbarItems = useMemo(
     () => [
       {
         location: 'before',

--- a/JSDemos/Demos/FileManager/BindingToEF/React/App.tsx
+++ b/JSDemos/Demos/FileManager/BindingToEF/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import FileManager, {
   Permissions, ItemView, Details, Column, FileManagerTypes,
 } from 'devextreme-react/file-manager';
@@ -11,9 +11,9 @@ const remoteProvider = new RemoteFileSystemProvider({
 const allowedFileExtensions = [];
 
 export default function App() {
-  const [currentPath, setCurrentPath] = React.useState('Documents/Reports');
+  const [currentPath, setCurrentPath] = useState('Documents/Reports');
 
-  const onCurrentDirectoryChanged = React.useCallback((e: FileManagerTypes.CurrentDirectoryChangedEvent) => {
+  const onCurrentDirectoryChanged = useCallback((e: FileManagerTypes.CurrentDirectoryChangedEvent) => {
     setCurrentPath(e.component.option('currentPath'));
   }, []);
 

--- a/JSDemos/Demos/FileManager/BindingToEF/ReactJs/App.js
+++ b/JSDemos/Demos/FileManager/BindingToEF/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import FileManager, {
   Permissions, ItemView, Details, Column,
 } from 'devextreme-react/file-manager';
@@ -9,8 +9,8 @@ const remoteProvider = new RemoteFileSystemProvider({
 });
 const allowedFileExtensions = [];
 export default function App() {
-  const [currentPath, setCurrentPath] = React.useState('Documents/Reports');
-  const onCurrentDirectoryChanged = React.useCallback((e) => {
+  const [currentPath, setCurrentPath] = useState('Documents/Reports');
+  const onCurrentDirectoryChanged = useCallback((e) => {
     setCurrentPath(e.component.option('currentPath'));
   }, []);
   return (

--- a/JSDemos/Demos/FileManager/CustomThumbnails/React/App.tsx
+++ b/JSDemos/Demos/FileManager/CustomThumbnails/React/App.tsx
@@ -1,19 +1,19 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import FileManager, {
   Permissions, ItemView, FileManagerTypes, IItemViewProps,
 } from 'devextreme-react/file-manager';
 import { fileItems } from './data.ts';
 
 export default function App() {
-  const [itemViewMode, setItemViewMode] = React.useState<IItemViewProps['mode']>('thumbnails');
+  const [itemViewMode, setItemViewMode] = useState<IItemViewProps['mode']>('thumbnails');
 
-  const onOptionChanged = React.useCallback((e: FileManagerTypes.OptionChangedEvent) => {
+  const onOptionChanged = useCallback((e: FileManagerTypes.OptionChangedEvent) => {
     if (e.fullName === 'itemView.mode') {
       setItemViewMode(e.value);
     }
   }, [setItemViewMode]);
 
-  const customizeIcon = React.useCallback<FileManagerTypes.Properties['customizeThumbnail']>((fileSystemItem) => {
+  const customizeIcon = useCallback<FileManagerTypes.Properties['customizeThumbnail']>((fileSystemItem) => {
     if (fileSystemItem.isDirectory) {
       return '../../../../images/thumbnails/folder.svg';
     }

--- a/JSDemos/Demos/FileManager/CustomThumbnails/ReactJs/App.js
+++ b/JSDemos/Demos/FileManager/CustomThumbnails/ReactJs/App.js
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import FileManager, { Permissions, ItemView } from 'devextreme-react/file-manager';
 import { fileItems } from './data.js';
 
 export default function App() {
-  const [itemViewMode, setItemViewMode] = React.useState('thumbnails');
-  const onOptionChanged = React.useCallback(
+  const [itemViewMode, setItemViewMode] = useState('thumbnails');
+  const onOptionChanged = useCallback(
     (e) => {
       if (e.fullName === 'itemView.mode') {
         setItemViewMode(e.value);
@@ -12,7 +12,7 @@ export default function App() {
     },
     [setItemViewMode],
   );
-  const customizeIcon = React.useCallback((fileSystemItem) => {
+  const customizeIcon = useCallback((fileSystemItem) => {
     if (fileSystemItem.isDirectory) {
       return '../../../../images/thumbnails/folder.svg';
     }

--- a/JSDemos/Demos/FileManager/Overview/React/App.tsx
+++ b/JSDemos/Demos/FileManager/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import FileManager, { FileManagerTypes, Permissions } from 'devextreme-react/file-manager';
 import RemoteFileSystemProvider from 'devextreme/file_management/remote_provider';
 import { Popup } from 'devextreme-react/popup';
@@ -8,11 +8,11 @@ const remoteProvider = new RemoteFileSystemProvider({
 });
 
 export default function App() {
-  const [currentPath, setCurrentPath] = React.useState('Widescreen');
-  const [popupVisible, setPopupVisible] = React.useState(false);
-  const [imageItemToDisplay, setImageItemToDisplay] = React.useState<{ name?: string, url?: string }>({});
+  const [currentPath, setCurrentPath] = useState('Widescreen');
+  const [popupVisible, setPopupVisible] = useState(false);
+  const [imageItemToDisplay, setImageItemToDisplay] = useState<{ name?: string, url?: string }>({});
 
-  const displayImagePopup = React.useCallback((e: FileManagerTypes.SelectedFileOpenedEvent) => {
+  const displayImagePopup = useCallback((e: FileManagerTypes.SelectedFileOpenedEvent) => {
     setPopupVisible(true);
     setImageItemToDisplay({
       name: e.file.name,
@@ -20,11 +20,11 @@ export default function App() {
     });
   }, [setPopupVisible, setImageItemToDisplay]);
 
-  const hideImagePopup = React.useCallback(() => {
+  const hideImagePopup = useCallback(() => {
     setPopupVisible(false);
   }, [setPopupVisible]);
 
-  const onCurrentDirectoryChanged = React.useCallback((e: FileManagerTypes.CurrentDirectoryChangedEvent) => {
+  const onCurrentDirectoryChanged = useCallback((e: FileManagerTypes.CurrentDirectoryChangedEvent) => {
     setCurrentPath(e.component.option('currentPath'));
   }, [setCurrentPath]);
 

--- a/JSDemos/Demos/FileManager/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/FileManager/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import FileManager, { Permissions } from 'devextreme-react/file-manager';
 import RemoteFileSystemProvider from 'devextreme/file_management/remote_provider';
 import { Popup } from 'devextreme-react/popup';
@@ -7,10 +7,10 @@ const remoteProvider = new RemoteFileSystemProvider({
   endpointUrl: 'https://js.devexpress.com/Demos/Mvc/api/file-manager-file-system-images',
 });
 export default function App() {
-  const [currentPath, setCurrentPath] = React.useState('Widescreen');
-  const [popupVisible, setPopupVisible] = React.useState(false);
-  const [imageItemToDisplay, setImageItemToDisplay] = React.useState({});
-  const displayImagePopup = React.useCallback(
+  const [currentPath, setCurrentPath] = useState('Widescreen');
+  const [popupVisible, setPopupVisible] = useState(false);
+  const [imageItemToDisplay, setImageItemToDisplay] = useState({});
+  const displayImagePopup = useCallback(
     (e) => {
       setPopupVisible(true);
       setImageItemToDisplay({
@@ -20,10 +20,10 @@ export default function App() {
     },
     [setPopupVisible, setImageItemToDisplay],
   );
-  const hideImagePopup = React.useCallback(() => {
+  const hideImagePopup = useCallback(() => {
     setPopupVisible(false);
   }, [setPopupVisible]);
-  const onCurrentDirectoryChanged = React.useCallback(
+  const onCurrentDirectoryChanged = useCallback(
     (e) => {
       setCurrentPath(e.component.option('currentPath'));
     },

--- a/JSDemos/Demos/FileManager/UICustomization/React/App.tsx
+++ b/JSDemos/Demos/FileManager/UICustomization/React/App.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import FileManager, {
   Permissions, Toolbar, ContextMenu, Item, FileSelectionItem, ItemView, Details, Column,
 } from 'devextreme-react/file-manager';
 import { fileItems, getItemInfo } from './data.ts';
 
 export default function App() {
-  const fileManagerRef = React.useRef<FileManager>(null);
+  const fileManagerRef = useRef<FileManager>(null);
 
-  const createFile = React.useCallback((
+  const createFile = useCallback((
     fileExtension,
     directory = fileManagerRef.current.instance.getCurrentDirectory(),
   ) => {
@@ -37,7 +37,7 @@ export default function App() {
     return true;
   }, []);
 
-  const updateCategory = React.useCallback((newCategory, directory, viewArea: string) => {
+  const updateCategory = useCallback((newCategory, directory, viewArea: string) => {
     let items = null;
 
     if (viewArea === 'navPane') {
@@ -55,7 +55,7 @@ export default function App() {
     return items.length > 0;
   }, []);
 
-  const onItemClick = React.useCallback(({ itemData, viewArea, fileSystemItem }) => {
+  const onItemClick = useCallback(({ itemData, viewArea, fileSystemItem }) => {
     let updated = false;
     const { extension, category } = getItemInfo(itemData.text);
 
@@ -70,7 +70,7 @@ export default function App() {
     }
   }, [createFile, updateCategory]);
 
-  const getNewFileMenuOptions = React.useCallback(() => ({
+  const getNewFileMenuOptions = useCallback(() => ({
     items: [
       {
         text: 'Create new file',
@@ -94,7 +94,7 @@ export default function App() {
     onItemClick,
   }), [onItemClick]);
 
-  const getChangeCategoryMenuOptions = React.useCallback(() => ({
+  const getChangeCategoryMenuOptions = useCallback(() => ({
     items: [
       {
         text: 'Category',

--- a/JSDemos/Demos/FileManager/UICustomization/ReactJs/App.js
+++ b/JSDemos/Demos/FileManager/UICustomization/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import FileManager, {
   Permissions,
   Toolbar,
@@ -12,8 +12,8 @@ import FileManager, {
 import { fileItems, getItemInfo } from './data.js';
 
 export default function App() {
-  const fileManagerRef = React.useRef(null);
-  const createFile = React.useCallback(
+  const fileManagerRef = useRef(null);
+  const createFile = useCallback(
     (fileExtension, directory = fileManagerRef.current.instance.getCurrentDirectory()) => {
       const newItem = {
         __KEY__: Date.now(),
@@ -39,7 +39,7 @@ export default function App() {
     },
     [],
   );
-  const updateCategory = React.useCallback((newCategory, directory, viewArea) => {
+  const updateCategory = useCallback((newCategory, directory, viewArea) => {
     let items = null;
     if (viewArea === 'navPane') {
       items = [directory];
@@ -53,7 +53,7 @@ export default function App() {
     });
     return items.length > 0;
   }, []);
-  const onItemClick = React.useCallback(
+  const onItemClick = useCallback(
     ({ itemData, viewArea, fileSystemItem }) => {
       let updated = false;
       const { extension, category } = getItemInfo(itemData.text);
@@ -68,7 +68,7 @@ export default function App() {
     },
     [createFile, updateCategory],
   );
-  const getNewFileMenuOptions = React.useCallback(
+  const getNewFileMenuOptions = useCallback(
     () => ({
       items: [
         {
@@ -94,7 +94,7 @@ export default function App() {
     }),
     [onItemClick],
   );
-  const getChangeCategoryMenuOptions = React.useCallback(
+  const getChangeCategoryMenuOptions = useCallback(
     () => ({
       items: [
         {

--- a/JSDemos/Demos/FileUploader/ChunkUploading/React/App.tsx
+++ b/JSDemos/Demos/FileUploader/ChunkUploading/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import FileUploader, { FileUploaderTypes } from 'devextreme-react/file-uploader';
 
 function getValueInKb(value: number) {
@@ -6,9 +6,9 @@ function getValueInKb(value: number) {
 }
 
 export default function App() {
-  const [chunks, setChunks] = React.useState([]);
+  const [chunks, setChunks] = useState([]);
 
-  const onUploadProgress = React.useCallback((e: FileUploaderTypes.ProgressEvent) => {
+  const onUploadProgress = useCallback((e: FileUploaderTypes.ProgressEvent) => {
     const chunk = {
       segmentSize: e.segmentSize,
       bytesLoaded: e.bytesLoaded,
@@ -17,7 +17,7 @@ export default function App() {
     setChunks([...chunks, chunk]);
   }, [chunks, setChunks]);
 
-  const onUploadStarted = React.useCallback(() => {
+  const onUploadStarted = useCallback(() => {
     setChunks([]);
   }, [setChunks]);
 

--- a/JSDemos/Demos/FileUploader/ChunkUploading/ReactJs/App.js
+++ b/JSDemos/Demos/FileUploader/ChunkUploading/ReactJs/App.js
@@ -1,12 +1,12 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import FileUploader from 'devextreme-react/file-uploader';
 
 function getValueInKb(value) {
   return `${(value / 1024).toFixed(0)}kb`;
 }
 export default function App() {
-  const [chunks, setChunks] = React.useState([]);
-  const onUploadProgress = React.useCallback(
+  const [chunks, setChunks] = useState([]);
+  const onUploadProgress = useCallback(
     (e) => {
       const chunk = {
         segmentSize: e.segmentSize,
@@ -17,7 +17,7 @@ export default function App() {
     },
     [chunks, setChunks],
   );
-  const onUploadStarted = React.useCallback(() => {
+  const onUploadStarted = useCallback(() => {
     setChunks([]);
   }, [setChunks]);
   return (

--- a/JSDemos/Demos/FileUploader/CustomDropzone/React/App.tsx
+++ b/JSDemos/Demos/FileUploader/CustomDropzone/React/App.tsx
@@ -1,29 +1,29 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import FileUploader, { FileUploaderTypes } from 'devextreme-react/file-uploader';
 import ProgressBar from 'devextreme-react/progress-bar';
 
 const allowedFileExtensions = ['.jpg', '.jpeg', '.gif', '.png'];
 
 export default function App() {
-  const [isDropZoneActive, setIsDropZoneActive] = React.useState(false);
-  const [imageSource, setImageSource] = React.useState<string>('');
-  const [textVisible, setTextVisible] = React.useState(true);
-  const [progressVisible, setProgressVisible] = React.useState(false);
-  const [progressValue, setProgressValue] = React.useState(0);
+  const [isDropZoneActive, setIsDropZoneActive] = useState(false);
+  const [imageSource, setImageSource] = useState<string>('');
+  const [textVisible, setTextVisible] = useState(true);
+  const [progressVisible, setProgressVisible] = useState(false);
+  const [progressValue, setProgressValue] = useState(0);
 
-  const onDropZoneEnter = React.useCallback((e: FileUploaderTypes.DropZoneEnterEvent) => {
+  const onDropZoneEnter = useCallback((e: FileUploaderTypes.DropZoneEnterEvent) => {
     if (e.dropZoneElement.id === 'dropzone-external') {
       setIsDropZoneActive(true);
     }
   }, [setIsDropZoneActive]);
 
-  const onDropZoneLeave = React.useCallback((e: FileUploaderTypes.DropZoneLeaveEvent) => {
+  const onDropZoneLeave = useCallback((e: FileUploaderTypes.DropZoneLeaveEvent) => {
     if (e.dropZoneElement.id === 'dropzone-external') {
       setIsDropZoneActive(false);
     }
   }, [setIsDropZoneActive]);
 
-  const onUploaded = React.useCallback((e: FileUploaderTypes.UploadedEvent) => {
+  const onUploaded = useCallback((e: FileUploaderTypes.UploadedEvent) => {
     const { file } = e;
     const fileReader = new FileReader();
     fileReader.onload = () => {
@@ -36,11 +36,11 @@ export default function App() {
     setProgressValue(0);
   }, [setImageSource, setIsDropZoneActive, setTextVisible, setProgressVisible, setProgressValue]);
 
-  const onProgress = React.useCallback((e: { bytesLoaded: number; bytesTotal: number; }) => {
+  const onProgress = useCallback((e: { bytesLoaded: number; bytesTotal: number; }) => {
     setProgressValue((e.bytesLoaded / e.bytesTotal) * 100);
   }, [setProgressValue]);
 
-  const onUploadStarted = React.useCallback(() => {
+  const onUploadStarted = useCallback(() => {
     setImageSource('');
     setProgressVisible(true);
   }, [setImageSource, setProgressVisible]);

--- a/JSDemos/Demos/FileUploader/CustomDropzone/ReactJs/App.js
+++ b/JSDemos/Demos/FileUploader/CustomDropzone/ReactJs/App.js
@@ -1,15 +1,15 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import FileUploader from 'devextreme-react/file-uploader';
 import ProgressBar from 'devextreme-react/progress-bar';
 
 const allowedFileExtensions = ['.jpg', '.jpeg', '.gif', '.png'];
 export default function App() {
-  const [isDropZoneActive, setIsDropZoneActive] = React.useState(false);
-  const [imageSource, setImageSource] = React.useState('');
-  const [textVisible, setTextVisible] = React.useState(true);
-  const [progressVisible, setProgressVisible] = React.useState(false);
-  const [progressValue, setProgressValue] = React.useState(0);
-  const onDropZoneEnter = React.useCallback(
+  const [isDropZoneActive, setIsDropZoneActive] = useState(false);
+  const [imageSource, setImageSource] = useState('');
+  const [textVisible, setTextVisible] = useState(true);
+  const [progressVisible, setProgressVisible] = useState(false);
+  const [progressValue, setProgressValue] = useState(0);
+  const onDropZoneEnter = useCallback(
     (e) => {
       if (e.dropZoneElement.id === 'dropzone-external') {
         setIsDropZoneActive(true);
@@ -17,7 +17,7 @@ export default function App() {
     },
     [setIsDropZoneActive],
   );
-  const onDropZoneLeave = React.useCallback(
+  const onDropZoneLeave = useCallback(
     (e) => {
       if (e.dropZoneElement.id === 'dropzone-external') {
         setIsDropZoneActive(false);
@@ -25,7 +25,7 @@ export default function App() {
     },
     [setIsDropZoneActive],
   );
-  const onUploaded = React.useCallback(
+  const onUploaded = useCallback(
     (e) => {
       const { file } = e;
       const fileReader = new FileReader();
@@ -40,13 +40,13 @@ export default function App() {
     },
     [setImageSource, setIsDropZoneActive, setTextVisible, setProgressVisible, setProgressValue],
   );
-  const onProgress = React.useCallback(
+  const onProgress = useCallback(
     (e) => {
       setProgressValue((e.bytesLoaded / e.bytesTotal) * 100);
     },
     [setProgressValue],
   );
-  const onUploadStarted = React.useCallback(() => {
+  const onUploadStarted = useCallback(() => {
     setImageSource('');
     setProgressVisible(true);
   }, [setImageSource, setProgressVisible]);

--- a/JSDemos/Demos/FileUploader/FileSelection/React/App.tsx
+++ b/JSDemos/Demos/FileUploader/FileSelection/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import FileUploader from 'devextreme-react/file-uploader';
 import Button from 'devextreme-react/button';
 import TextBox from 'devextreme-react/text-box';
@@ -8,9 +8,9 @@ const firstNameLabel = { 'aria-label': 'First Name' };
 const lastNameLabel = { 'aria-label': 'Last Name' };
 
 export default function App() {
-  const formElement = React.useRef(null);
+  const formElement = useRef(null);
 
-  const onClick = React.useCallback(() => {
+  const onClick = useCallback(() => {
     notify('Uncomment the line to enable sending a form to the server.');
     // formElement.current.submit();
   }, []);

--- a/JSDemos/Demos/FileUploader/FileSelection/ReactJs/App.js
+++ b/JSDemos/Demos/FileUploader/FileSelection/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import FileUploader from 'devextreme-react/file-uploader';
 import Button from 'devextreme-react/button';
 import TextBox from 'devextreme-react/text-box';
@@ -7,8 +7,8 @@ import notify from 'devextreme/ui/notify';
 const firstNameLabel = { 'aria-label': 'First Name' };
 const lastNameLabel = { 'aria-label': 'Last Name' };
 export default function App() {
-  const formElement = React.useRef(null);
-  const onClick = React.useCallback(() => {
+  const formElement = useRef(null);
+  const onClick = useCallback(() => {
     notify('Uncomment the line to enable sending a form to the server.');
     // formElement.current.submit();
   }, []);

--- a/JSDemos/Demos/FileUploader/FileUploading/React/App.tsx
+++ b/JSDemos/Demos/FileUploader/FileUploading/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import FileUploader, { FileUploaderTypes } from 'devextreme-react/file-uploader';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 import CheckBox, { CheckBoxTypes } from 'devextreme-react/check-box';
@@ -13,24 +13,24 @@ const fileTypesSource = [
 ];
 
 export default function App() {
-  const [multiple, setMultiple] = React.useState(false);
-  const [uploadMode, setUploadMode] = React.useState<FileUploaderTypes.Properties['uploadMode']>('instantly');
-  const [accept, setAccept] = React.useState('*');
-  const [selectedFiles, setSelectedFiles] = React.useState([]);
+  const [multiple, setMultiple] = useState(false);
+  const [uploadMode, setUploadMode] = useState<FileUploaderTypes.Properties['uploadMode']>('instantly');
+  const [accept, setAccept] = useState('*');
+  const [selectedFiles, setSelectedFiles] = useState([]);
 
-  const onSelectedFilesChanged = React.useCallback((e: FileUploaderTypes.ValueChangedEvent) => {
+  const onSelectedFilesChanged = useCallback((e: FileUploaderTypes.ValueChangedEvent) => {
     setSelectedFiles(e.value);
   }, [setSelectedFiles]);
 
-  const onAcceptChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const onAcceptChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setAccept(e.value);
   }, [setAccept]);
 
-  const onUploadModeChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const onUploadModeChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setUploadMode(e.value);
   }, [setUploadMode]);
 
-  const onMultipleChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onMultipleChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setMultiple(e.value);
   }, [setMultiple]);
 

--- a/JSDemos/Demos/FileUploader/FileUploading/ReactJs/App.js
+++ b/JSDemos/Demos/FileUploader/FileUploading/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import FileUploader from 'devextreme-react/file-uploader';
 import SelectBox from 'devextreme-react/select-box';
 import CheckBox from 'devextreme-react/check-box';
@@ -12,29 +12,29 @@ const fileTypesSource = [
   { name: 'Videos', value: 'video/*' },
 ];
 export default function App() {
-  const [multiple, setMultiple] = React.useState(false);
-  const [uploadMode, setUploadMode] = React.useState('instantly');
-  const [accept, setAccept] = React.useState('*');
-  const [selectedFiles, setSelectedFiles] = React.useState([]);
-  const onSelectedFilesChanged = React.useCallback(
+  const [multiple, setMultiple] = useState(false);
+  const [uploadMode, setUploadMode] = useState('instantly');
+  const [accept, setAccept] = useState('*');
+  const [selectedFiles, setSelectedFiles] = useState([]);
+  const onSelectedFilesChanged = useCallback(
     (e) => {
       setSelectedFiles(e.value);
     },
     [setSelectedFiles],
   );
-  const onAcceptChanged = React.useCallback(
+  const onAcceptChanged = useCallback(
     (e) => {
       setAccept(e.value);
     },
     [setAccept],
   );
-  const onUploadModeChanged = React.useCallback(
+  const onUploadModeChanged = useCallback(
     (e) => {
       setUploadMode(e.value);
     },
     [setUploadMode],
   );
-  const onMultipleChanged = React.useCallback(
+  const onMultipleChanged = useCallback(
     (e) => {
       setMultiple(e.value);
     },

--- a/JSDemos/Demos/FilterBuilder/Customization/React/App.tsx
+++ b/JSDemos/Demos/FilterBuilder/Customization/React/App.tsx
@@ -1,25 +1,25 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import FilterBuilder, { CustomOperation, FilterBuilderTypes, ICustomOperationProps } from 'devextreme-react/filter-builder';
 import { filter, fields, groupOperations } from './data.ts';
 import { formatValue } from './helpers.ts';
 import { EditorComponent } from './EditorComponent.tsx';
 
 function App() {
-  const [value, setValue] = React.useState(filter);
-  const [filterText, setFilterText] = React.useState('');
-  const [dataSourceText, setDataSourceText] = React.useState('');
+  const [value, setValue] = useState(filter);
+  const [filterText, setFilterText] = useState('');
+  const [dataSourceText, setDataSourceText] = useState('');
 
-  const updateTexts = React.useCallback((e: FilterBuilderTypes.InitializedEvent) => {
+  const updateTexts = useCallback((e: FilterBuilderTypes.InitializedEvent) => {
     setFilterText(formatValue(e.component.option('value')));
     setDataSourceText(formatValue(e.component.getFilterExpression()));
   }, [setFilterText, setDataSourceText]);
 
-  const onValueChanged = React.useCallback((e: FilterBuilderTypes.ValueChangedEvent) => {
+  const onValueChanged = useCallback((e: FilterBuilderTypes.ValueChangedEvent) => {
     setValue(e.value);
     updateTexts(e);
   }, [updateTexts, setValue]);
 
-  const calculateFilterExpression: ICustomOperationProps['calculateFilterExpression'] = React.useCallback((filterValue, field) => (
+  const calculateFilterExpression: ICustomOperationProps['calculateFilterExpression'] = useCallback((filterValue, field) => (
     filterValue
       && filterValue.length
       && Array.prototype.concat

--- a/JSDemos/Demos/FilterBuilder/Customization/React/EditorComponent.tsx
+++ b/JSDemos/Demos/FilterBuilder/Customization/React/EditorComponent.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import TagBox, { TagBoxTypes } from 'devextreme-react/tag-box';
 import { categories, categoryLabel } from './data.ts';
 
 // eslint-disable-next-line no-unused-vars
 export const EditorComponent = (props: { data: { value: any, setValue: (value: any) => void } }) => {
-  const onValueChanged = React.useCallback((e: TagBoxTypes.ValueChangedEvent) => {
+  const onValueChanged = useCallback((e: TagBoxTypes.ValueChangedEvent) => {
     props.data.setValue(e.value && e.value.length ? e.value : null);
   }, [props.data]);
 

--- a/JSDemos/Demos/FilterBuilder/Customization/ReactJs/App.js
+++ b/JSDemos/Demos/FilterBuilder/Customization/ReactJs/App.js
@@ -1,28 +1,28 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import FilterBuilder, { CustomOperation } from 'devextreme-react/filter-builder';
 import { filter, fields, groupOperations } from './data.js';
 import { formatValue } from './helpers.js';
 import { EditorComponent } from './EditorComponent.js';
 
 function App() {
-  const [value, setValue] = React.useState(filter);
-  const [filterText, setFilterText] = React.useState('');
-  const [dataSourceText, setDataSourceText] = React.useState('');
-  const updateTexts = React.useCallback(
+  const [value, setValue] = useState(filter);
+  const [filterText, setFilterText] = useState('');
+  const [dataSourceText, setDataSourceText] = useState('');
+  const updateTexts = useCallback(
     (e) => {
       setFilterText(formatValue(e.component.option('value')));
       setDataSourceText(formatValue(e.component.getFilterExpression()));
     },
     [setFilterText, setDataSourceText],
   );
-  const onValueChanged = React.useCallback(
+  const onValueChanged = useCallback(
     (e) => {
       setValue(e.value);
       updateTexts(e);
     },
     [updateTexts, setValue],
   );
-  const calculateFilterExpression = React.useCallback(
+  const calculateFilterExpression = useCallback(
     (filterValue, field) =>
       filterValue
       && filterValue.length

--- a/JSDemos/Demos/FilterBuilder/Customization/ReactJs/EditorComponent.js
+++ b/JSDemos/Demos/FilterBuilder/Customization/ReactJs/EditorComponent.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import TagBox from 'devextreme-react/tag-box';
 import { categories, categoryLabel } from './data.js';
 // eslint-disable-next-line no-unused-vars
 export const EditorComponent = (props) => {
-  const onValueChanged = React.useCallback(
+  const onValueChanged = useCallback(
     (e) => {
       props.data.setValue(e.value && e.value.length ? e.value : null);
     },

--- a/JSDemos/Demos/FilterBuilder/WithDataGrid/React/App.tsx
+++ b/JSDemos/Demos/FilterBuilder/WithDataGrid/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import FilterBuilder, { FilterBuilderTypes } from 'devextreme-react/filter-builder';
 import Button from 'devextreme-react/button';
 import DataGrid from 'devextreme-react/data-grid';
@@ -27,14 +27,14 @@ const dataSource = new DataSource({
 });
 
 const App = () => {
-  const [value, setValue] = React.useState(filter);
-  const [gridFilterValue, setGridFilterValue] = React.useState(filter);
+  const [value, setValue] = useState(filter);
+  const [gridFilterValue, setGridFilterValue] = useState(filter);
 
-  const onValueChanged = React.useCallback((e: FilterBuilderTypes.ValueChangedEvent) => {
+  const onValueChanged = useCallback((e: FilterBuilderTypes.ValueChangedEvent) => {
     setValue(e.value);
   }, [setValue]);
 
-  const buttonClick = React.useCallback(() => {
+  const buttonClick = useCallback(() => {
     setGridFilterValue(value);
   }, [value, setGridFilterValue]);
 

--- a/JSDemos/Demos/FilterBuilder/WithDataGrid/ReactJs/App.js
+++ b/JSDemos/Demos/FilterBuilder/WithDataGrid/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import FilterBuilder from 'devextreme-react/filter-builder';
 import Button from 'devextreme-react/button';
 import DataGrid from 'devextreme-react/data-grid';
@@ -26,15 +26,15 @@ const dataSource = new DataSource({
   ],
 });
 const App = () => {
-  const [value, setValue] = React.useState(filter);
-  const [gridFilterValue, setGridFilterValue] = React.useState(filter);
-  const onValueChanged = React.useCallback(
+  const [value, setValue] = useState(filter);
+  const [gridFilterValue, setGridFilterValue] = useState(filter);
+  const onValueChanged = useCallback(
     (e) => {
       setValue(e.value);
     },
     [setValue],
   );
-  const buttonClick = React.useCallback(() => {
+  const buttonClick = useCallback(() => {
     setGridFilterValue(value);
   }, [value, setGridFilterValue]);
   return (

--- a/JSDemos/Demos/FilterBuilder/WithList/React/App.tsx
+++ b/JSDemos/Demos/FilterBuilder/WithList/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import FilterBuilder, { FilterBuilderTypes } from 'devextreme-react/filter-builder';
 import Button from 'devextreme-react/button';
 import List from 'devextreme-react/list';
@@ -7,22 +7,22 @@ import { filter, fields, products } from './data.ts';
 import CustomItem from './CustomItem.tsx';
 
 const App = () => {
-  const dataSource = React.useRef(new DataSource({
+  const dataSource = useRef(new DataSource({
     store: products,
   }));
-  const filterBuilderInstance = React.useRef(null);
-  const [value, setValue] = React.useState(filter);
+  const filterBuilderInstance = useRef(null);
+  const [value, setValue] = useState(filter);
 
   const setFilterBuilderInstance = (ref: { instance: any; }) => {
     filterBuilderInstance.current = ref.instance;
     refreshDataSource();
   };
 
-  const onValueChanged = React.useCallback((e: FilterBuilderTypes.ValueChangedEvent) => {
+  const onValueChanged = useCallback((e: FilterBuilderTypes.ValueChangedEvent) => {
     setValue(e.value);
   }, [setValue]);
 
-  const refreshDataSource = React.useCallback(() => {
+  const refreshDataSource = useCallback(() => {
     dataSource.current.filter(filterBuilderInstance.current.getFilterExpression());
     dataSource.current.load();
   }, []);

--- a/JSDemos/Demos/FilterBuilder/WithList/ReactJs/App.js
+++ b/JSDemos/Demos/FilterBuilder/WithList/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import FilterBuilder from 'devextreme-react/filter-builder';
 import Button from 'devextreme-react/button';
 import List from 'devextreme-react/list';
@@ -7,24 +7,24 @@ import { filter, fields, products } from './data.js';
 import CustomItem from './CustomItem.js';
 
 const App = () => {
-  const dataSource = React.useRef(
+  const dataSource = useRef(
     new DataSource({
       store: products,
     }),
   );
-  const filterBuilderInstance = React.useRef(null);
-  const [value, setValue] = React.useState(filter);
+  const filterBuilderInstance = useRef(null);
+  const [value, setValue] = useState(filter);
   const setFilterBuilderInstance = (ref) => {
     filterBuilderInstance.current = ref.instance;
     refreshDataSource();
   };
-  const onValueChanged = React.useCallback(
+  const onValueChanged = useCallback(
     (e) => {
       setValue(e.value);
     },
     [setValue],
   );
-  const refreshDataSource = React.useCallback(() => {
+  const refreshDataSource = useCallback(() => {
     dataSource.current.filter(filterBuilderInstance.current.getFilterExpression());
     dataSource.current.load();
   }, []);

--- a/JSDemos/Demos/FloatingActionButton/Overview/React/App.tsx
+++ b/JSDemos/Demos/FloatingActionButton/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import config from 'devextreme/core/config';
 import repaintFloatingActionButton from 'devextreme/ui/speed_dial_action/repaint_floating_action_button';
 import DataGrid, {
@@ -13,14 +13,14 @@ import {
 const optionDirections = ['auto', 'up', 'down'];
 
 const App = () => {
-  const [selectedRowIndex, setSelectedRowIndex] = React.useState(-1);
-  const gridRef = React.useRef(null);
+  const [selectedRowIndex, setSelectedRowIndex] = useState(-1);
+  const gridRef = useRef(null);
 
-  const selectedChanged = React.useCallback((e: DataGridTypes.SelectionChangedEvent) => {
+  const selectedChanged = useCallback((e: DataGridTypes.SelectionChangedEvent) => {
     setSelectedRowIndex(e.component.getRowIndexByKey(e.selectedRowKeys[0]));
   }, [setSelectedRowIndex]);
 
-  const directionChanged = React.useCallback((e: SelectBoxTypes.SelectionChangedEvent) => {
+  const directionChanged = useCallback((e: SelectBoxTypes.SelectionChangedEvent) => {
     config({
       floatingActionButtonConfig: directions[e.selectedItem],
     });
@@ -28,17 +28,17 @@ const App = () => {
     repaintFloatingActionButton();
   }, []);
 
-  const editRow = React.useCallback(() => {
+  const editRow = useCallback(() => {
     gridRef.current.instance.editRow(selectedRowIndex);
     gridRef.current.instance.deselectAll();
   }, [gridRef, selectedRowIndex]);
 
-  const deleteRow = React.useCallback(() => {
+  const deleteRow = useCallback(() => {
     gridRef.current.instance.deleteRow(selectedRowIndex);
     gridRef.current.instance.deselectAll();
   }, [gridRef, selectedRowIndex]);
 
-  const addRow = React.useCallback(() => {
+  const addRow = useCallback(() => {
     gridRef.current.instance.addRow();
     gridRef.current.instance.deselectAll();
   }, [gridRef]);

--- a/JSDemos/Demos/FloatingActionButton/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/FloatingActionButton/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import config from 'devextreme/core/config';
 import repaintFloatingActionButton from 'devextreme/ui/speed_dial_action/repaint_floating_action_button';
 import DataGrid, {
@@ -12,29 +12,29 @@ import {
 
 const optionDirections = ['auto', 'up', 'down'];
 const App = () => {
-  const [selectedRowIndex, setSelectedRowIndex] = React.useState(-1);
-  const gridRef = React.useRef(null);
-  const selectedChanged = React.useCallback(
+  const [selectedRowIndex, setSelectedRowIndex] = useState(-1);
+  const gridRef = useRef(null);
+  const selectedChanged = useCallback(
     (e) => {
       setSelectedRowIndex(e.component.getRowIndexByKey(e.selectedRowKeys[0]));
     },
     [setSelectedRowIndex],
   );
-  const directionChanged = React.useCallback((e) => {
+  const directionChanged = useCallback((e) => {
     config({
       floatingActionButtonConfig: directions[e.selectedItem],
     });
     repaintFloatingActionButton();
   }, []);
-  const editRow = React.useCallback(() => {
+  const editRow = useCallback(() => {
     gridRef.current.instance.editRow(selectedRowIndex);
     gridRef.current.instance.deselectAll();
   }, [gridRef, selectedRowIndex]);
-  const deleteRow = React.useCallback(() => {
+  const deleteRow = useCallback(() => {
     gridRef.current.instance.deleteRow(selectedRowIndex);
     gridRef.current.instance.deselectAll();
   }, [gridRef, selectedRowIndex]);
-  const addRow = React.useCallback(() => {
+  const addRow = useCallback(() => {
     gridRef.current.instance.addRow();
     gridRef.current.instance.deselectAll();
   }, [gridRef]);

--- a/JSDemos/Demos/Form/ColumnsAdaptability/React/App.tsx
+++ b/JSDemos/Demos/Form/ColumnsAdaptability/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import CheckBox, { CheckBoxTypes } from 'devextreme-react/check-box';
 import Form from 'devextreme-react/form';
 import employee from './data.ts';
@@ -9,9 +9,9 @@ const colCountByScreen = {
 };
 
 const App = () => {
-  const [calculateColCountAutomatically, setCalculateColCountAutomatically] = React.useState(false);
+  const [calculateColCountAutomatically, setCalculateColCountAutomatically] = useState(false);
 
-  const onCalculateColCountAutomaticallyChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onCalculateColCountAutomaticallyChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setCalculateColCountAutomatically(e.value);
   }, [setCalculateColCountAutomatically]);
 

--- a/JSDemos/Demos/Form/ColumnsAdaptability/ReactJs/App.js
+++ b/JSDemos/Demos/Form/ColumnsAdaptability/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import CheckBox from 'devextreme-react/check-box';
 import Form from 'devextreme-react/form';
 import employee from './data.js';
@@ -8,8 +8,8 @@ const colCountByScreen = {
   md: 4,
 };
 const App = () => {
-  const [calculateColCountAutomatically, setCalculateColCountAutomatically] = React.useState(false);
-  const onCalculateColCountAutomaticallyChanged = React.useCallback(
+  const [calculateColCountAutomatically, setCalculateColCountAutomatically] = useState(false);
+  const onCalculateColCountAutomaticallyChanged = useCallback(
     (e) => {
       setCalculateColCountAutomatically(e.value);
     },

--- a/JSDemos/Demos/Form/CustomizeItem/React/App.tsx
+++ b/JSDemos/Demos/Form/CustomizeItem/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import 'devextreme-react/text-area';
 
 import Form, {
@@ -31,7 +31,7 @@ const notesEditorOptions = { height: 90, maxLength: 200 };
 const phoneEditorOptions = { mask: '+1 (X00) 000-0000', maskRules: { X: /[02-9]/ } };
 
 const App = () => {
-  const validateForm = React.useCallback((e: FormTypes.ContentReadyEvent) => {
+  const validateForm = useCallback((e: FormTypes.ContentReadyEvent) => {
     e.component.validate();
   }, []);
 

--- a/JSDemos/Demos/Form/CustomizeItem/ReactJs/App.js
+++ b/JSDemos/Demos/Form/CustomizeItem/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import 'devextreme-react/text-area';
 import Form, { Item, GroupItem, Label } from 'devextreme-react/form';
 import LabelTemplate from './LabelTemplate.js';
@@ -17,7 +17,7 @@ const birthDateEditorOptions = { width: '100%', disabled: true };
 const notesEditorOptions = { height: 90, maxLength: 200 };
 const phoneEditorOptions = { mask: '+1 (X00) 000-0000', maskRules: { X: /[02-9]/ } };
 const App = () => {
-  const validateForm = React.useCallback((e) => {
+  const validateForm = useCallback((e) => {
     e.component.validate();
   }, []);
   return (

--- a/JSDemos/Demos/Form/Overview/React/App.tsx
+++ b/JSDemos/Demos/Form/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import CheckBox, { CheckBoxTypes } from 'devextreme-react/check-box';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 import NumberBox, { NumberBoxTypes } from 'devextreme-react/number-box';
@@ -18,44 +18,44 @@ const minCountWidthLabel = { 'aria-label': 'Min Count Width' };
 
 const App = () => {
   const companies = service.getCompanies();
-  const [labelMode, setLabelMode] = React.useState<FormTypes.Properties['labelMode']>('floating');
-  const [labelLocation, setLabelLocation] = React.useState<FormTypes.Properties['labelLocation']>('left');
-  const [readOnly, setReadOnly] = React.useState(false);
-  const [showColon, setShowColon] = React.useState(true);
-  const [minColWidth, setMinColWidth] = React.useState(300);
-  const [colCount, setColCount] = React.useState(2);
-  const [company, setCompany] = React.useState(companies[0]);
-  const [width, setWidth] = React.useState();
+  const [labelMode, setLabelMode] = useState<FormTypes.Properties['labelMode']>('floating');
+  const [labelLocation, setLabelLocation] = useState<FormTypes.Properties['labelLocation']>('left');
+  const [readOnly, setReadOnly] = useState(false);
+  const [showColon, setShowColon] = useState(true);
+  const [minColWidth, setMinColWidth] = useState(300);
+  const [colCount, setColCount] = useState(2);
+  const [company, setCompany] = useState(companies[0]);
+  const [width, setWidth] = useState();
 
-  const onCompanyChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const onCompanyChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setCompany(e.value);
   }, [setCompany]);
 
-  const onLabelModeChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const onLabelModeChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setLabelMode(e.value);
   }, [setLabelMode]);
 
-  const onLabelLocationChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const onLabelLocationChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setLabelLocation(e.value);
   }, [setLabelLocation]);
 
-  const onReadOnlyChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onReadOnlyChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setReadOnly(e.value);
   }, [setReadOnly]);
 
-  const onShowColonChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onShowColonChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setShowColon(e.value);
   }, [setShowColon]);
 
-  const onMinColWidthChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const onMinColWidthChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setMinColWidth(e.value);
   }, [setMinColWidth]);
 
-  const onColumnsCountChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const onColumnsCountChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setColCount(e.value);
   }, [setColCount]);
 
-  const onFormWidthChanged = React.useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
+  const onFormWidthChanged = useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
     setWidth(e.value);
   }, [setWidth]);
 

--- a/JSDemos/Demos/Form/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/Form/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import CheckBox from 'devextreme-react/check-box';
 import SelectBox from 'devextreme-react/select-box';
 import NumberBox from 'devextreme-react/number-box';
@@ -17,57 +17,57 @@ const columnCountLabel = { 'aria-label': 'Column Count' };
 const minCountWidthLabel = { 'aria-label': 'Min Count Width' };
 const App = () => {
   const companies = service.getCompanies();
-  const [labelMode, setLabelMode] = React.useState('floating');
-  const [labelLocation, setLabelLocation] = React.useState('left');
-  const [readOnly, setReadOnly] = React.useState(false);
-  const [showColon, setShowColon] = React.useState(true);
-  const [minColWidth, setMinColWidth] = React.useState(300);
-  const [colCount, setColCount] = React.useState(2);
-  const [company, setCompany] = React.useState(companies[0]);
-  const [width, setWidth] = React.useState();
-  const onCompanyChanged = React.useCallback(
+  const [labelMode, setLabelMode] = useState('floating');
+  const [labelLocation, setLabelLocation] = useState('left');
+  const [readOnly, setReadOnly] = useState(false);
+  const [showColon, setShowColon] = useState(true);
+  const [minColWidth, setMinColWidth] = useState(300);
+  const [colCount, setColCount] = useState(2);
+  const [company, setCompany] = useState(companies[0]);
+  const [width, setWidth] = useState();
+  const onCompanyChanged = useCallback(
     (e) => {
       setCompany(e.value);
     },
     [setCompany],
   );
-  const onLabelModeChanged = React.useCallback(
+  const onLabelModeChanged = useCallback(
     (e) => {
       setLabelMode(e.value);
     },
     [setLabelMode],
   );
-  const onLabelLocationChanged = React.useCallback(
+  const onLabelLocationChanged = useCallback(
     (e) => {
       setLabelLocation(e.value);
     },
     [setLabelLocation],
   );
-  const onReadOnlyChanged = React.useCallback(
+  const onReadOnlyChanged = useCallback(
     (e) => {
       setReadOnly(e.value);
     },
     [setReadOnly],
   );
-  const onShowColonChanged = React.useCallback(
+  const onShowColonChanged = useCallback(
     (e) => {
       setShowColon(e.value);
     },
     [setShowColon],
   );
-  const onMinColWidthChanged = React.useCallback(
+  const onMinColWidthChanged = useCallback(
     (e) => {
       setMinColWidth(e.value);
     },
     [setMinColWidth],
   );
-  const onColumnsCountChanged = React.useCallback(
+  const onColumnsCountChanged = useCallback(
     (e) => {
       setColCount(e.value);
     },
     [setColCount],
   );
-  const onFormWidthChanged = React.useCallback(
+  const onFormWidthChanged = useCallback(
     (e) => {
       setWidth(e.value);
     },

--- a/JSDemos/Demos/Form/UpdateItemsDynamically/React/App.tsx
+++ b/JSDemos/Demos/Form/UpdateItemsDynamically/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import 'devextreme-react/text-area';
 import Form, {
   GroupItem, SimpleItem, Label, ButtonItem,
@@ -8,11 +8,11 @@ import service from './data.ts';
 const employee = service.getEmployee();
 
 const App = () => {
-  const [phones, setPhones] = React.useState(employee.Phones);
-  const [isHomeAddressVisible, setIsHomeAddressVisible] = React.useState(true);
-  const formData = React.useMemo(() => ({ ...employee, Phones: phones }), [phones]);
+  const [phones, setPhones] = useState(employee.Phones);
+  const [isHomeAddressVisible, setIsHomeAddressVisible] = useState(true);
+  const formData = useMemo(() => ({ ...employee, Phones: phones }), [phones]);
 
-  const CheckBoxOptions = React.useMemo(() => ({
+  const CheckBoxOptions = useMemo(() => ({
     text: 'Show Address',
     value: isHomeAddressVisible,
     onValueChanged: (e) => {
@@ -20,7 +20,7 @@ const App = () => {
     },
   }), [setIsHomeAddressVisible, isHomeAddressVisible]);
 
-  const generateNewPhoneOptions = React.useCallback((index: number) => ({
+  const generateNewPhoneOptions = useCallback((index: number) => ({
     mask: '+1 (X00) 000-0000',
     maskRules: { X: /[01-9]/ },
     buttons: [{
@@ -37,7 +37,7 @@ const App = () => {
     }],
   }), [phones]);
 
-  const PhoneOptions = React.useMemo(() => {
+  const PhoneOptions = useMemo(() => {
     const options: any[] = [];
     for (let i = 0; i < phones.length; i += 1) {
       options.push(generateNewPhoneOptions(i));
@@ -45,7 +45,7 @@ const App = () => {
     return options;
   }, [phones, generateNewPhoneOptions]);
 
-  const PhoneButtonOptions = React.useMemo(() => ({
+  const PhoneButtonOptions = useMemo(() => ({
     icon: 'add',
     text: 'Add phone',
     onClick: () => {

--- a/JSDemos/Demos/Form/UpdateItemsDynamically/ReactJs/App.js
+++ b/JSDemos/Demos/Form/UpdateItemsDynamically/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import 'devextreme-react/text-area';
 import Form, {
   GroupItem, SimpleItem, Label, ButtonItem,
@@ -7,10 +7,10 @@ import service from './data.js';
 
 const employee = service.getEmployee();
 const App = () => {
-  const [phones, setPhones] = React.useState(employee.Phones);
-  const [isHomeAddressVisible, setIsHomeAddressVisible] = React.useState(true);
-  const formData = React.useMemo(() => ({ ...employee, Phones: phones }), [phones]);
-  const CheckBoxOptions = React.useMemo(
+  const [phones, setPhones] = useState(employee.Phones);
+  const [isHomeAddressVisible, setIsHomeAddressVisible] = useState(true);
+  const formData = useMemo(() => ({ ...employee, Phones: phones }), [phones]);
+  const CheckBoxOptions = useMemo(
     () => ({
       text: 'Show Address',
       value: isHomeAddressVisible,
@@ -20,7 +20,7 @@ const App = () => {
     }),
     [setIsHomeAddressVisible, isHomeAddressVisible],
   );
-  const generateNewPhoneOptions = React.useCallback(
+  const generateNewPhoneOptions = useCallback(
     (index) => ({
       mask: '+1 (X00) 000-0000',
       maskRules: { X: /[01-9]/ },
@@ -41,14 +41,14 @@ const App = () => {
     }),
     [phones],
   );
-  const PhoneOptions = React.useMemo(() => {
+  const PhoneOptions = useMemo(() => {
     const options = [];
     for (let i = 0; i < phones.length; i += 1) {
       options.push(generateNewPhoneOptions(i));
     }
     return options;
   }, [phones, generateNewPhoneOptions]);
-  const PhoneButtonOptions = React.useMemo(
+  const PhoneButtonOptions = useMemo(
     () => ({
       icon: 'add',
       text: 'Add phone',

--- a/JSDemos/Demos/Form/Validation/React/App.tsx
+++ b/JSDemos/Demos/Form/Validation/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import Form, {
   ButtonItem,
   GroupItem,
@@ -130,9 +130,9 @@ const registerButtonOptions = {
 };
 
 function App() {
-  const formRef = React.useRef<Form>(null);
+  const formRef = useRef<Form>(null);
 
-  const [resetButtonOptions, setResetButtonOptions] = React.useState({
+  const [resetButtonOptions, setResetButtonOptions] = useState({
     disabled: true,
     icon: 'refresh',
     text: 'Reset',
@@ -142,12 +142,12 @@ function App() {
     },
   });
 
-  const changePasswordMode = React.useCallback((name) => {
+  const changePasswordMode = useCallback((name) => {
     const editor = formRef.current.instance.getEditor(name);
     editor.option('mode', editor.option('mode') === 'text' ? 'password' : 'text');
   }, []);
 
-  const getPasswordOptions = React.useCallback(() => ({
+  const getPasswordOptions = useCallback(() => ({
     mode: 'password',
     valueChangeEvent: 'keyup',
     onValueChanged: () => {
@@ -170,7 +170,7 @@ function App() {
     ],
   }), [changePasswordMode]);
 
-  const getConfirmOptions = React.useCallback(() => ({
+  const getConfirmOptions = useCallback(() => ({
     mode: 'password',
     valueChangeEvent: 'keyup',
     buttons: [
@@ -186,7 +186,7 @@ function App() {
     ],
   }), [changePasswordMode]);
 
-  const handleSubmit = React.useCallback((e: { preventDefault: () => void; }) => {
+  const handleSubmit = useCallback((e: { preventDefault: () => void; }) => {
     notify({
       message: 'You have submitted the form',
       position: {
@@ -197,7 +197,7 @@ function App() {
     e.preventDefault();
   }, []);
 
-  const onOptionChanged = React.useCallback((e: FormTypes.OptionChangedEvent) => {
+  const onOptionChanged = useCallback((e: FormTypes.OptionChangedEvent) => {
     if (e.name === 'isDirty') {
       setResetButtonOptions({ ...resetButtonOptions, disabled: !e.value });
     }

--- a/JSDemos/Demos/Form/Validation/ReactJs/App.js
+++ b/JSDemos/Demos/Form/Validation/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import Form, {
   ButtonItem,
   GroupItem,
@@ -103,8 +103,8 @@ const registerButtonOptions = {
   width: '120px',
 };
 function App() {
-  const formRef = React.useRef(null);
-  const [resetButtonOptions, setResetButtonOptions] = React.useState({
+  const formRef = useRef(null);
+  const [resetButtonOptions, setResetButtonOptions] = useState({
     disabled: true,
     icon: 'refresh',
     text: 'Reset',
@@ -113,11 +113,11 @@ function App() {
       formRef.current.instance.reset();
     },
   });
-  const changePasswordMode = React.useCallback((name) => {
+  const changePasswordMode = useCallback((name) => {
     const editor = formRef.current.instance.getEditor(name);
     editor.option('mode', editor.option('mode') === 'text' ? 'password' : 'text');
   }, []);
-  const getPasswordOptions = React.useCallback(
+  const getPasswordOptions = useCallback(
     () => ({
       mode: 'password',
       valueChangeEvent: 'keyup',
@@ -142,7 +142,7 @@ function App() {
     }),
     [changePasswordMode],
   );
-  const getConfirmOptions = React.useCallback(
+  const getConfirmOptions = useCallback(
     () => ({
       mode: 'password',
       valueChangeEvent: 'keyup',
@@ -160,7 +160,7 @@ function App() {
     }),
     [changePasswordMode],
   );
-  const handleSubmit = React.useCallback((e) => {
+  const handleSubmit = useCallback((e) => {
     notify(
       {
         message: 'You have submitted the form',
@@ -174,7 +174,7 @@ function App() {
     );
     e.preventDefault();
   }, []);
-  const onOptionChanged = React.useCallback(
+  const onOptionChanged = useCallback(
     (e) => {
       if (e.name === 'isDirty') {
         setResetButtonOptions({ ...resetButtonOptions, disabled: !e.value });

--- a/JSDemos/Demos/Gallery/Overview/React/App.tsx
+++ b/JSDemos/Demos/Gallery/Overview/React/App.tsx
@@ -1,27 +1,27 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Gallery from 'devextreme-react/gallery';
 import CheckBox, { CheckBoxTypes } from 'devextreme-react/check-box';
 import { gallery } from './data.ts';
 
 const App = () => {
-  const [loop, setLoop] = React.useState(true);
-  const [slideShow, setSlideShow] = React.useState(true);
-  const [showNavButtons, setShowNavButtons] = React.useState(true);
-  const [showIndicator, setShowIndicator] = React.useState(true);
+  const [loop, setLoop] = useState(true);
+  const [slideShow, setSlideShow] = useState(true);
+  const [showNavButtons, setShowNavButtons] = useState(true);
+  const [showIndicator, setShowIndicator] = useState(true);
 
-  const onLoopChanged = React.useCallback((data: CheckBoxTypes.ValueChangedEvent) => {
+  const onLoopChanged = useCallback((data: CheckBoxTypes.ValueChangedEvent) => {
     setLoop(data.value);
   }, [setLoop]);
 
-  const onSlideShowChanged = React.useCallback((data: CheckBoxTypes.ValueChangedEvent) => {
+  const onSlideShowChanged = useCallback((data: CheckBoxTypes.ValueChangedEvent) => {
     setSlideShow(data.value);
   }, [setSlideShow]);
 
-  const onShowNavButtonsChanged = React.useCallback((data: CheckBoxTypes.ValueChangedEvent) => {
+  const onShowNavButtonsChanged = useCallback((data: CheckBoxTypes.ValueChangedEvent) => {
     setShowNavButtons(data.value);
   }, [setShowNavButtons]);
 
-  const onShowIndicatorChanged = React.useCallback((data: CheckBoxTypes.ValueChangedEvent) => {
+  const onShowIndicatorChanged = useCallback((data: CheckBoxTypes.ValueChangedEvent) => {
     setShowIndicator(data.value);
   }, [setShowIndicator]);
 

--- a/JSDemos/Demos/Gallery/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/Gallery/Overview/ReactJs/App.js
@@ -1,32 +1,32 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Gallery from 'devextreme-react/gallery';
 import CheckBox from 'devextreme-react/check-box';
 import { gallery } from './data.js';
 
 const App = () => {
-  const [loop, setLoop] = React.useState(true);
-  const [slideShow, setSlideShow] = React.useState(true);
-  const [showNavButtons, setShowNavButtons] = React.useState(true);
-  const [showIndicator, setShowIndicator] = React.useState(true);
-  const onLoopChanged = React.useCallback(
+  const [loop, setLoop] = useState(true);
+  const [slideShow, setSlideShow] = useState(true);
+  const [showNavButtons, setShowNavButtons] = useState(true);
+  const [showIndicator, setShowIndicator] = useState(true);
+  const onLoopChanged = useCallback(
     (data) => {
       setLoop(data.value);
     },
     [setLoop],
   );
-  const onSlideShowChanged = React.useCallback(
+  const onSlideShowChanged = useCallback(
     (data) => {
       setSlideShow(data.value);
     },
     [setSlideShow],
   );
-  const onShowNavButtonsChanged = React.useCallback(
+  const onShowNavButtonsChanged = useCallback(
     (data) => {
       setShowNavButtons(data.value);
     },
     [setShowNavButtons],
   );
-  const onShowIndicatorChanged = React.useCallback(
+  const onShowIndicatorChanged = useCallback(
     (data) => {
       setShowIndicator(data.value);
     },

--- a/JSDemos/Demos/Gantt/ChartAppearance/React/App.tsx
+++ b/JSDemos/Demos/Gantt/ChartAppearance/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Gantt, {
   Tasks, Dependencies, Resources, ResourceAssignments, Column, Editing, IGanttOptions,
 } from 'devextreme-react/gantt';
@@ -30,7 +30,7 @@ const initialGanttConfig = {
 };
 
 function App() {
-  const [ganttConfig, setGanttConfig] = React.useState(initialGanttConfig);
+  const [ganttConfig, setGanttConfig] = useState(initialGanttConfig);
   const updateGanttConfig = (value: Partial<typeof initialGanttConfig>) => setGanttConfig({
     ...ganttConfig,
     ...value,

--- a/JSDemos/Demos/Gantt/ChartAppearance/ReactJs/App.js
+++ b/JSDemos/Demos/Gantt/ChartAppearance/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Gantt, {
   Tasks,
   Dependencies,
@@ -38,7 +38,7 @@ const initialGanttConfig = {
   endDateRange: new Date(2019, 11, 1),
 };
 function App() {
-  const [ganttConfig, setGanttConfig] = React.useState(initialGanttConfig);
+  const [ganttConfig, setGanttConfig] = useState(initialGanttConfig);
   const updateGanttConfig = (value) =>
     setGanttConfig({
       ...ganttConfig,

--- a/JSDemos/Demos/Gantt/ContextMenu/React/App.tsx
+++ b/JSDemos/Demos/Gantt/ContextMenu/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Gantt, {
   Tasks, Dependencies, Resources, ResourceAssignments, Column, Editing, ContextMenu, IContextMenuProps,
 } from 'devextreme-react/gantt';
@@ -8,7 +8,7 @@ import {
 } from './data.ts';
 
 function App() {
-  const [ganttConfig, setGanttConfig] = React.useState({
+  const [ganttConfig, setGanttConfig] = useState({
     showResources: true,
     disableContextMenu: false,
     contextMenuItems: getContextMenuItems(),

--- a/JSDemos/Demos/Gantt/ContextMenu/ReactJs/App.js
+++ b/JSDemos/Demos/Gantt/ContextMenu/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Gantt, {
   Tasks,
   Dependencies,
@@ -14,7 +14,7 @@ import {
 } from './data.js';
 
 function App() {
-  const [ganttConfig, setGanttConfig] = React.useState({
+  const [ganttConfig, setGanttConfig] = useState({
     showResources: true,
     disableContextMenu: false,
     contextMenuItems: getContextMenuItems(),

--- a/JSDemos/Demos/Gantt/Sorting/React/App.tsx
+++ b/JSDemos/Demos/Gantt/Sorting/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Gantt, {
   Tasks, Dependencies, Resources, ResourceAssignments, Column, Editing, Sorting, ISortingProps,
 } from 'devextreme-react/gantt';
@@ -11,7 +11,7 @@ import {
 const sortingModeValues: ISortingProps['mode'][] = ['single', 'multiple', 'none'];
 const sortingMode: ISortingProps['mode'] = 'single';
 function App() {
-  const [ganttConfig, setGanttConfig] = React.useState({
+  const [ganttConfig, setGanttConfig] = useState({
     sortingMode,
     showSortIndexes: false,
     showSortIndexesDisabled: true,

--- a/JSDemos/Demos/Gantt/Sorting/ReactJs/App.js
+++ b/JSDemos/Demos/Gantt/Sorting/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Gantt, {
   Tasks,
   Dependencies,
@@ -17,7 +17,7 @@ import {
 const sortingModeValues = ['single', 'multiple', 'none'];
 const sortingMode = 'single';
 function App() {
-  const [ganttConfig, setGanttConfig] = React.useState({
+  const [ganttConfig, setGanttConfig] = useState({
     sortingMode,
     showSortIndexes: false,
     showSortIndexesDisabled: true,

--- a/JSDemos/Demos/Gantt/Toolbar/React/App.tsx
+++ b/JSDemos/Demos/Gantt/Toolbar/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import Gantt, {
   Tasks, Dependencies, Resources, ResourceAssignments, Column, Editing, Toolbar, Item,
@@ -10,25 +10,25 @@ import {
 } from './data.ts';
 
 function App() {
-  const [ganttConfig, setGanttConfig] = React.useState({
+  const [ganttConfig, setGanttConfig] = useState({
     popupVisible: false,
   });
 
-  const aboutButtonClick = React.useCallback(() => {
+  const aboutButtonClick = useCallback(() => {
     setGanttConfig({
       ...ganttConfig,
       popupVisible: true,
     });
   }, [ganttConfig]);
 
-  const getAboutButtonOptions = React.useCallback(() => ({
+  const getAboutButtonOptions = useCallback(() => ({
     text: 'About',
     icon: 'info',
     stylingMode: 'text',
     onClick: () => { aboutButtonClick(); },
   }), [aboutButtonClick]);
 
-  const onHiding = React.useCallback(() => {
+  const onHiding = useCallback(() => {
     setGanttConfig({
       ...ganttConfig,
       popupVisible: false,

--- a/JSDemos/Demos/Gantt/Toolbar/ReactJs/App.js
+++ b/JSDemos/Demos/Gantt/Toolbar/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Gantt, {
   Tasks,
   Dependencies,
@@ -15,16 +15,16 @@ import {
 } from './data.js';
 
 function App() {
-  const [ganttConfig, setGanttConfig] = React.useState({
+  const [ganttConfig, setGanttConfig] = useState({
     popupVisible: false,
   });
-  const aboutButtonClick = React.useCallback(() => {
+  const aboutButtonClick = useCallback(() => {
     setGanttConfig({
       ...ganttConfig,
       popupVisible: true,
     });
   }, [ganttConfig]);
-  const getAboutButtonOptions = React.useCallback(
+  const getAboutButtonOptions = useCallback(
     () => ({
       text: 'About',
       icon: 'info',
@@ -35,7 +35,7 @@ function App() {
     }),
     [aboutButtonClick],
   );
-  const onHiding = React.useCallback(() => {
+  const onHiding = useCallback(() => {
     setGanttConfig({
       ...ganttConfig,
       popupVisible: false,

--- a/JSDemos/Demos/Gantt/Validation/React/App.tsx
+++ b/JSDemos/Demos/Gantt/Validation/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Gantt, {
   Tasks, Dependencies, Column, Validation, Editing,
 } from 'devextreme-react/gantt';
@@ -6,7 +6,7 @@ import CheckBox, { ICheckBoxOptions } from 'devextreme-react/check-box';
 import { tasks, dependencies } from './data.ts';
 
 function App() {
-  const [ganttConfig, setGanttConfig] = React.useState({
+  const [ganttConfig, setGanttConfig] = useState({
     autoUpdateParentTasks: true,
     validateDependencies: true,
     enablePredecessorGap: true,

--- a/JSDemos/Demos/Gantt/Validation/ReactJs/App.js
+++ b/JSDemos/Demos/Gantt/Validation/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Gantt, {
   Tasks, Dependencies, Column, Validation, Editing,
 } from 'devextreme-react/gantt';
@@ -6,7 +6,7 @@ import CheckBox from 'devextreme-react/check-box';
 import { tasks, dependencies } from './data.js';
 
 function App() {
-  const [ganttConfig, setGanttConfig] = React.useState({
+  const [ganttConfig, setGanttConfig] = useState({
     autoUpdateParentTasks: true,
     validateDependencies: true,
     enablePredecessorGap: true,

--- a/JSDemos/Demos/Gauges/Overview/React/App.tsx
+++ b/JSDemos/Demos/Gauges/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import CircularGauge, {
   Geometry,
   Scale as CircularScale,
@@ -27,9 +27,9 @@ function CenterTemplate(gauge) {
 }
 
 function App() {
-  const [speedValue, setSpeedValue] = React.useState(40);
+  const [speedValue, setSpeedValue] = useState(40);
 
-  const handleSpeedChange = React.useCallback(({ value }) => {
+  const handleSpeedChange = useCallback(({ value }) => {
     setSpeedValue(value);
   }, [setSpeedValue]);
 

--- a/JSDemos/Demos/Gauges/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/Gauges/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import CircularGauge, {
   Geometry,
   Scale as CircularScale,
@@ -42,8 +42,8 @@ function CenterTemplate(gauge) {
   );
 }
 function App() {
-  const [speedValue, setSpeedValue] = React.useState(40);
-  const handleSpeedChange = React.useCallback(
+  const [speedValue, setSpeedValue] = useState(40);
+  const handleSpeedChange = useCallback(
     ({ value }) => {
       setSpeedValue(value);
     },

--- a/JSDemos/Demos/Gauges/UpdateBarGaugeDataAtRuntime/React/App.tsx
+++ b/JSDemos/Demos/Gauges/UpdateBarGaugeDataAtRuntime/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { BarGauge, Label } from 'devextreme-react/bar-gauge';
 import { SelectBox } from 'devextreme-react/select-box';
 import { colors, colorLabel } from './data.ts';
@@ -15,10 +15,10 @@ function getBasicColors(value: string | any[]) {
 }
 
 function App() {
-  const [basis, setBasis] = React.useState(getBasicColors(colors[0].code));
-  const [currentColor, setCurrentColor] = React.useState(colors[0].code);
+  const [basis, setBasis] = useState(getBasicColors(colors[0].code));
+  const [currentColor, setCurrentColor] = useState(colors[0].code);
 
-  const onSelectionChanged = React.useCallback(({ selectedItem: { code } }) => {
+  const onSelectionChanged = useCallback(({ selectedItem: { code } }) => {
     setCurrentColor(code);
     setBasis(getBasicColors(code));
   }, [setCurrentColor, setBasis]);

--- a/JSDemos/Demos/Gauges/UpdateBarGaugeDataAtRuntime/ReactJs/App.js
+++ b/JSDemos/Demos/Gauges/UpdateBarGaugeDataAtRuntime/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { BarGauge, Label } from 'devextreme-react/bar-gauge';
 import { SelectBox } from 'devextreme-react/select-box';
 import { colors, colorLabel } from './data.js';
@@ -9,9 +9,9 @@ function getBasicColors(value) {
   return [(code >> 16) & 0xff, (code >> 8) & 0xff, code & 0xff];
 }
 function App() {
-  const [basis, setBasis] = React.useState(getBasicColors(colors[0].code));
-  const [currentColor, setCurrentColor] = React.useState(colors[0].code);
-  const onSelectionChanged = React.useCallback(
+  const [basis, setBasis] = useState(getBasicColors(colors[0].code));
+  const [currentColor, setCurrentColor] = useState(colors[0].code);
+  const onSelectionChanged = useCallback(
     ({ selectedItem: { code } }) => {
       setCurrentColor(code);
       setBasis(getBasicColors(code));

--- a/JSDemos/Demos/Gauges/UpdateCircularGaugeDataAtRuntime/React/App.tsx
+++ b/JSDemos/Demos/Gauges/UpdateCircularGaugeDataAtRuntime/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   CircularGauge, Scale, Label, RangeContainer, Range, Tooltip, Title, Font,
 } from 'devextreme-react/circular-gauge';
@@ -10,10 +10,10 @@ function customizeText({ valueText }) {
 }
 
 function App() {
-  const [value, setValue] = React.useState(dataSource[0].mean);
-  const [subvalues, setSubvalues] = React.useState([dataSource[0].min, dataSource[0].max]);
+  const [value, setValue] = useState(dataSource[0].mean);
+  const [subvalues, setSubvalues] = useState([dataSource[0].min, dataSource[0].max]);
 
-  const onSelectionChanged = React.useCallback(({ selectedItem }) => {
+  const onSelectionChanged = useCallback(({ selectedItem }) => {
     setValue(selectedItem.mean);
     setSubvalues([selectedItem.min, selectedItem.max]);
   }, [setValue, setSubvalues]);

--- a/JSDemos/Demos/Gauges/UpdateCircularGaugeDataAtRuntime/ReactJs/App.js
+++ b/JSDemos/Demos/Gauges/UpdateCircularGaugeDataAtRuntime/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   CircularGauge,
   Scale,
@@ -16,9 +16,9 @@ function customizeText({ valueText }) {
   return `${valueText} °C`;
 }
 function App() {
-  const [value, setValue] = React.useState(dataSource[0].mean);
-  const [subvalues, setSubvalues] = React.useState([dataSource[0].min, dataSource[0].max]);
-  const onSelectionChanged = React.useCallback(
+  const [value, setValue] = useState(dataSource[0].mean);
+  const [subvalues, setSubvalues] = useState([dataSource[0].min, dataSource[0].max]);
+  const onSelectionChanged = useCallback(
     ({ selectedItem }) => {
       setValue(selectedItem.mean);
       setSubvalues([selectedItem.min, selectedItem.max]);

--- a/JSDemos/Demos/Gauges/UpdateLinearGaugeDataAtRuntime/React/App.tsx
+++ b/JSDemos/Demos/Gauges/UpdateLinearGaugeDataAtRuntime/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   LinearGauge, Title, Font, Geometry, Scale, RangeContainer, Range, ValueIndicator, Label,
 } from 'devextreme-react/linear-gauge';
@@ -13,12 +13,12 @@ const pressureLabelFormat = {
 };
 
 function App() {
-  const [selectBoxValue, setSelectBoxValue] = React.useState(cities[0].data);
-  const [temperature, setTemperature] = React.useState(cities[0].data.temperature);
-  const [humidity, setHumidity] = React.useState(cities[0].data.humidity);
-  const [pressure, setPressure] = React.useState(cities[0].data.pressure);
+  const [selectBoxValue, setSelectBoxValue] = useState(cities[0].data);
+  const [temperature, setTemperature] = useState(cities[0].data.temperature);
+  const [humidity, setHumidity] = useState(cities[0].data.humidity);
+  const [pressure, setPressure] = useState(cities[0].data.pressure);
 
-  const onSelectionChanged = React.useCallback((e: SelectBoxTypes.SelectionChangedEvent) => {
+  const onSelectionChanged = useCallback((e: SelectBoxTypes.SelectionChangedEvent) => {
     const weatherData = e.selectedItem.data;
     setSelectBoxValue(weatherData);
     setTemperature(weatherData.temperature);

--- a/JSDemos/Demos/Gauges/UpdateLinearGaugeDataAtRuntime/ReactJs/App.js
+++ b/JSDemos/Demos/Gauges/UpdateLinearGaugeDataAtRuntime/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   LinearGauge,
   Title,
@@ -19,11 +19,11 @@ const pressureLabelFormat = {
   type: 'decimal',
 };
 function App() {
-  const [selectBoxValue, setSelectBoxValue] = React.useState(cities[0].data);
-  const [temperature, setTemperature] = React.useState(cities[0].data.temperature);
-  const [humidity, setHumidity] = React.useState(cities[0].data.humidity);
-  const [pressure, setPressure] = React.useState(cities[0].data.pressure);
-  const onSelectionChanged = React.useCallback(
+  const [selectBoxValue, setSelectBoxValue] = useState(cities[0].data);
+  const [temperature, setTemperature] = useState(cities[0].data.temperature);
+  const [humidity, setHumidity] = useState(cities[0].data.humidity);
+  const [pressure, setPressure] = useState(cities[0].data.pressure);
+  const onSelectionChanged = useCallback(
     (e) => {
       const weatherData = e.selectedItem.data;
       setSelectBoxValue(weatherData);

--- a/JSDemos/Demos/Gauges/ValueIndicatorsAPI/React/App.tsx
+++ b/JSDemos/Demos/Gauges/ValueIndicatorsAPI/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
   CircularGauge, Scale, Label, Tooltip, Title, Font,
 } from 'devextreme-react/circular-gauge';
@@ -14,12 +14,12 @@ function customizeText({ valueText }) {
 }
 
 function App() {
-  const [mainGeneratorValue, setMainGeneratorValue] = React.useState(34);
-  const [additionalGenerator1Value, setAdditionalGenerator1Value] = React.useState(12);
-  const [additionalGenerator2Value, setAdditionalGenerator2Value] = React.useState(23);
-  const gaugeRef = React.useRef(null);
+  const [mainGeneratorValue, setMainGeneratorValue] = useState(34);
+  const [additionalGenerator1Value, setAdditionalGenerator1Value] = useState(12);
+  const [additionalGenerator2Value, setAdditionalGenerator2Value] = useState(23);
+  const gaugeRef = useRef(null);
 
-  const updateValues = React.useCallback(() => {
+  const updateValues = useCallback(() => {
     const gauge = gaugeRef.current.instance;
     gauge.value(mainGeneratorValue);
     gauge.subvalues([additionalGenerator1Value, additionalGenerator2Value]);
@@ -30,7 +30,7 @@ function App() {
     additionalGenerator2Value,
   ]);
 
-  const defaultSubvalues = React.useMemo(
+  const defaultSubvalues = useMemo(
     () => [additionalGenerator1Value, additionalGenerator2Value],
     [additionalGenerator1Value, additionalGenerator2Value],
   );

--- a/JSDemos/Demos/Gauges/ValueIndicatorsAPI/React/App.tsx
+++ b/JSDemos/Demos/Gauges/ValueIndicatorsAPI/React/App.tsx
@@ -1,4 +1,6 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback, useMemo, useRef, useState,
+} from 'react';
 import {
   CircularGauge, Scale, Label, Tooltip, Title, Font,
 } from 'devextreme-react/circular-gauge';

--- a/JSDemos/Demos/Gauges/ValueIndicatorsAPI/ReactJs/App.js
+++ b/JSDemos/Demos/Gauges/ValueIndicatorsAPI/ReactJs/App.js
@@ -1,4 +1,6 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback, useMemo, useRef, useState,
+} from 'react';
 import {
   CircularGauge, Scale, Label, Tooltip, Title, Font,
 } from 'devextreme-react/circular-gauge';

--- a/JSDemos/Demos/Gauges/ValueIndicatorsAPI/ReactJs/App.js
+++ b/JSDemos/Demos/Gauges/ValueIndicatorsAPI/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
   CircularGauge, Scale, Label, Tooltip, Title, Font,
 } from 'devextreme-react/circular-gauge';
@@ -12,16 +12,16 @@ function customizeText({ valueText }) {
   return `${valueText} kV`;
 }
 function App() {
-  const [mainGeneratorValue, setMainGeneratorValue] = React.useState(34);
-  const [additionalGenerator1Value, setAdditionalGenerator1Value] = React.useState(12);
-  const [additionalGenerator2Value, setAdditionalGenerator2Value] = React.useState(23);
-  const gaugeRef = React.useRef(null);
-  const updateValues = React.useCallback(() => {
+  const [mainGeneratorValue, setMainGeneratorValue] = useState(34);
+  const [additionalGenerator1Value, setAdditionalGenerator1Value] = useState(12);
+  const [additionalGenerator2Value, setAdditionalGenerator2Value] = useState(23);
+  const gaugeRef = useRef(null);
+  const updateValues = useCallback(() => {
     const gauge = gaugeRef.current.instance;
     gauge.value(mainGeneratorValue);
     gauge.subvalues([additionalGenerator1Value, additionalGenerator2Value]);
   }, [gaugeRef, mainGeneratorValue, additionalGenerator1Value, additionalGenerator2Value]);
-  const defaultSubvalues = React.useMemo(
+  const defaultSubvalues = useMemo(
     () => [additionalGenerator1Value, additionalGenerator2Value],
     [additionalGenerator1Value, additionalGenerator2Value],
   );

--- a/JSDemos/Demos/Gauges/VariableNumberOfBars/React/App.tsx
+++ b/JSDemos/Demos/Gauges/VariableNumberOfBars/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { BarGauge, Label } from 'devextreme-react/bar-gauge';
 import { CheckBox, CheckBoxTypes } from 'devextreme-react/check-box';
 import { products } from './data.ts';
@@ -9,10 +9,10 @@ const format = {
 };
 
 function App() {
-  const [productsActivity, setProductsActivity] = React.useState(products.map((p) => p.active));
-  const [values, setValues] = React.useState(products.map((p) => p.count));
+  const [productsActivity, setProductsActivity] = useState(products.map((p) => p.active));
+  const [values, setValues] = useState(products.map((p) => p.count));
 
-  const getValueChangedHandler = React.useCallback((productIndex: string | number) => (e: CheckBoxTypes.ValueChangedEvent) => {
+  const getValueChangedHandler = useCallback((productIndex: string | number) => (e: CheckBoxTypes.ValueChangedEvent) => {
     const updatedProductsActivity = [...productsActivity];
     updatedProductsActivity[productIndex] = e.value;
     setProductsActivity(updatedProductsActivity);

--- a/JSDemos/Demos/Gauges/VariableNumberOfBars/ReactJs/App.js
+++ b/JSDemos/Demos/Gauges/VariableNumberOfBars/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { BarGauge, Label } from 'devextreme-react/bar-gauge';
 import { CheckBox } from 'devextreme-react/check-box';
 import { products } from './data.js';
@@ -8,9 +8,9 @@ const format = {
   precision: 0,
 };
 function App() {
-  const [productsActivity, setProductsActivity] = React.useState(products.map((p) => p.active));
-  const [values, setValues] = React.useState(products.map((p) => p.count));
-  const getValueChangedHandler = React.useCallback(
+  const [productsActivity, setProductsActivity] = useState(products.map((p) => p.active));
+  const [values, setValues] = useState(products.map((p) => p.count));
+  const getValueChangedHandler = useCallback(
     (productIndex) => (e) => {
       const updatedProductsActivity = [...productsActivity];
       updatedProductsActivity[productIndex] = e.value;

--- a/JSDemos/Demos/Gauges/VariableNumberOfSubvalueIndicators/React/App.tsx
+++ b/JSDemos/Demos/Gauges/VariableNumberOfSubvalueIndicators/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   LinearGauge, Scale, Label, Tooltip, Export, Title, Font,
 } from 'devextreme-react/linear-gauge';
@@ -22,10 +22,10 @@ function customizeTooltip(arg: { valueText: string; index?: number; }) {
 }
 
 function App() {
-  const [value, setValue] = React.useState(dataSource[0].primary);
-  const [subvalues, setSubvalues] = React.useState(dataSource[0].secondary);
+  const [value, setValue] = useState(dataSource[0].primary);
+  const [subvalues, setSubvalues] = useState(dataSource[0].secondary);
 
-  const onValueChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const onValueChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setValue(e.value.primary);
     setSubvalues(e.value.secondary);
   }, [setValue, setSubvalues]);

--- a/JSDemos/Demos/Gauges/VariableNumberOfSubvalueIndicators/ReactJs/App.js
+++ b/JSDemos/Demos/Gauges/VariableNumberOfSubvalueIndicators/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   LinearGauge,
   Scale,
@@ -26,9 +26,9 @@ function customizeTooltip(arg) {
   };
 }
 function App() {
-  const [value, setValue] = React.useState(dataSource[0].primary);
-  const [subvalues, setSubvalues] = React.useState(dataSource[0].secondary);
-  const onValueChanged = React.useCallback(
+  const [value, setValue] = useState(dataSource[0].primary);
+  const [subvalues, setSubvalues] = useState(dataSource[0].secondary);
+  const onValueChanged = useCallback(
     (e) => {
       setValue(e.value.primary);
       setSubvalues(e.value.secondary);

--- a/JSDemos/Demos/HtmlEditor/OutputFormats/React/App.tsx
+++ b/JSDemos/Demos/HtmlEditor/OutputFormats/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import HtmlEditor, { Toolbar, Item } from 'devextreme-react/html-editor';
 import ButtonGroup, { Item as ButtonItem } from 'devextreme-react/button-group';
 import prettier from 'prettier/standalone';
@@ -21,19 +21,19 @@ const fontFamilyOptions = {
 };
 
 export default function App() {
-  const [valueContent, setValueContent] = React.useState(markup);
-  const [editorValueType, setEditorValueType] = React.useState<'html' | 'markdown'>('html');
+  const [valueContent, setValueContent] = useState(markup);
+  const [editorValueType, setEditorValueType] = useState<'html' | 'markdown'>('html');
 
-  const valueChanged = React.useCallback((e: { value?: string; }) => {
+  const valueChanged = useCallback((e: { value?: string; }) => {
     setValueContent(e.value);
   }, [setValueContent]);
 
-  const valueTypeChanged = React.useCallback((e: { addedItems: { text: string; }[]; }) => {
+  const valueTypeChanged = useCallback((e: { addedItems: { text: string; }[]; }) => {
     const newEditorValue = e.addedItems[0].text.toLowerCase() as 'html' | 'markdown';
     setEditorValueType(newEditorValue);
   }, [setEditorValueType]);
 
-  const prettierFormat = React.useCallback((text) => {
+  const prettierFormat = useCallback((text) => {
     if (editorValueType === 'html') {
       return prettier.format(text, {
         parser: 'html',

--- a/JSDemos/Demos/HtmlEditor/OutputFormats/ReactJs/App.js
+++ b/JSDemos/Demos/HtmlEditor/OutputFormats/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import HtmlEditor, { Toolbar, Item } from 'devextreme-react/html-editor';
 import ButtonGroup, { Item as ButtonItem } from 'devextreme-react/button-group';
 import prettier from 'prettier/standalone';
@@ -29,22 +29,22 @@ const fontFamilyOptions = {
   },
 };
 export default function App() {
-  const [valueContent, setValueContent] = React.useState(markup);
-  const [editorValueType, setEditorValueType] = React.useState('html');
-  const valueChanged = React.useCallback(
+  const [valueContent, setValueContent] = useState(markup);
+  const [editorValueType, setEditorValueType] = useState('html');
+  const valueChanged = useCallback(
     (e) => {
       setValueContent(e.value);
     },
     [setValueContent],
   );
-  const valueTypeChanged = React.useCallback(
+  const valueTypeChanged = useCallback(
     (e) => {
       const newEditorValue = e.addedItems[0].text.toLowerCase();
       setEditorValueType(newEditorValue);
     },
     [setEditorValueType],
   );
-  const prettierFormat = React.useCallback(
+  const prettierFormat = useCallback(
     (text) => {
       if (editorValueType === 'html') {
         return prettier.format(text, {

--- a/JSDemos/Demos/HtmlEditor/Overview/React/App.tsx
+++ b/JSDemos/Demos/HtmlEditor/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import HtmlEditor, {
   Toolbar,
   MediaResizing,
@@ -38,14 +38,14 @@ const headerOptions = {
 };
 
 export default function App() {
-  const [isMultiline, setIsMultiline] = React.useState(true);
-  const [currentTab, setCurrentTab] = React.useState(tabs[2].value);
+  const [isMultiline, setIsMultiline] = useState(true);
+  const [currentTab, setCurrentTab] = useState(tabs[2].value);
 
-  const multilineChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const multilineChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setIsMultiline(e.value);
   }, [setIsMultiline]);
 
-  const currentTabChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const currentTabChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setCurrentTab(e.value);
   }, [setCurrentTab]);
 

--- a/JSDemos/Demos/HtmlEditor/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/HtmlEditor/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import HtmlEditor, {
   Toolbar,
   MediaResizing,
@@ -37,15 +37,15 @@ const headerOptions = {
   },
 };
 export default function App() {
-  const [isMultiline, setIsMultiline] = React.useState(true);
-  const [currentTab, setCurrentTab] = React.useState(tabs[2].value);
-  const multilineChanged = React.useCallback(
+  const [isMultiline, setIsMultiline] = useState(true);
+  const [currentTab, setCurrentTab] = useState(tabs[2].value);
+  const multilineChanged = useCallback(
     (e) => {
       setIsMultiline(e.value);
     },
     [setIsMultiline],
   );
-  const currentTabChanged = React.useCallback(
+  const currentTabChanged = useCallback(
     (e) => {
       setCurrentTab(e.value);
     },

--- a/JSDemos/Demos/HtmlEditor/Tables/React/App.tsx
+++ b/JSDemos/Demos/HtmlEditor/Tables/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import HtmlEditor, {
   TableContextMenu,
   TableResizing,
@@ -9,14 +9,14 @@ import { CheckBox, CheckBoxTypes } from 'devextreme-react/check-box';
 import { markup } from './data.ts';
 
 export default function App() {
-  const [allowResizing, setAllowResizing] = React.useState(true);
-  const [contextMenuEnabled, setContextMenuEnabled] = React.useState(true);
+  const [allowResizing, setAllowResizing] = useState(true);
+  const [contextMenuEnabled, setContextMenuEnabled] = useState(true);
 
-  const tableResizingChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const tableResizingChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setAllowResizing(e.value);
   }, [setAllowResizing]);
 
-  const tableContextMenuChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const tableContextMenuChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setContextMenuEnabled(e.value);
   }, [setContextMenuEnabled]);
 

--- a/JSDemos/Demos/HtmlEditor/Tables/ReactJs/App.js
+++ b/JSDemos/Demos/HtmlEditor/Tables/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import HtmlEditor, {
   TableContextMenu,
   TableResizing,
@@ -9,15 +9,15 @@ import { CheckBox } from 'devextreme-react/check-box';
 import { markup } from './data.js';
 
 export default function App() {
-  const [allowResizing, setAllowResizing] = React.useState(true);
-  const [contextMenuEnabled, setContextMenuEnabled] = React.useState(true);
-  const tableResizingChanged = React.useCallback(
+  const [allowResizing, setAllowResizing] = useState(true);
+  const [contextMenuEnabled, setContextMenuEnabled] = useState(true);
+  const tableResizingChanged = useCallback(
     (e) => {
       setAllowResizing(e.value);
     },
     [setAllowResizing],
   );
-  const tableContextMenuChanged = React.useCallback(
+  const tableContextMenuChanged = useCallback(
     (e) => {
       setContextMenuEnabled(e.value);
     },

--- a/JSDemos/Demos/HtmlEditor/ToolbarCustomization/React/App.tsx
+++ b/JSDemos/Demos/HtmlEditor/ToolbarCustomization/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import HtmlEditor, { Toolbar, Item, HtmlEditorTypes } from 'devextreme-react/html-editor';
 import Popup from 'devextreme-react/popup';
 import { markup } from './data.ts';
@@ -7,24 +7,24 @@ const headerValues = [false, 1, 2, 3, 4, 5];
 const headerOptions = { inputAttr: { 'aria-label': 'Header' } };
 
 export default function App() {
-  const [value, setValue] = React.useState(markup);
-  const [popupVisible, setPopupVisible] = React.useState(false);
+  const [value, setValue] = useState(markup);
+  const [popupVisible, setPopupVisible] = useState(false);
 
-  const customButtonClick = React.useCallback(() => {
+  const customButtonClick = useCallback(() => {
     setPopupVisible(true);
   }, [setPopupVisible]);
 
-  const getToolbarButtonOptions = React.useCallback(() => ({
+  const getToolbarButtonOptions = useCallback(() => ({
     text: 'Show markup',
     stylingMode: 'text',
     onClick: customButtonClick,
   }), [customButtonClick]);
 
-  const valueChanged = React.useCallback((e: HtmlEditorTypes.ValueChangedEvent) => {
+  const valueChanged = useCallback((e: HtmlEditorTypes.ValueChangedEvent) => {
     setValue(e.value);
   }, [setValue]);
 
-  const popupHiding = React.useCallback(() => {
+  const popupHiding = useCallback(() => {
     setPopupVisible(false);
   }, [setPopupVisible]);
 

--- a/JSDemos/Demos/HtmlEditor/ToolbarCustomization/ReactJs/App.js
+++ b/JSDemos/Demos/HtmlEditor/ToolbarCustomization/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import HtmlEditor, { Toolbar, Item } from 'devextreme-react/html-editor';
 import Popup from 'devextreme-react/popup';
 import { markup } from './data.js';
@@ -6,12 +6,12 @@ import { markup } from './data.js';
 const headerValues = [false, 1, 2, 3, 4, 5];
 const headerOptions = { inputAttr: { 'aria-label': 'Header' } };
 export default function App() {
-  const [value, setValue] = React.useState(markup);
-  const [popupVisible, setPopupVisible] = React.useState(false);
-  const customButtonClick = React.useCallback(() => {
+  const [value, setValue] = useState(markup);
+  const [popupVisible, setPopupVisible] = useState(false);
+  const customButtonClick = useCallback(() => {
     setPopupVisible(true);
   }, [setPopupVisible]);
-  const getToolbarButtonOptions = React.useCallback(
+  const getToolbarButtonOptions = useCallback(
     () => ({
       text: 'Show markup',
       stylingMode: 'text',
@@ -19,13 +19,13 @@ export default function App() {
     }),
     [customButtonClick],
   );
-  const valueChanged = React.useCallback(
+  const valueChanged = useCallback(
     (e) => {
       setValue(e.value);
     },
     [setValue],
   );
-  const popupHiding = React.useCallback(() => {
+  const popupHiding = useCallback(() => {
     setPopupVisible(false);
   }, [setPopupVisible]);
   return (

--- a/JSDemos/Demos/List/ItemDragging/React/App.tsx
+++ b/JSDemos/Demos/List/ItemDragging/React/App.tsx
@@ -1,16 +1,16 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import List, { IItemDraggingProps, ItemDragging } from 'devextreme-react/list';
 import { plannedTasks, doingTasks } from './data.ts';
 
 const App = () => {
-  const [plannedTasksState, setPlannedTasksState] = React.useState(plannedTasks);
-  const [doingTasksState, setDoingTasksState] = React.useState(doingTasks);
+  const [plannedTasksState, setPlannedTasksState] = useState(plannedTasks);
+  const [doingTasksState, setDoingTasksState] = useState(doingTasks);
 
-  const onDragStart = React.useCallback<IItemDraggingProps['onDragStart']>((e) => {
+  const onDragStart = useCallback<IItemDraggingProps['onDragStart']>((e) => {
     e.itemData = e.fromData === 'plannedTasks' ? plannedTasksState[e.fromIndex] : doingTasksState[e.fromIndex];
   }, [plannedTasksState, doingTasksState]);
 
-  const onAdd = React.useCallback<IItemDraggingProps['onAdd']>((e) => {
+  const onAdd = useCallback<IItemDraggingProps['onAdd']>((e) => {
     const tasks = e.toData === 'plannedTasks' ? plannedTasksState : doingTasksState;
     const updatedTasks = [...tasks.slice(0, e.toIndex), e.itemData, ...tasks.slice(e.toIndex)];
 
@@ -21,7 +21,7 @@ const App = () => {
     }
   }, [setPlannedTasksState, setDoingTasksState, plannedTasksState, doingTasksState]);
 
-  const onRemove = React.useCallback<IItemDraggingProps['onRemove']>((e) => {
+  const onRemove = useCallback<IItemDraggingProps['onRemove']>((e) => {
     const tasks = e.fromData === 'plannedTasks' ? plannedTasksState : doingTasksState;
     const updatedTasks = [...tasks.slice(0, e.fromIndex), ...tasks.slice(e.fromIndex + 1)];
 
@@ -32,7 +32,7 @@ const App = () => {
     }
   }, [setPlannedTasksState, setDoingTasksState, plannedTasksState, doingTasksState]);
 
-  const onReorder = React.useCallback((e) => {
+  const onReorder = useCallback((e) => {
     onRemove(e);
     onAdd(e);
   }, [onAdd, onRemove]);

--- a/JSDemos/Demos/List/ItemDragging/ReactJs/App.js
+++ b/JSDemos/Demos/List/ItemDragging/ReactJs/App.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import List, { ItemDragging } from 'devextreme-react/list';
 import { plannedTasks, doingTasks } from './data.js';
 
 const App = () => {
-  const [plannedTasksState, setPlannedTasksState] = React.useState(plannedTasks);
-  const [doingTasksState, setDoingTasksState] = React.useState(doingTasks);
-  const onDragStart = React.useCallback(
+  const [plannedTasksState, setPlannedTasksState] = useState(plannedTasks);
+  const [doingTasksState, setDoingTasksState] = useState(doingTasks);
+  const onDragStart = useCallback(
     (e) => {
       e.itemData = e.fromData === 'plannedTasks'
         ? plannedTasksState[e.fromIndex]
@@ -13,7 +13,7 @@ const App = () => {
     },
     [plannedTasksState, doingTasksState],
   );
-  const onAdd = React.useCallback(
+  const onAdd = useCallback(
     (e) => {
       const tasks = e.toData === 'plannedTasks' ? plannedTasksState : doingTasksState;
       const updatedTasks = [...tasks.slice(0, e.toIndex), e.itemData, ...tasks.slice(e.toIndex)];
@@ -25,7 +25,7 @@ const App = () => {
     },
     [setPlannedTasksState, setDoingTasksState, plannedTasksState, doingTasksState],
   );
-  const onRemove = React.useCallback(
+  const onRemove = useCallback(
     (e) => {
       const tasks = e.fromData === 'plannedTasks' ? plannedTasksState : doingTasksState;
       const updatedTasks = [...tasks.slice(0, e.fromIndex), ...tasks.slice(e.fromIndex + 1)];
@@ -37,7 +37,7 @@ const App = () => {
     },
     [setPlannedTasksState, setDoingTasksState, plannedTasksState, doingTasksState],
   );
-  const onReorder = React.useCallback(
+  const onReorder = useCallback(
     (e) => {
       onRemove(e);
       onAdd(e);

--- a/JSDemos/Demos/List/ListEditingAndAPI/React/App.tsx
+++ b/JSDemos/Demos/List/ListEditingAndAPI/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 import CheckBox, { CheckBoxTypes } from 'devextreme-react/check-box';
 import List, { ListTypes } from 'devextreme-react/list';
@@ -7,14 +7,14 @@ import { tasks, deleteModeLabel } from './data.ts';
 const itemDeleteModes = ['static', 'toggle', 'slideButton', 'slideItem', 'swipe', 'context'];
 
 const App = () => {
-  const [allowDeletion, setAllowDeletion] = React.useState(false);
-  const [itemDeleteMode, setItemDeleteMode] = React.useState<ListTypes.Properties['itemDeleteMode']>('toggle');
+  const [allowDeletion, setAllowDeletion] = useState(false);
+  const [itemDeleteMode, setItemDeleteMode] = useState<ListTypes.Properties['itemDeleteMode']>('toggle');
 
-  const onAllowDeletionChange = React.useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
+  const onAllowDeletionChange = useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
     setAllowDeletion(args.value);
   }, [setAllowDeletion]);
 
-  const onItemDeleteModeChange = React.useCallback((args: SelectBoxTypes.ValueChangedEvent) => {
+  const onItemDeleteModeChange = useCallback((args: SelectBoxTypes.ValueChangedEvent) => {
     setItemDeleteMode(args.value);
   }, [setItemDeleteMode]);
 

--- a/JSDemos/Demos/List/ListEditingAndAPI/ReactJs/App.js
+++ b/JSDemos/Demos/List/ListEditingAndAPI/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import CheckBox from 'devextreme-react/check-box';
 import List from 'devextreme-react/list';
@@ -6,15 +6,15 @@ import { tasks, deleteModeLabel } from './data.js';
 
 const itemDeleteModes = ['static', 'toggle', 'slideButton', 'slideItem', 'swipe', 'context'];
 const App = () => {
-  const [allowDeletion, setAllowDeletion] = React.useState(false);
-  const [itemDeleteMode, setItemDeleteMode] = React.useState('toggle');
-  const onAllowDeletionChange = React.useCallback(
+  const [allowDeletion, setAllowDeletion] = useState(false);
+  const [itemDeleteMode, setItemDeleteMode] = useState('toggle');
+  const onAllowDeletionChange = useCallback(
     (args) => {
       setAllowDeletion(args.value);
     },
     [setAllowDeletion],
   );
-  const onItemDeleteModeChange = React.useCallback(
+  const onItemDeleteModeChange = useCallback(
     (args) => {
       setItemDeleteMode(args.value);
     },

--- a/JSDemos/Demos/List/ListSelection/React/App.tsx
+++ b/JSDemos/Demos/List/ListSelection/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import SelectBox from 'devextreme-react/select-box';
 import List, { ListTypes } from 'devextreme-react/list';
@@ -21,12 +21,12 @@ const selectionModes = ['none', 'single', 'multiple', 'all'];
 const selectAllModes = ['page', 'allPages'];
 
 export default function App() {
-  const [selectionMode, setSelectionMode] = React.useState<ListTypes.Properties['selectionMode']>('all');
-  const [selectAllMode, setSelectAllMode] = React.useState<ListTypes.Properties['selectAllMode']>('page');
-  const [selectByClick, setSelectByClick] = React.useState(false);
-  const [selectedItemKeys, setSelectedItemKeys] = React.useState([]);
+  const [selectionMode, setSelectionMode] = useState<ListTypes.Properties['selectionMode']>('all');
+  const [selectAllMode, setSelectAllMode] = useState<ListTypes.Properties['selectAllMode']>('page');
+  const [selectByClick, setSelectByClick] = useState(false);
+  const [selectedItemKeys, setSelectedItemKeys] = useState([]);
 
-  const onSelectedItemKeysChange = React.useCallback(({ name, value }) => {
+  const onSelectedItemKeysChange = useCallback(({ name, value }) => {
     if (name === 'selectedItemKeys') {
       if (selectionMode !== 'none' || selectedItemKeys.length !== 0) {
         setSelectedItemKeys(value);
@@ -34,15 +34,15 @@ export default function App() {
     }
   }, [selectionMode, selectedItemKeys, setSelectedItemKeys]);
 
-  const onSelectionModeChange = React.useCallback((value) => {
+  const onSelectionModeChange = useCallback((value) => {
     setSelectionMode(value);
   }, [setSelectionMode]);
 
-  const onSelectAllModeChange = React.useCallback((value) => {
+  const onSelectAllModeChange = useCallback((value) => {
     setSelectAllMode(value);
   }, [setSelectAllMode]);
 
-  const onSelectByClickChange = React.useCallback((value) => {
+  const onSelectByClickChange = useCallback((value) => {
     setSelectByClick(value);
   }, [setSelectByClick]);
 

--- a/JSDemos/Demos/List/ListSelection/ReactJs/App.js
+++ b/JSDemos/Demos/List/ListSelection/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import List from 'devextreme-react/list';
 import CheckBox from 'devextreme-react/check-box';
@@ -14,11 +14,11 @@ const dataSource = new ArrayStore({
 const selectionModes = ['none', 'single', 'multiple', 'all'];
 const selectAllModes = ['page', 'allPages'];
 export default function App() {
-  const [selectionMode, setSelectionMode] = React.useState('all');
-  const [selectAllMode, setSelectAllMode] = React.useState('page');
-  const [selectByClick, setSelectByClick] = React.useState(false);
-  const [selectedItemKeys, setSelectedItemKeys] = React.useState([]);
-  const onSelectedItemKeysChange = React.useCallback(
+  const [selectionMode, setSelectionMode] = useState('all');
+  const [selectAllMode, setSelectAllMode] = useState('page');
+  const [selectByClick, setSelectByClick] = useState(false);
+  const [selectedItemKeys, setSelectedItemKeys] = useState([]);
+  const onSelectedItemKeysChange = useCallback(
     ({ name, value }) => {
       if (name === 'selectedItemKeys') {
         if (selectionMode !== 'none' || selectedItemKeys.length !== 0) {
@@ -28,19 +28,19 @@ export default function App() {
     },
     [selectionMode, selectedItemKeys, setSelectedItemKeys],
   );
-  const onSelectionModeChange = React.useCallback(
+  const onSelectionModeChange = useCallback(
     (value) => {
       setSelectionMode(value);
     },
     [setSelectionMode],
   );
-  const onSelectAllModeChange = React.useCallback(
+  const onSelectAllModeChange = useCallback(
     (value) => {
       setSelectAllMode(value);
     },
     [setSelectAllMode],
   );
-  const onSelectByClickChange = React.useCallback(
+  const onSelectByClickChange = useCallback(
     (value) => {
       setSelectByClick(value);
     },

--- a/JSDemos/Demos/List/ListWithSearchBar/React/App.tsx
+++ b/JSDemos/Demos/List/ListWithSearchBar/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 import List, { ListTypes } from 'devextreme-react/list';
 import { products, searchModeLabel } from './data.ts';
@@ -10,9 +10,9 @@ function ItemTemplate(data) {
 const searchModes = ['contains', 'startsWith', 'equals'];
 
 const App = () => {
-  const [searchMode, setSearchMode] = React.useState<ListTypes.Properties['searchMode']>('contains');
+  const [searchMode, setSearchMode] = useState<ListTypes.Properties['searchMode']>('contains');
 
-  const onSearchModeChange = React.useCallback((args: SelectBoxTypes.ValueChangedEvent) => {
+  const onSearchModeChange = useCallback((args: SelectBoxTypes.ValueChangedEvent) => {
     setSearchMode(args.value);
   }, [setSearchMode]);
 

--- a/JSDemos/Demos/List/ListWithSearchBar/ReactJs/App.js
+++ b/JSDemos/Demos/List/ListWithSearchBar/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import List from 'devextreme-react/list';
 import { products, searchModeLabel } from './data.js';
@@ -8,8 +8,8 @@ function ItemTemplate(data) {
 }
 const searchModes = ['contains', 'startsWith', 'equals'];
 const App = () => {
-  const [searchMode, setSearchMode] = React.useState('contains');
-  const onSearchModeChange = React.useCallback(
+  const [searchMode, setSearchMode] = useState('contains');
+  const onSearchModeChange = useCallback(
     (args) => {
       setSearchMode(args.value);
     },

--- a/JSDemos/Demos/LoadIndicator/Overview/React/App.tsx
+++ b/JSDemos/Demos/LoadIndicator/Overview/React/App.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { Button } from 'devextreme-react/button';
 import { LoadIndicator } from 'devextreme-react/load-indicator';
 
 export default function App() {
-  const [loadIndicatorVisible, setLoadIndicatorVisible] = React.useState(false);
-  const [buttonText, setButtonText] = React.useState('Send');
+  const [loadIndicatorVisible, setLoadIndicatorVisible] = useState(false);
+  const [buttonText, setButtonText] = useState('Send');
 
-  const handleClick = React.useCallback(() => {
+  const handleClick = useCallback(() => {
     setLoadIndicatorVisible(true);
     setButtonText('Sending');
 

--- a/JSDemos/Demos/LoadIndicator/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/LoadIndicator/Overview/ReactJs/App.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { Button } from 'devextreme-react/button';
 import { LoadIndicator } from 'devextreme-react/load-indicator';
 
 export default function App() {
-  const [loadIndicatorVisible, setLoadIndicatorVisible] = React.useState(false);
-  const [buttonText, setButtonText] = React.useState('Send');
-  const handleClick = React.useCallback(() => {
+  const [loadIndicatorVisible, setLoadIndicatorVisible] = useState(false);
+  const [buttonText, setButtonText] = useState('Send');
+  const handleClick = useCallback(() => {
     setLoadIndicatorVisible(true);
     setButtonText('Sending');
     setTimeout(() => {

--- a/JSDemos/Demos/LoadPanel/Overview/React/App.tsx
+++ b/JSDemos/Demos/LoadPanel/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { Button } from 'devextreme-react/button';
 import { CheckBox, ICheckBoxOptions } from 'devextreme-react/check-box';
 import { LoadPanel } from 'devextreme-react/load-panel';
@@ -7,37 +7,37 @@ import { employee } from './data.ts';
 const position = { of: '#employee' };
 const defaultEmployeeInfo: Partial<typeof employee> = {};
 export default function App() {
-  const [employeeInfo, setEmployeeInfo] = React.useState(defaultEmployeeInfo);
-  const [loadPanelVisible, setLoadPanelVisible] = React.useState(false);
-  const [showIndicator, setShowIndicator] = React.useState(true);
-  const [shading, setShading] = React.useState(true);
-  const [showPane, setShowPane] = React.useState(true);
-  const [hideOnOutsideClick, setHideOnOutsideClick] = React.useState(false);
+  const [employeeInfo, setEmployeeInfo] = useState(defaultEmployeeInfo);
+  const [loadPanelVisible, setLoadPanelVisible] = useState(false);
+  const [showIndicator, setShowIndicator] = useState(true);
+  const [shading, setShading] = useState(true);
+  const [showPane, setShowPane] = useState(true);
+  const [hideOnOutsideClick, setHideOnOutsideClick] = useState(false);
 
-  const hideLoadPanel = React.useCallback(() => {
+  const hideLoadPanel = useCallback(() => {
     setLoadPanelVisible(false);
     setEmployeeInfo(employee);
   }, [setLoadPanelVisible, setEmployeeInfo]);
 
-  const onClick = React.useCallback(() => {
+  const onClick = useCallback(() => {
     setEmployeeInfo({});
     setLoadPanelVisible(true);
     setTimeout(hideLoadPanel, 3000);
   }, [setEmployeeInfo, setLoadPanelVisible]);
 
-  const onShowIndicatorChange = React.useCallback((e: { value: any; }) => {
+  const onShowIndicatorChange = useCallback((e: { value: any; }) => {
     setShowIndicator(e.value);
   }, [setShowIndicator]) as ICheckBoxOptions['onValueChanged'];
 
-  const onShadingChange = React.useCallback((e: { value: any; }) => {
+  const onShadingChange = useCallback((e: { value: any; }) => {
     setShading(e.value);
   }, [setShading]) as ICheckBoxOptions['onValueChanged'];
 
-  const onShowPaneChange = React.useCallback((e: { value: any; }) => {
+  const onShowPaneChange = useCallback((e: { value: any; }) => {
     setShowPane(e.value);
   }, [setShowPane]) as ICheckBoxOptions['onValueChanged'];
 
-  const onHideOnOutsideClickChange = React.useCallback((e: { value: any; }) => {
+  const onHideOnOutsideClickChange = useCallback((e: { value: any; }) => {
     setHideOnOutsideClick(e.value);
   }, [setHideOnOutsideClick]) as ICheckBoxOptions['onValueChanged'];
 

--- a/JSDemos/Demos/LoadPanel/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/LoadPanel/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { Button } from 'devextreme-react/button';
 import { CheckBox } from 'devextreme-react/check-box';
 import { LoadPanel } from 'devextreme-react/load-panel';
@@ -7,40 +7,40 @@ import { employee } from './data.js';
 const position = { of: '#employee' };
 const defaultEmployeeInfo = {};
 export default function App() {
-  const [employeeInfo, setEmployeeInfo] = React.useState(defaultEmployeeInfo);
-  const [loadPanelVisible, setLoadPanelVisible] = React.useState(false);
-  const [showIndicator, setShowIndicator] = React.useState(true);
-  const [shading, setShading] = React.useState(true);
-  const [showPane, setShowPane] = React.useState(true);
-  const [hideOnOutsideClick, setHideOnOutsideClick] = React.useState(false);
-  const hideLoadPanel = React.useCallback(() => {
+  const [employeeInfo, setEmployeeInfo] = useState(defaultEmployeeInfo);
+  const [loadPanelVisible, setLoadPanelVisible] = useState(false);
+  const [showIndicator, setShowIndicator] = useState(true);
+  const [shading, setShading] = useState(true);
+  const [showPane, setShowPane] = useState(true);
+  const [hideOnOutsideClick, setHideOnOutsideClick] = useState(false);
+  const hideLoadPanel = useCallback(() => {
     setLoadPanelVisible(false);
     setEmployeeInfo(employee);
   }, [setLoadPanelVisible, setEmployeeInfo]);
-  const onClick = React.useCallback(() => {
+  const onClick = useCallback(() => {
     setEmployeeInfo({});
     setLoadPanelVisible(true);
     setTimeout(hideLoadPanel, 3000);
   }, [setEmployeeInfo, setLoadPanelVisible]);
-  const onShowIndicatorChange = React.useCallback(
+  const onShowIndicatorChange = useCallback(
     (e) => {
       setShowIndicator(e.value);
     },
     [setShowIndicator],
   );
-  const onShadingChange = React.useCallback(
+  const onShadingChange = useCallback(
     (e) => {
       setShading(e.value);
     },
     [setShading],
   );
-  const onShowPaneChange = React.useCallback(
+  const onShowPaneChange = useCallback(
     (e) => {
       setShowPane(e.value);
     },
     [setShowPane],
   );
-  const onHideOnOutsideClickChange = React.useCallback(
+  const onHideOnOutsideClickChange = useCallback(
     (e) => {
       setHideOnOutsideClick(e.value);
     },

--- a/JSDemos/Demos/Localization/UsingGlobalize/React/App.tsx
+++ b/JSDemos/Demos/Localization/UsingGlobalize/React/App.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/no-webpack-loader-syntax */
-import React from 'react';
+import React, { useState } from 'react';
 import DataGrid, { Column, Editing, FilterRow } from 'devextreme-react/data-grid';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 
@@ -41,7 +41,7 @@ Globalize.loadMessages(service.getDictionary());
 Globalize.locale(sessionStorage.getItem('locale') || 'en');
 
 const App = () => {
-  const [locale, setLocale] = React.useState(sessionStorage.getItem('locale') || 'en');
+  const [locale, setLocale] = useState(sessionStorage.getItem('locale') || 'en');
   const locales = service.getLocales();
   const payments = service.getPayments();
 

--- a/JSDemos/Demos/Localization/UsingGlobalize/ReactJs/App.js
+++ b/JSDemos/Demos/Localization/UsingGlobalize/ReactJs/App.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/no-webpack-loader-syntax */
-import React from 'react';
+import React, { useState } from 'react';
 import DataGrid, { Column, Editing, FilterRow } from 'devextreme-react/data-grid';
 import SelectBox from 'devextreme-react/select-box';
 import 'devextreme/localization/globalize/number';
@@ -30,7 +30,7 @@ Globalize.loadMessages(ruMessages);
 Globalize.loadMessages(service.getDictionary());
 Globalize.locale(sessionStorage.getItem('locale') || 'en');
 const App = () => {
-  const [locale, setLocale] = React.useState(sessionStorage.getItem('locale') || 'en');
+  const [locale, setLocale] = useState(sessionStorage.getItem('locale') || 'en');
   const locales = service.getLocales();
   const payments = service.getPayments();
   const changeLocale = (e) => {

--- a/JSDemos/Demos/Localization/UsingIntl/React/App.tsx
+++ b/JSDemos/Demos/Localization/UsingIntl/React/App.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/no-webpack-loader-syntax */
-import React from 'react';
+import React, { useState } from 'react';
 import DataGrid, { Column, Editing, FilterRow } from 'devextreme-react/data-grid';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 
@@ -29,7 +29,7 @@ loadMessages(ruMessages);
 loadMessages(service.getDictionary());
 
 const App = () => {
-  const [localeState, setLocaleState] = React.useState(sessionStorage.getItem('locale') || 'en');
+  const [localeState, setLocaleState] = useState(sessionStorage.getItem('locale') || 'en');
   const locales = service.getLocales();
   const payments = service.getPayments();
 

--- a/JSDemos/Demos/Localization/UsingIntl/ReactJs/App.js
+++ b/JSDemos/Demos/Localization/UsingIntl/ReactJs/App.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/no-webpack-loader-syntax */
-import React from 'react';
+import React, { useState } from 'react';
 import DataGrid, { Column, Editing, FilterRow } from 'devextreme-react/data-grid';
 import SelectBox from 'devextreme-react/select-box';
 import deMessages from 'devextreme/localization/messages/de.json';
@@ -22,7 +22,7 @@ loadMessages(deMessages);
 loadMessages(ruMessages);
 loadMessages(service.getDictionary());
 const App = () => {
-  const [localeState, setLocaleState] = React.useState(sessionStorage.getItem('locale') || 'en');
+  const [localeState, setLocaleState] = useState(sessionStorage.getItem('locale') || 'en');
   const locales = service.getLocales();
   const payments = service.getPayments();
   const changeLocale = (e) => {

--- a/JSDemos/Demos/Lookup/EventHandling/React/App.tsx
+++ b/JSDemos/Demos/Lookup/EventHandling/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { Lookup, DropDownOptions, LookupTypes } from 'devextreme-react/lookup';
 import { SelectBox } from 'devextreme-react';
 import { SelectBoxTypes } from 'devextreme-react/select-box';
@@ -9,14 +9,14 @@ const applyValueModes = ['instantly', 'useButtons'];
 const getDisplayExpr = (item: { FirstName: string; LastName: string; }) => (item ? `${item.FirstName} ${item.LastName}` : '');
 
 function App() {
-  const [selectedValue, setSelectedValue] = React.useState(null);
-  const [applyValueMode, setApplyValueMode] = React.useState<LookupTypes.ApplyValueMode>('instantly');
+  const [selectedValue, setSelectedValue] = useState(null);
+  const [applyValueMode, setApplyValueMode] = useState<LookupTypes.ApplyValueMode>('instantly');
 
-  const onValueChanged = React.useCallback((e: LookupTypes.ValueChangedEvent) => {
+  const onValueChanged = useCallback((e: LookupTypes.ValueChangedEvent) => {
     setSelectedValue(e.value);
   }, [setSelectedValue]);
 
-  const changeApplyValueMode = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const changeApplyValueMode = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setApplyValueMode(e.value);
   }, [setApplyValueMode]);
 

--- a/JSDemos/Demos/Lookup/EventHandling/ReactJs/App.js
+++ b/JSDemos/Demos/Lookup/EventHandling/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { Lookup, DropDownOptions } from 'devextreme-react/lookup';
 import { SelectBox } from 'devextreme-react';
 import { employees, applyValueModeLabel, lookupLabel } from './data.js';
@@ -6,15 +6,15 @@ import { employees, applyValueModeLabel, lookupLabel } from './data.js';
 const applyValueModes = ['instantly', 'useButtons'];
 const getDisplayExpr = (item) => (item ? `${item.FirstName} ${item.LastName}` : '');
 function App() {
-  const [selectedValue, setSelectedValue] = React.useState(null);
-  const [applyValueMode, setApplyValueMode] = React.useState('instantly');
-  const onValueChanged = React.useCallback(
+  const [selectedValue, setSelectedValue] = useState(null);
+  const [applyValueMode, setApplyValueMode] = useState('instantly');
+  const onValueChanged = useCallback(
     (e) => {
       setSelectedValue(e.value);
     },
     [setSelectedValue],
   );
-  const changeApplyValueMode = React.useCallback(
+  const changeApplyValueMode = useCallback(
     (e) => {
       setApplyValueMode(e.value);
     },

--- a/JSDemos/Demos/Map/Markers/React/App.tsx
+++ b/JSDemos/Demos/Map/Markers/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Map from 'devextreme-react/map';
 import Button from 'devextreme-react/button';
 import CheckBox from 'devextreme-react/check-box';
@@ -11,15 +11,15 @@ const apiKey = {
 };
 
 const App = () => {
-  const [currentMarkersData, setCurrentMarkersData] = React.useState(markersData);
-  const [currentMarkerUrl, setCurrentMarkerUrl] = React.useState(markerUrl);
+  const [currentMarkersData, setCurrentMarkersData] = useState(markersData);
+  const [currentMarkerUrl, setCurrentMarkerUrl] = useState(markerUrl);
 
-  const onCustomMarkersChange = React.useCallback((value) => {
+  const onCustomMarkersChange = useCallback((value) => {
     setCurrentMarkerUrl(value ? currentMarkerUrl : null);
     setCurrentMarkersData(markersData);
   }, [currentMarkerUrl, setCurrentMarkerUrl, setCurrentMarkersData]);
 
-  const showTooltips = React.useCallback(() => {
+  const showTooltips = useCallback(() => {
     setCurrentMarkersData(currentMarkersData.map((item) => {
       const newItem = JSON.parse(JSON.stringify(item));
       newItem.tooltip.isShown = true;

--- a/JSDemos/Demos/Map/Markers/ReactJs/App.js
+++ b/JSDemos/Demos/Map/Markers/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Map from 'devextreme-react/map';
 import Button from 'devextreme-react/button';
 import CheckBox from 'devextreme-react/check-box';
@@ -9,16 +9,16 @@ const apiKey = {
   bing: 'Aq3LKP2BOmzWY47TZoT1YdieypN_rB6RY9FqBfx-MDCKjvvWBbT68R51xwbL-AqC',
 };
 const App = () => {
-  const [currentMarkersData, setCurrentMarkersData] = React.useState(markersData);
-  const [currentMarkerUrl, setCurrentMarkerUrl] = React.useState(markerUrl);
-  const onCustomMarkersChange = React.useCallback(
+  const [currentMarkersData, setCurrentMarkersData] = useState(markersData);
+  const [currentMarkerUrl, setCurrentMarkerUrl] = useState(markerUrl);
+  const onCustomMarkersChange = useCallback(
     (value) => {
       setCurrentMarkerUrl(value ? currentMarkerUrl : null);
       setCurrentMarkersData(markersData);
     },
     [currentMarkerUrl, setCurrentMarkerUrl, setCurrentMarkersData],
   );
-  const showTooltips = React.useCallback(() => {
+  const showTooltips = useCallback(() => {
     setCurrentMarkersData(
       currentMarkersData.map((item) => {
         const newItem = JSON.parse(JSON.stringify(item));

--- a/JSDemos/Demos/Map/ProvidersAndTypes/React/App.tsx
+++ b/JSDemos/Demos/Map/ProvidersAndTypes/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import Map from 'devextreme-react/map';
 import SelectBox from 'devextreme-react/select-box';
@@ -10,9 +10,9 @@ const apiKey = {
 };
 
 const App = () => {
-  const [mapTypeValue, setMapTypeValue] = React.useState(mapTypes[0].key);
+  const [mapTypeValue, setMapTypeValue] = useState(mapTypes[0].key);
 
-  const onMapTypeChange = React.useCallback((value) => {
+  const onMapTypeChange = useCallback((value) => {
     setMapTypeValue(value);
   }, [setMapTypeValue]);
 

--- a/JSDemos/Demos/Map/ProvidersAndTypes/ReactJs/App.js
+++ b/JSDemos/Demos/Map/ProvidersAndTypes/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Map from 'devextreme-react/map';
 import SelectBox from 'devextreme-react/select-box';
 import { mapTypes, mapTypeLabel } from './data.js';
@@ -7,8 +7,8 @@ const apiKey = {
   bing: 'Aq3LKP2BOmzWY47TZoT1YdieypN_rB6RY9FqBfx-MDCKjvvWBbT68R51xwbL-AqC',
 };
 const App = () => {
-  const [mapTypeValue, setMapTypeValue] = React.useState(mapTypes[0].key);
-  const onMapTypeChange = React.useCallback(
+  const [mapTypeValue, setMapTypeValue] = useState(mapTypes[0].key);
+  const onMapTypeChange = useCallback(
     (value) => {
       setMapTypeValue(value);
     },

--- a/JSDemos/Demos/Map/Routes/React/App.tsx
+++ b/JSDemos/Demos/Map/Routes/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Map from 'devextreme-react/map';
 import SelectBox from 'devextreme-react/select-box';
 import {
@@ -13,16 +13,16 @@ const apiKey = {
 };
 
 export default function App() {
-  const [routes, setRoutes] = React.useState(routesData);
+  const [routes, setRoutes] = useState(routesData);
 
-  const routeModeChange = React.useCallback((value) => {
+  const routeModeChange = useCallback((value) => {
     setRoutes(routes.map((item) => {
       item.mode = value;
       return item;
     }));
   }, [routes, setRoutes]);
 
-  const routeColorChange = React.useCallback((value) => {
+  const routeColorChange = useCallback((value) => {
     setRoutes(routes.map((item) => {
       item.color = value;
       return item;

--- a/JSDemos/Demos/Map/Routes/ReactJs/App.js
+++ b/JSDemos/Demos/Map/Routes/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Map from 'devextreme-react/map';
 import SelectBox from 'devextreme-react/select-box';
 import {
@@ -11,8 +11,8 @@ const apiKey = {
   bing: 'Aq3LKP2BOmzWY47TZoT1YdieypN_rB6RY9FqBfx-MDCKjvvWBbT68R51xwbL-AqC',
 };
 export default function App() {
-  const [routes, setRoutes] = React.useState(routesData);
-  const routeModeChange = React.useCallback(
+  const [routes, setRoutes] = useState(routesData);
+  const routeModeChange = useCallback(
     (value) => {
       setRoutes(
         routes.map((item) => {
@@ -23,7 +23,7 @@ export default function App() {
     },
     [routes, setRoutes],
   );
-  const routeColorChange = React.useCallback(
+  const routeColorChange = useCallback(
     (value) => {
       setRoutes(
         routes.map((item) => {

--- a/JSDemos/Demos/Menu/Overview/React/App.tsx
+++ b/JSDemos/Demos/Menu/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Menu, { MenuTypes } from 'devextreme-react/menu';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 import CheckBox, { CheckBoxTypes } from 'devextreme-react/check-box';
@@ -28,26 +28,26 @@ const showSubmenuModes: showSubmenuModesType[] = [
 ];
 
 const App = () => {
-  const [showFirstSubmenuModes, setShowFirstSubmenuModes] = React.useState(showSubmenuModes[1]);
-  const [orientation, setOrientation] = React.useState<MenuTypes.Orientation>('horizontal');
-  const [hideSubmenuOnMouseLeave, setHideSubmenuOnMouseLeave] = React.useState(false);
-  const [currentProduct, setCurrentProduct] = React.useState(null);
+  const [showFirstSubmenuModes, setShowFirstSubmenuModes] = useState(showSubmenuModes[1]);
+  const [orientation, setOrientation] = useState<MenuTypes.Orientation>('horizontal');
+  const [hideSubmenuOnMouseLeave, setHideSubmenuOnMouseLeave] = useState(false);
+  const [currentProduct, setCurrentProduct] = useState(null);
 
-  const itemClick = React.useCallback((e: MenuTypes.ItemClickEvent & { itemData: ProductItemType }) => {
+  const itemClick = useCallback((e: MenuTypes.ItemClickEvent & { itemData: ProductItemType }) => {
     if (e.itemData.price) {
       setCurrentProduct(e.itemData);
     }
   }, [setCurrentProduct]);
 
-  const showSubmenuModeChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const showSubmenuModeChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setShowFirstSubmenuModes(e.value);
   }, [setShowFirstSubmenuModes]);
 
-  const orientationChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const orientationChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setOrientation(e.value);
   }, [setOrientation]);
 
-  const hideSubmenuOnMouseLeaveChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const hideSubmenuOnMouseLeaveChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setHideSubmenuOnMouseLeave(e.value);
   }, [setHideSubmenuOnMouseLeave]);
 

--- a/JSDemos/Demos/Menu/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/Menu/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Menu from 'devextreme-react/menu';
 import SelectBox from 'devextreme-react/select-box';
 import CheckBox from 'devextreme-react/check-box';
@@ -19,11 +19,11 @@ const showSubmenuModes = [
   },
 ];
 const App = () => {
-  const [showFirstSubmenuModes, setShowFirstSubmenuModes] = React.useState(showSubmenuModes[1]);
-  const [orientation, setOrientation] = React.useState('horizontal');
-  const [hideSubmenuOnMouseLeave, setHideSubmenuOnMouseLeave] = React.useState(false);
-  const [currentProduct, setCurrentProduct] = React.useState(null);
-  const itemClick = React.useCallback(
+  const [showFirstSubmenuModes, setShowFirstSubmenuModes] = useState(showSubmenuModes[1]);
+  const [orientation, setOrientation] = useState('horizontal');
+  const [hideSubmenuOnMouseLeave, setHideSubmenuOnMouseLeave] = useState(false);
+  const [currentProduct, setCurrentProduct] = useState(null);
+  const itemClick = useCallback(
     (e) => {
       if (e.itemData.price) {
         setCurrentProduct(e.itemData);
@@ -31,19 +31,19 @@ const App = () => {
     },
     [setCurrentProduct],
   );
-  const showSubmenuModeChanged = React.useCallback(
+  const showSubmenuModeChanged = useCallback(
     (e) => {
       setShowFirstSubmenuModes(e.value);
     },
     [setShowFirstSubmenuModes],
   );
-  const orientationChanged = React.useCallback(
+  const orientationChanged = useCallback(
     (e) => {
       setOrientation(e.value);
     },
     [setOrientation],
   );
-  const hideSubmenuOnMouseLeaveChanged = React.useCallback(
+  const hideSubmenuOnMouseLeaveChanged = useCallback(
     (e) => {
       setHideSubmenuOnMouseLeave(e.value);
     },

--- a/JSDemos/Demos/MultiView/Overview/React/App.tsx
+++ b/JSDemos/Demos/MultiView/Overview/React/App.tsx
@@ -1,25 +1,25 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import CheckBox, { CheckBoxTypes } from 'devextreme-react/check-box';
 import MultiView, { MultiViewTypes } from 'devextreme-react/multi-view';
 import { multiViewItems as companies } from './data.ts';
 import CompanyItem from './CompanyItem.tsx';
 
 const App = () => {
-  const [animationEnabled, setAnimationEnabled] = React.useState(true);
-  const [loop, setLoop] = React.useState(false);
-  const [selectedIndex, setSelectedIndex] = React.useState(0);
+  const [animationEnabled, setAnimationEnabled] = useState(true);
+  const [loop, setLoop] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
 
-  const onSelectionChanged = React.useCallback((args: MultiViewTypes.OptionChangedEvent) => {
+  const onSelectionChanged = useCallback((args: MultiViewTypes.OptionChangedEvent) => {
     if (args.name === 'selectedIndex') {
       setSelectedIndex(args.value);
     }
   }, [setSelectedIndex]);
 
-  const onLoopChanged = React.useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
+  const onLoopChanged = useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
     setLoop(args.value);
   }, [setLoop]);
 
-  const onAnimationEnabledChanged = React.useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
+  const onAnimationEnabledChanged = useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
     setAnimationEnabled(args.value);
   }, [setAnimationEnabled]);
 

--- a/JSDemos/Demos/MultiView/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/MultiView/Overview/ReactJs/App.js
@@ -1,14 +1,14 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import CheckBox from 'devextreme-react/check-box';
 import MultiView from 'devextreme-react/multi-view';
 import { multiViewItems as companies } from './data.js';
 import CompanyItem from './CompanyItem.js';
 
 const App = () => {
-  const [animationEnabled, setAnimationEnabled] = React.useState(true);
-  const [loop, setLoop] = React.useState(false);
-  const [selectedIndex, setSelectedIndex] = React.useState(0);
-  const onSelectionChanged = React.useCallback(
+  const [animationEnabled, setAnimationEnabled] = useState(true);
+  const [loop, setLoop] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const onSelectionChanged = useCallback(
     (args) => {
       if (args.name === 'selectedIndex') {
         setSelectedIndex(args.value);
@@ -16,13 +16,13 @@ const App = () => {
     },
     [setSelectedIndex],
   );
-  const onLoopChanged = React.useCallback(
+  const onLoopChanged = useCallback(
     (args) => {
       setLoop(args.value);
     },
     [setLoop],
   );
-  const onAnimationEnabledChanged = React.useCallback(
+  const onAnimationEnabledChanged = useCallback(
     (args) => {
       setAnimationEnabled(args.value);
     },

--- a/JSDemos/Demos/NumberBox/Overview/React/App.tsx
+++ b/JSDemos/Demos/NumberBox/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { NumberBox, NumberBoxTypes } from 'devextreme-react/number-box';
 
 const simpleLabel = { 'aria-label': 'Simple' };
@@ -17,10 +17,10 @@ const keyDown = (e: NumberBoxTypes.KeyDownEvent) => {
 };
 
 function App() {
-  const [value, setValue] = React.useState(16);
-  const [max] = React.useState(30);
+  const [value, setValue] = useState(16);
+  const [max] = useState(30);
 
-  const valueChanged = React.useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
+  const valueChanged = useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
     setValue(e.value);
   }, []);
 

--- a/JSDemos/Demos/NumberBox/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/NumberBox/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { NumberBox } from 'devextreme-react/number-box';
 
 const simpleLabel = { 'aria-label': 'Simple' };
@@ -15,9 +15,9 @@ const keyDown = (e) => {
   }
 };
 function App() {
-  const [value, setValue] = React.useState(16);
-  const [max] = React.useState(30);
-  const valueChanged = React.useCallback((e) => {
+  const [value, setValue] = useState(16);
+  const [max] = useState(30);
+  const valueChanged = useCallback((e) => {
     setValue(e.value);
   }, []);
   return (

--- a/JSDemos/Demos/PivotGrid/ChartIntegration/React/App.tsx
+++ b/JSDemos/Demos/PivotGrid/ChartIntegration/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
 
@@ -27,10 +27,10 @@ const customizeTooltip = (args) => {
 };
 
 const App = () => {
-  const chartRef = React.useRef<Chart>(null);
-  const pivotGridRef = React.useRef<PivotGrid>(null);
+  const chartRef = useRef<Chart>(null);
+  const pivotGridRef = useRef<PivotGrid>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     pivotGridRef.current.instance.bindChart(chartRef.current.instance, {
       dataFieldsDisplayMode: 'splitPanes',
       alternateDataFields: false,

--- a/JSDemos/Demos/PivotGrid/ChartIntegration/ReactJs/App.js
+++ b/JSDemos/Demos/PivotGrid/ChartIntegration/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
 import Chart, {
   AdaptiveLayout, CommonSeriesSettings, Size, Tooltip,
@@ -17,9 +17,9 @@ const customizeTooltip = (args) => {
   };
 };
 const App = () => {
-  const chartRef = React.useRef(null);
-  const pivotGridRef = React.useRef(null);
-  React.useEffect(() => {
+  const chartRef = useRef(null);
+  const pivotGridRef = useRef(null);
+  useEffect(() => {
     pivotGridRef.current.instance.bindChart(chartRef.current.instance, {
       dataFieldsDisplayMode: 'splitPanes',
       alternateDataFields: false,

--- a/JSDemos/Demos/PivotGrid/DrillDown/React/App.tsx
+++ b/JSDemos/Demos/PivotGrid/DrillDown/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import {
   PivotGrid,
   FieldChooser,
@@ -12,12 +12,12 @@ import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
 import { sales } from './data.ts';
 
 const App = () => {
-  const [popupTitle, setPopupTitle] = React.useState('');
-  const [drillDownDataSource, setDrillDownDataSource] = React.useState<DataSource>(null);
-  const [popupVisible, setPopupVisible] = React.useState(false);
-  const dataGridRef = React.useRef<DataGrid>(null);
+  const [popupTitle, setPopupTitle] = useState('');
+  const [drillDownDataSource, setDrillDownDataSource] = useState<DataSource>(null);
+  const [popupVisible, setPopupVisible] = useState(false);
+  const dataGridRef = useRef<DataGrid>(null);
 
-  const onCellClick = React.useCallback((e: PivotGridTypes.CellClickEvent) => {
+  const onCellClick = useCallback((e: PivotGridTypes.CellClickEvent) => {
     if (e.area === 'data') {
       const pivotGridDataSource = e.component.getDataSource();
       const rowPathLength = e.cell.rowPath.length;

--- a/JSDemos/Demos/PivotGrid/DrillDown/ReactJs/App.js
+++ b/JSDemos/Demos/PivotGrid/DrillDown/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { PivotGrid, FieldChooser } from 'devextreme-react/pivot-grid';
 import { DataGrid, Column } from 'devextreme-react/data-grid';
 import { Popup } from 'devextreme-react/popup';
@@ -6,11 +6,11 @@ import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
 import { sales } from './data.js';
 
 const App = () => {
-  const [popupTitle, setPopupTitle] = React.useState('');
-  const [drillDownDataSource, setDrillDownDataSource] = React.useState(null);
-  const [popupVisible, setPopupVisible] = React.useState(false);
-  const dataGridRef = React.useRef(null);
-  const onCellClick = React.useCallback((e) => {
+  const [popupTitle, setPopupTitle] = useState('');
+  const [drillDownDataSource, setDrillDownDataSource] = useState(null);
+  const [popupVisible, setPopupVisible] = useState(false);
+  const dataGridRef = useRef(null);
+  const onCellClick = useCallback((e) => {
     if (e.area === 'data') {
       const pivotGridDataSource = e.component.getDataSource();
       const rowPathLength = e.cell.rowPath.length;

--- a/JSDemos/Demos/PivotGrid/ExcelJsHeaderAndFooter/React/App.tsx
+++ b/JSDemos/Demos/PivotGrid/ExcelJsHeaderAndFooter/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import PivotGrid, {
   FieldChooser,
@@ -50,12 +50,12 @@ const dataSource = new PivotGridDataSource({
 });
 
 const App = () => {
-  const [exportDataFieldHeaders, setExportDataFieldHeaders] = React.useState(false);
-  const [exportRowFieldHeaders, setExportRowFieldHeaders] = React.useState(false);
-  const [exportColumnFieldHeaders, setExportColumnFieldHeaders] = React.useState(false);
-  const [exportFilterFieldHeaders, setExportFilterFieldHeaders] = React.useState(false);
+  const [exportDataFieldHeaders, setExportDataFieldHeaders] = useState(false);
+  const [exportRowFieldHeaders, setExportRowFieldHeaders] = useState(false);
+  const [exportColumnFieldHeaders, setExportColumnFieldHeaders] = useState(false);
+  const [exportFilterFieldHeaders, setExportFilterFieldHeaders] = useState(false);
 
-  const onExporting = React.useCallback((e: PivotGridTypes.ExportingEvent) => {
+  const onExporting = useCallback((e: PivotGridTypes.ExportingEvent) => {
     const workbook = new Workbook();
     const worksheet = workbook.addWorksheet('Sales');
 

--- a/JSDemos/Demos/PivotGrid/ExcelJsHeaderAndFooter/ReactJs/App.js
+++ b/JSDemos/Demos/PivotGrid/ExcelJsHeaderAndFooter/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import PivotGrid, { FieldChooser, FieldPanel, Export } from 'devextreme-react/pivot-grid';
 import CheckBox from 'devextreme-react/check-box';
 import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
@@ -48,11 +48,11 @@ const dataSource = new PivotGridDataSource({
   store: sales,
 });
 const App = () => {
-  const [exportDataFieldHeaders, setExportDataFieldHeaders] = React.useState(false);
-  const [exportRowFieldHeaders, setExportRowFieldHeaders] = React.useState(false);
-  const [exportColumnFieldHeaders, setExportColumnFieldHeaders] = React.useState(false);
-  const [exportFilterFieldHeaders, setExportFilterFieldHeaders] = React.useState(false);
-  const onExporting = React.useCallback(
+  const [exportDataFieldHeaders, setExportDataFieldHeaders] = useState(false);
+  const [exportRowFieldHeaders, setExportRowFieldHeaders] = useState(false);
+  const [exportColumnFieldHeaders, setExportColumnFieldHeaders] = useState(false);
+  const [exportFilterFieldHeaders, setExportFilterFieldHeaders] = useState(false);
+  const onExporting = useCallback(
     (e) => {
       const workbook = new Workbook();
       const worksheet = workbook.addWorksheet('Sales');

--- a/JSDemos/Demos/PivotGrid/FieldPanel/React/App.tsx
+++ b/JSDemos/Demos/PivotGrid/FieldPanel/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import PivotGrid, {
   FieldChooser,
@@ -65,10 +65,10 @@ const onContextMenuPreparing = (e) => {
 };
 
 const App = () => {
-  const [showColumnFields, setShowColumnFields] = React.useState(true);
-  const [showDataFields, setShowDataFields] = React.useState(true);
-  const [showFilterFields, setShowFilterFields] = React.useState(true);
-  const [showRowFields, setShowRowFields] = React.useState(true);
+  const [showColumnFields, setShowColumnFields] = useState(true);
+  const [showDataFields, setShowDataFields] = useState(true);
+  const [showFilterFields, setShowFilterFields] = useState(true);
+  const [showRowFields, setShowRowFields] = useState(true);
 
   return (
     <React.Fragment>

--- a/JSDemos/Demos/PivotGrid/FieldPanel/ReactJs/App.js
+++ b/JSDemos/Demos/PivotGrid/FieldPanel/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PivotGrid, { FieldChooser, FieldPanel } from 'devextreme-react/pivot-grid';
 import CheckBox from 'devextreme-react/check-box';
 import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
@@ -51,10 +51,10 @@ const onContextMenuPreparing = (e) => {
   }
 };
 const App = () => {
-  const [showColumnFields, setShowColumnFields] = React.useState(true);
-  const [showDataFields, setShowDataFields] = React.useState(true);
-  const [showFilterFields, setShowFilterFields] = React.useState(true);
-  const [showRowFields, setShowRowFields] = React.useState(true);
+  const [showColumnFields, setShowColumnFields] = useState(true);
+  const [showDataFields, setShowDataFields] = useState(true);
+  const [showFilterFields, setShowFilterFields] = useState(true);
+  const [showRowFields, setShowRowFields] = useState(true);
   return (
     <React.Fragment>
       <PivotGrid

--- a/JSDemos/Demos/PivotGrid/HeaderFilter/React/App.tsx
+++ b/JSDemos/Demos/PivotGrid/HeaderFilter/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   PivotGrid, HeaderFilter, Search, FieldChooser, FieldPanel,
 } from 'devextreme-react/pivot-grid';
@@ -32,8 +32,8 @@ const dataSource = new PivotGridDataSource({
 });
 
 const App = () => {
-  const [searchEnabled, setSearchEnabled] = React.useState(true);
-  const [showRelevantValues, setShowRelevantValues] = React.useState(true);
+  const [searchEnabled, setSearchEnabled] = useState(true);
+  const [showRelevantValues, setShowRelevantValues] = useState(true);
 
   return (
     <div>

--- a/JSDemos/Demos/PivotGrid/HeaderFilter/ReactJs/App.js
+++ b/JSDemos/Demos/PivotGrid/HeaderFilter/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   PivotGrid,
   HeaderFilter,
@@ -34,8 +34,8 @@ const dataSource = new PivotGridDataSource({
   }),
 });
 const App = () => {
-  const [searchEnabled, setSearchEnabled] = React.useState(true);
-  const [showRelevantValues, setShowRelevantValues] = React.useState(true);
+  const [searchEnabled, setSearchEnabled] = useState(true);
+  const [showRelevantValues, setShowRelevantValues] = useState(true);
   return (
     <div>
       <PivotGrid

--- a/JSDemos/Demos/PivotGrid/IntegratedFieldChooser/React/App.tsx
+++ b/JSDemos/Demos/PivotGrid/IntegratedFieldChooser/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
 
@@ -11,7 +11,7 @@ import PivotGrid, {
 const applyChangesModeLabel = { 'aria-label': 'Apply Changes Mode' };
 
 const App = () => {
-  const [applyChangesMode, setApplyChangesMode] = React.useState<'instantly' | 'onDemand'>('instantly');
+  const [applyChangesMode, setApplyChangesMode] = useState<'instantly' | 'onDemand'>('instantly');
 
   return (
     <React.Fragment>

--- a/JSDemos/Demos/PivotGrid/IntegratedFieldChooser/ReactJs/App.js
+++ b/JSDemos/Demos/PivotGrid/IntegratedFieldChooser/ReactJs/App.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
 import SelectBox from 'devextreme-react/select-box';
 import PivotGrid, { FieldChooser } from 'devextreme-react/pivot-grid';
 
 const applyChangesModeLabel = { 'aria-label': 'Apply Changes Mode' };
 const App = () => {
-  const [applyChangesMode, setApplyChangesMode] = React.useState('instantly');
+  const [applyChangesMode, setApplyChangesMode] = useState('instantly');
   return (
     <React.Fragment>
       <PivotGrid

--- a/JSDemos/Demos/PivotGrid/LayoutCustomization/React/App.tsx
+++ b/JSDemos/Demos/PivotGrid/LayoutCustomization/React/App.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PivotGrid, { FieldChooser } from 'devextreme-react/pivot-grid';
 import CheckBox from 'devextreme-react/check-box';
 import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
 import sales from './data.ts';
 
 const App = () => {
-  const [showTotalsPrior, setShowTotalsPrior] = React.useState(false);
-  const [dataFieldArea, setDataFieldArea] = React.useState(false);
-  const [rowHeaderLayout, setRowHeaderLayout] = React.useState(true);
+  const [showTotalsPrior, setShowTotalsPrior] = useState(false);
+  const [dataFieldArea, setDataFieldArea] = useState(false);
+  const [rowHeaderLayout, setRowHeaderLayout] = useState(true);
 
   return (
     <React.Fragment>

--- a/JSDemos/Demos/PivotGrid/LayoutCustomization/ReactJs/App.js
+++ b/JSDemos/Demos/PivotGrid/LayoutCustomization/ReactJs/App.js
@@ -1,13 +1,13 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PivotGrid, { FieldChooser } from 'devextreme-react/pivot-grid';
 import CheckBox from 'devextreme-react/check-box';
 import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
 import sales from './data.js';
 
 const App = () => {
-  const [showTotalsPrior, setShowTotalsPrior] = React.useState(false);
-  const [dataFieldArea, setDataFieldArea] = React.useState(false);
-  const [rowHeaderLayout, setRowHeaderLayout] = React.useState(true);
+  const [showTotalsPrior, setShowTotalsPrior] = useState(false);
+  const [dataFieldArea, setDataFieldArea] = useState(false);
+  const [rowHeaderLayout, setRowHeaderLayout] = useState(true);
   return (
     <React.Fragment>
       <PivotGrid

--- a/JSDemos/Demos/PivotGrid/Overview/React/App.tsx
+++ b/JSDemos/Demos/PivotGrid/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
 
@@ -66,10 +66,10 @@ const dataSource = new PivotGridDataSource({
 });
 
 const App = () => {
-  const chartRef = React.useRef<Chart>(null);
-  const pivotGridRef = React.useRef<PivotGrid>(null);
+  const chartRef = useRef<Chart>(null);
+  const pivotGridRef = useRef<PivotGrid>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     pivotGridRef.current.instance.bindChart(chartRef.current.instance, {
       dataFieldsDisplayMode: 'splitPanes',
       alternateDataFields: false,

--- a/JSDemos/Demos/PivotGrid/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/PivotGrid/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
 import Chart, {
   AdaptiveLayout, CommonSeriesSettings, Size, Tooltip,
@@ -54,9 +54,9 @@ const dataSource = new PivotGridDataSource({
   store: sales,
 });
 const App = () => {
-  const chartRef = React.useRef(null);
-  const pivotGridRef = React.useRef(null);
-  React.useEffect(() => {
+  const chartRef = useRef(null);
+  const pivotGridRef = useRef(null);
+  useEffect(() => {
     pivotGridRef.current.instance.bindChart(chartRef.current.instance, {
       dataFieldsDisplayMode: 'splitPanes',
       alternateDataFields: false,

--- a/JSDemos/Demos/PivotGrid/StandaloneFieldChooser/React/App.tsx
+++ b/JSDemos/Demos/PivotGrid/StandaloneFieldChooser/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 
 import {
   PivotGrid,
@@ -34,9 +34,9 @@ const applyChangesModes = ['instantly', 'onDemand'];
 const layouts = service.getLayouts();
 
 const App = () => {
-  const [applyChangesMode, setApplyChangesMode] = React.useState<ApplyChangesMode>('instantly');
-  const [layout, setLayout] = React.useState<FieldChooserLayout>(0);
-  const fieldChooserRef = React.useRef<PivotGridFieldChooser>(null);
+  const [applyChangesMode, setApplyChangesMode] = useState<ApplyChangesMode>('instantly');
+  const [layout, setLayout] = useState<FieldChooserLayout>(0);
+  const fieldChooserRef = useRef<PivotGridFieldChooser>(null);
 
   return (
     <React.Fragment>

--- a/JSDemos/Demos/PivotGrid/StandaloneFieldChooser/ReactJs/App.js
+++ b/JSDemos/Demos/PivotGrid/StandaloneFieldChooser/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import { PivotGrid, FieldChooser } from 'devextreme-react/pivot-grid';
 import { PivotGridFieldChooser, Texts } from 'devextreme-react/pivot-grid-field-chooser';
 import { SelectBox } from 'devextreme-react/select-box';
@@ -11,9 +11,9 @@ const applyChangesModeLabel = { 'aria-label': 'Apply Changes Mode' };
 const applyChangesModes = ['instantly', 'onDemand'];
 const layouts = service.getLayouts();
 const App = () => {
-  const [applyChangesMode, setApplyChangesMode] = React.useState('instantly');
-  const [layout, setLayout] = React.useState(0);
-  const fieldChooserRef = React.useRef(null);
+  const [applyChangesMode, setApplyChangesMode] = useState('instantly');
+  const [layout, setLayout] = useState(0);
+  const fieldChooserRef = useRef(null);
   return (
     <React.Fragment>
       <PivotGrid

--- a/JSDemos/Demos/Popup/Overview/React/App.tsx
+++ b/JSDemos/Demos/Popup/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { Popup, Position, ToolbarItem } from 'devextreme-react/popup';
 import notify from 'devextreme/ui/notify';
 import { EmployeeItem, EmployeeItemProps } from './EmployeeItem.tsx';
@@ -6,22 +6,22 @@ import { employees } from './data.ts';
 
 const defaultCurrentEmployee: Partial<EmployeeItemProps['employee']> = {};
 export default function App() {
-  const [currentEmployee, setCurrentEmployee] = React.useState(defaultCurrentEmployee);
-  const [popupVisible, setPopupVisible] = React.useState(false);
-  const [positionOf, setPositionOf] = React.useState('');
+  const [currentEmployee, setCurrentEmployee] = useState(defaultCurrentEmployee);
+  const [popupVisible, setPopupVisible] = useState(false);
+  const [positionOf, setPositionOf] = useState('');
 
-  const showInfo = React.useCallback((employee: EmployeeItemProps['employee']) => {
+  const showInfo = useCallback((employee: EmployeeItemProps['employee']) => {
     setCurrentEmployee(employee);
     setPositionOf(`#image${employee.ID}`);
     setPopupVisible(true);
   }, [setCurrentEmployee, setPositionOf, setPopupVisible]);
 
-  const hideInfo = React.useCallback(() => {
+  const hideInfo = useCallback(() => {
     setCurrentEmployee({});
     setPopupVisible(false);
   }, [setCurrentEmployee, setPopupVisible]);
 
-  const sendEmail = React.useCallback(() => {
+  const sendEmail = useCallback(() => {
     const message = `Email is sent to ${currentEmployee.FirstName} ${currentEmployee.LastName}`;
     notify(
       {
@@ -36,7 +36,7 @@ export default function App() {
     );
   }, [currentEmployee]);
 
-  const showMoreInfo = React.useCallback(() => {
+  const showMoreInfo = useCallback(() => {
     const message = `More info about ${currentEmployee.FirstName} ${currentEmployee.LastName}`;
     notify(
       {
@@ -51,26 +51,26 @@ export default function App() {
     );
   }, [currentEmployee]);
 
-  const getInfoButtonOptions = React.useCallback(() => ({
+  const getInfoButtonOptions = useCallback(() => ({
     text: 'More info',
     onClick: showMoreInfo,
   }), [showMoreInfo]);
 
-  const getEmailButtonOptions = React.useCallback(() => ({
+  const getEmailButtonOptions = useCallback(() => ({
     icon: 'email',
     stylingMode: 'contained',
     text: 'Send',
     onClick: sendEmail,
   }), [sendEmail]);
 
-  const getCloseButtonOptions = React.useCallback(() => ({
+  const getCloseButtonOptions = useCallback(() => ({
     text: 'Close',
     stylingMode: 'outlined',
     type: 'normal',
     onClick: hideInfo,
   }), [hideInfo]);
 
-  const getItems = React.useCallback(() => employees.map((employee) => (
+  const getItems = useCallback(() => employees.map((employee) => (
     <li key={employee.ID}>
       <EmployeeItem employee={employee} showInfo={showInfo} />
     </li>

--- a/JSDemos/Demos/Popup/Overview/React/EmployeeItem.tsx
+++ b/JSDemos/Demos/Popup/Overview/React/EmployeeItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Button } from 'devextreme-react/button';
 
 export interface EmployeeItemProps {
@@ -7,7 +7,7 @@ export interface EmployeeItemProps {
 }
 
 export function EmployeeItem(props: EmployeeItemProps) {
-  const showInfo = React.useCallback(() => {
+  const showInfo = useCallback(() => {
     props.showInfo(props.employee);
   }, [props]);
 

--- a/JSDemos/Demos/Popup/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/Popup/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { Popup, Position, ToolbarItem } from 'devextreme-react/popup';
 import notify from 'devextreme/ui/notify';
 import { EmployeeItem } from './EmployeeItem.js';
@@ -6,10 +6,10 @@ import { employees } from './data.js';
 
 const defaultCurrentEmployee = {};
 export default function App() {
-  const [currentEmployee, setCurrentEmployee] = React.useState(defaultCurrentEmployee);
-  const [popupVisible, setPopupVisible] = React.useState(false);
-  const [positionOf, setPositionOf] = React.useState('');
-  const showInfo = React.useCallback(
+  const [currentEmployee, setCurrentEmployee] = useState(defaultCurrentEmployee);
+  const [popupVisible, setPopupVisible] = useState(false);
+  const [positionOf, setPositionOf] = useState('');
+  const showInfo = useCallback(
     (employee) => {
       setCurrentEmployee(employee);
       setPositionOf(`#image${employee.ID}`);
@@ -17,11 +17,11 @@ export default function App() {
     },
     [setCurrentEmployee, setPositionOf, setPopupVisible],
   );
-  const hideInfo = React.useCallback(() => {
+  const hideInfo = useCallback(() => {
     setCurrentEmployee({});
     setPopupVisible(false);
   }, [setCurrentEmployee, setPopupVisible]);
-  const sendEmail = React.useCallback(() => {
+  const sendEmail = useCallback(() => {
     const message = `Email is sent to ${currentEmployee.FirstName} ${currentEmployee.LastName}`;
     notify(
       {
@@ -35,7 +35,7 @@ export default function App() {
       3000,
     );
   }, [currentEmployee]);
-  const showMoreInfo = React.useCallback(() => {
+  const showMoreInfo = useCallback(() => {
     const message = `More info about ${currentEmployee.FirstName} ${currentEmployee.LastName}`;
     notify(
       {
@@ -49,14 +49,14 @@ export default function App() {
       3000,
     );
   }, [currentEmployee]);
-  const getInfoButtonOptions = React.useCallback(
+  const getInfoButtonOptions = useCallback(
     () => ({
       text: 'More info',
       onClick: showMoreInfo,
     }),
     [showMoreInfo],
   );
-  const getEmailButtonOptions = React.useCallback(
+  const getEmailButtonOptions = useCallback(
     () => ({
       icon: 'email',
       stylingMode: 'contained',
@@ -65,7 +65,7 @@ export default function App() {
     }),
     [sendEmail],
   );
-  const getCloseButtonOptions = React.useCallback(
+  const getCloseButtonOptions = useCallback(
     () => ({
       text: 'Close',
       stylingMode: 'outlined',
@@ -74,7 +74,7 @@ export default function App() {
     }),
     [hideInfo],
   );
-  const getItems = React.useCallback(
+  const getItems = useCallback(
     () =>
       employees.map((employee) => (
         <li key={employee.ID}>

--- a/JSDemos/Demos/Popup/Overview/ReactJs/EmployeeItem.js
+++ b/JSDemos/Demos/Popup/Overview/ReactJs/EmployeeItem.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Button } from 'devextreme-react/button';
 
 export function EmployeeItem(props) {
-  const showInfo = React.useCallback(() => {
+  const showInfo = useCallback(() => {
     props.showInfo(props.employee);
   }, [props]);
   return (

--- a/JSDemos/Demos/Popup/Scrolling/React/App.tsx
+++ b/JSDemos/Demos/Popup/Scrolling/React/App.tsx
@@ -1,26 +1,26 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Button } from 'devextreme-react';
 import { Popup, ToolbarItem } from 'devextreme-react/popup';
 import ScrollView from 'devextreme-react/scroll-view';
 
 export default function App() {
-  const [popupVisible, setPopupVisible] = React.useState(false);
-  const [popupWithScrollViewVisible, setPopupWithScrollViewVisible] = React.useState(false);
+  const [popupVisible, setPopupVisible] = useState(false);
+  const [popupWithScrollViewVisible, setPopupWithScrollViewVisible] = useState(false);
 
-  const showPopup = React.useCallback(() => {
+  const showPopup = useCallback(() => {
     setPopupVisible(true);
   }, [setPopupVisible]);
 
-  const showPopupWithScrollView = React.useCallback(() => {
+  const showPopupWithScrollView = useCallback(() => {
     setPopupWithScrollViewVisible(true);
   }, [setPopupWithScrollViewVisible]);
 
-  const hide = React.useCallback(() => {
+  const hide = useCallback(() => {
     setPopupVisible(false);
     setPopupWithScrollViewVisible(false);
   }, [setPopupVisible, setPopupWithScrollViewVisible]);
 
-  const bookButtonOptions = React.useMemo(() => ({
+  const bookButtonOptions = useMemo(() => ({
     width: 300,
     text: 'Book',
     type: 'default',

--- a/JSDemos/Demos/Popup/Scrolling/ReactJs/App.js
+++ b/JSDemos/Demos/Popup/Scrolling/ReactJs/App.js
@@ -1,22 +1,22 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Button } from 'devextreme-react';
 import { Popup, ToolbarItem } from 'devextreme-react/popup';
 import ScrollView from 'devextreme-react/scroll-view';
 
 export default function App() {
-  const [popupVisible, setPopupVisible] = React.useState(false);
-  const [popupWithScrollViewVisible, setPopupWithScrollViewVisible] = React.useState(false);
-  const showPopup = React.useCallback(() => {
+  const [popupVisible, setPopupVisible] = useState(false);
+  const [popupWithScrollViewVisible, setPopupWithScrollViewVisible] = useState(false);
+  const showPopup = useCallback(() => {
     setPopupVisible(true);
   }, [setPopupVisible]);
-  const showPopupWithScrollView = React.useCallback(() => {
+  const showPopupWithScrollView = useCallback(() => {
     setPopupWithScrollViewVisible(true);
   }, [setPopupWithScrollViewVisible]);
-  const hide = React.useCallback(() => {
+  const hide = useCallback(() => {
     setPopupVisible(false);
     setPopupWithScrollViewVisible(false);
   }, [setPopupVisible, setPopupWithScrollViewVisible]);
-  const bookButtonOptions = React.useMemo(
+  const bookButtonOptions = useMemo(
     () => ({
       width: 300,
       text: 'Book',

--- a/JSDemos/Demos/ProgressBar/Overview/React/App.tsx
+++ b/JSDemos/Demos/ProgressBar/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Button } from 'devextreme-react/button';
 import { ProgressBar } from 'devextreme-react/progress-bar';
 
@@ -16,11 +16,11 @@ const elementAttr = { 'aria-label': 'Progress Bar' };
 let intervalId;
 
 export default function App() {
-  const [seconds, setSeconds] = React.useState(maxValue);
-  const [buttonText, setButtonText] = React.useState('Start progress');
-  const [inProgress, setInProgress] = React.useState(false);
+  const [seconds, setSeconds] = useState(maxValue);
+  const [buttonText, setButtonText] = useState('Start progress');
+  const [inProgress, setInProgress] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (seconds === 0) {
       setButtonText('Restart progress');
       setInProgress(!inProgress);
@@ -28,7 +28,7 @@ export default function App() {
     }
   }, [seconds]);
 
-  const onButtonClick = React.useCallback(() => {
+  const onButtonClick = useCallback(() => {
     if (inProgress) {
       setButtonText('Continue progress');
       clearInterval(intervalId);

--- a/JSDemos/Demos/ProgressBar/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/ProgressBar/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Button } from 'devextreme-react/button';
 import { ProgressBar } from 'devextreme-react/progress-bar';
 
@@ -12,17 +12,17 @@ function statusFormat(ratio) {
 const elementAttr = { 'aria-label': 'Progress Bar' };
 let intervalId;
 export default function App() {
-  const [seconds, setSeconds] = React.useState(maxValue);
-  const [buttonText, setButtonText] = React.useState('Start progress');
-  const [inProgress, setInProgress] = React.useState(false);
-  React.useEffect(() => {
+  const [seconds, setSeconds] = useState(maxValue);
+  const [buttonText, setButtonText] = useState('Start progress');
+  const [inProgress, setInProgress] = useState(false);
+  useEffect(() => {
     if (seconds === 0) {
       setButtonText('Restart progress');
       setInProgress(!inProgress);
       clearInterval(intervalId);
     }
   }, [seconds]);
-  const onButtonClick = React.useCallback(() => {
+  const onButtonClick = useCallback(() => {
     if (inProgress) {
       setButtonText('Continue progress');
       clearInterval(intervalId);

--- a/JSDemos/Demos/RadioGroup/Overview/React/App.tsx
+++ b/JSDemos/Demos/RadioGroup/Overview/React/App.tsx
@@ -1,18 +1,18 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import RadioGroup, { RadioGroupTypes } from 'devextreme-react/radio-group';
 import { priorities, priorityEntities, tasks } from './data.ts';
 
 const renderCustomItem = (data) => <div>{data}</div>;
 
 function App() {
-  const [colorPriority, setColorPriority] = React.useState(priorities[2]);
-  const [selectionPriority, setSelectionPriority] = React.useState(priorityEntities[0].id);
+  const [colorPriority, setColorPriority] = useState(priorities[2]);
+  const [selectionPriority, setSelectionPriority] = useState(priorityEntities[0].id);
 
-  const changeColorPriority = React.useCallback((e: RadioGroupTypes.ValueChangedEvent) => {
+  const changeColorPriority = useCallback((e: RadioGroupTypes.ValueChangedEvent) => {
     setColorPriority(e.value);
   }, [setColorPriority]);
 
-  const changeSelectionPriority = React.useCallback((e: RadioGroupTypes.ValueChangedEvent) => {
+  const changeSelectionPriority = useCallback((e: RadioGroupTypes.ValueChangedEvent) => {
     setSelectionPriority(e.value);
   }, [setSelectionPriority]);
 

--- a/JSDemos/Demos/RadioGroup/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/RadioGroup/Overview/ReactJs/App.js
@@ -1,18 +1,18 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import RadioGroup from 'devextreme-react/radio-group';
 import { priorities, priorityEntities, tasks } from './data.js';
 
 const renderCustomItem = (data) => <div>{data}</div>;
 function App() {
-  const [colorPriority, setColorPriority] = React.useState(priorities[2]);
-  const [selectionPriority, setSelectionPriority] = React.useState(priorityEntities[0].id);
-  const changeColorPriority = React.useCallback(
+  const [colorPriority, setColorPriority] = useState(priorities[2]);
+  const [selectionPriority, setSelectionPriority] = useState(priorityEntities[0].id);
+  const changeColorPriority = useCallback(
     (e) => {
       setColorPriority(e.value);
     },
     [setColorPriority],
   );
-  const changeSelectionPriority = React.useCallback(
+  const changeSelectionPriority = useCallback(
     (e) => {
       setSelectionPriority(e.value);
     },

--- a/JSDemos/Demos/RangeSelector/DiscreteScale/React/App.tsx
+++ b/JSDemos/Demos/RangeSelector/DiscreteScale/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import RangeSelector, { Chart, RangeSelectorTypes, Series } from 'devextreme-react/range-selector';
 import { dataSource } from './data.ts';
 
@@ -23,9 +23,9 @@ function calculateTotalProduction(range = []) {
 }
 
 function App() {
-  const [totalProduction, setTotalProduction] = React.useState(calculateTotalProduction());
+  const [totalProduction, setTotalProduction] = useState(calculateTotalProduction());
 
-  const processRange = React.useCallback((e: RangeSelectorTypes.ValueChangedEvent) => {
+  const processRange = useCallback((e: RangeSelectorTypes.ValueChangedEvent) => {
     setTotalProduction(calculateTotalProduction(e.value));
   }, [setTotalProduction]);
 

--- a/JSDemos/Demos/RangeSelector/DiscreteScale/ReactJs/App.js
+++ b/JSDemos/Demos/RangeSelector/DiscreteScale/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import RangeSelector, { Chart, Series } from 'devextreme-react/range-selector';
 import { dataSource } from './data.js';
 
@@ -19,8 +19,8 @@ function calculateTotalProduction(range = []) {
   );
 }
 function App() {
-  const [totalProduction, setTotalProduction] = React.useState(calculateTotalProduction());
-  const processRange = React.useCallback(
+  const [totalProduction, setTotalProduction] = useState(calculateTotalProduction());
+  const processRange = useCallback(
     (e) => {
       setTotalProduction(calculateTotalProduction(e.value));
     },

--- a/JSDemos/Demos/RangeSelector/LogarithmicScale/React/App.tsx
+++ b/JSDemos/Demos/RangeSelector/LogarithmicScale/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import RangeSelector, {
   Chart as RsChart, Series as RsSeries, Scale, Label as RsLabel, SliderMarker, Behavior,
 } from 'devextreme-react/range-selector';
@@ -8,9 +8,9 @@ import Chart, {
 import { dataSource } from './data.ts';
 
 const App = () => {
-  const [range, setRange] = React.useState([]);
+  const [range, setRange] = useState([]);
 
-  const updateRange = React.useCallback((data: { value: any; }) => {
+  const updateRange = useCallback((data: { value: any; }) => {
     setRange(data.value);
   }, [setRange]);
 

--- a/JSDemos/Demos/RangeSelector/LogarithmicScale/ReactJs/App.js
+++ b/JSDemos/Demos/RangeSelector/LogarithmicScale/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import RangeSelector, {
   Chart as RsChart,
   Series as RsSeries,
@@ -18,8 +18,8 @@ import Chart, {
 import { dataSource } from './data.js';
 
 const App = () => {
-  const [range, setRange] = React.useState([]);
-  const updateRange = React.useCallback(
+  const [range, setRange] = useState([]);
+  const updateRange = useCallback(
     (data) => {
       setRange(data.value);
     },

--- a/JSDemos/Demos/RangeSelector/UseRangeSelectionForCalculation/React/App.tsx
+++ b/JSDemos/Demos/RangeSelector/UseRangeSelectionForCalculation/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import RangeSelector, {
   Margin, Scale, MinorTick, Marker, Label, Behavior, SliderMarker, RangeSelectorTypes, IBehaviorProps,
 } from 'devextreme-react/range-selector';
@@ -11,16 +11,16 @@ const behaviorModes: (IBehaviorProps['valueChangeMode'])[] = ['onHandleMove', 'o
 const valueChangeModeLabel = { 'aria-label': 'Value Change Mode' };
 
 function App() {
-  const [workingDaysCount, setWorkingDaysCount] = React.useState(
+  const [workingDaysCount, setWorkingDaysCount] = useState(
     calculateWorkdays([startValue, endValue]),
   );
-  const [behaviorMode, setBehaviorMode] = React.useState(behaviorModes[0]);
+  const [behaviorMode, setBehaviorMode] = useState(behaviorModes[0]);
 
-  const processRange = React.useCallback((e: RangeSelectorTypes.ValueChangedEvent) => {
+  const processRange = useCallback((e: RangeSelectorTypes.ValueChangedEvent) => {
     setWorkingDaysCount(calculateWorkdays(e.value));
   }, [setWorkingDaysCount]);
 
-  const setBehavior = React.useCallback((data) => {
+  const setBehavior = useCallback((data) => {
     setBehaviorMode(data.value);
   }, [setBehaviorMode]);
 

--- a/JSDemos/Demos/RangeSelector/UseRangeSelectionForCalculation/ReactJs/App.js
+++ b/JSDemos/Demos/RangeSelector/UseRangeSelectionForCalculation/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import RangeSelector, {
   Margin,
   Scale,
@@ -15,17 +15,17 @@ const endValue = new Date(2011, 11, 31);
 const behaviorModes = ['onHandleMove', 'onHandleRelease'];
 const valueChangeModeLabel = { 'aria-label': 'Value Change Mode' };
 function App() {
-  const [workingDaysCount, setWorkingDaysCount] = React.useState(
+  const [workingDaysCount, setWorkingDaysCount] = useState(
     calculateWorkdays([startValue, endValue]),
   );
-  const [behaviorMode, setBehaviorMode] = React.useState(behaviorModes[0]);
-  const processRange = React.useCallback(
+  const [behaviorMode, setBehaviorMode] = useState(behaviorModes[0]);
+  const processRange = useCallback(
     (e) => {
       setWorkingDaysCount(calculateWorkdays(e.value));
     },
     [setWorkingDaysCount],
   );
-  const setBehavior = React.useCallback(
+  const setBehavior = useCallback(
     (data) => {
       setBehaviorMode(data.value);
     },

--- a/JSDemos/Demos/RangeSelector/UseRangeSelectionForFiltering/React/App.tsx
+++ b/JSDemos/Demos/RangeSelector/UseRangeSelectionForFiltering/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import RangeSelector, {
   Margin, Scale, Label, Behavior, Format,
 } from 'devextreme-react/range-selector';
@@ -8,9 +8,9 @@ import { employees } from './data.ts';
 const columns = ['FirstName', 'LastName', 'BirthYear', 'City', 'Title'];
 
 const App = () => {
-  const [selectedEmployees, setSelectedEmployees] = React.useState(employees);
+  const [selectedEmployees, setSelectedEmployees] = useState(employees);
 
-  const filterEmployees = React.useCallback(({ value }) => {
+  const filterEmployees = useCallback(({ value }) => {
     setSelectedEmployees(
       employees.filter(
         (employee) => (

--- a/JSDemos/Demos/RangeSelector/UseRangeSelectionForFiltering/ReactJs/App.js
+++ b/JSDemos/Demos/RangeSelector/UseRangeSelectionForFiltering/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import RangeSelector, {
   Margin,
   Scale,
@@ -11,8 +11,8 @@ import { employees } from './data.js';
 
 const columns = ['FirstName', 'LastName', 'BirthYear', 'City', 'Title'];
 const App = () => {
-  const [selectedEmployees, setSelectedEmployees] = React.useState(employees);
-  const filterEmployees = React.useCallback(
+  const [selectedEmployees, setSelectedEmployees] = useState(employees);
+  const filterEmployees = useCallback(
     ({ value }) => {
       setSelectedEmployees(
         employees.filter(

--- a/JSDemos/Demos/RangeSlider/Overview/React/App.tsx
+++ b/JSDemos/Demos/RangeSlider/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import RangeSlider, { Tooltip, Label, RangeSliderTypes } from 'devextreme-react/range-slider';
 import NumberBox, { NumberBoxTypes } from 'devextreme-react/number-box';
 
@@ -15,19 +15,19 @@ const startValueLabel = { 'aria-label': 'Start Value' };
 const endValueLabel = { 'aria-label': 'End Value' };
 
 function App() {
-  const [startValue, setStartValue] = React.useState(10);
-  const [endValue, setEndValue] = React.useState(90);
+  const [startValue, setStartValue] = useState(10);
+  const [endValue, setEndValue] = useState(90);
 
-  const onRangeChanged = React.useCallback((data: RangeSliderTypes.ValueChangedEvent) => {
+  const onRangeChanged = useCallback((data: RangeSliderTypes.ValueChangedEvent) => {
     setStartValue(data.start);
     setEndValue(data.end);
   }, [setStartValue, setEndValue]);
 
-  const onStartChanged = React.useCallback((data: NumberBoxTypes.ValueChangedEvent) => {
+  const onStartChanged = useCallback((data: NumberBoxTypes.ValueChangedEvent) => {
     setStartValue(data.value);
   }, [setStartValue]);
 
-  const onEndChanged = React.useCallback((data: NumberBoxTypes.ValueChangedEvent) => {
+  const onEndChanged = useCallback((data: NumberBoxTypes.ValueChangedEvent) => {
     setEndValue(data.value);
   }, [setEndValue]);
 

--- a/JSDemos/Demos/RangeSlider/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/RangeSlider/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import RangeSlider, { Tooltip, Label } from 'devextreme-react/range-slider';
 import NumberBox from 'devextreme-react/number-box';
 
@@ -13,22 +13,22 @@ const defaultValues = {
 const startValueLabel = { 'aria-label': 'Start Value' };
 const endValueLabel = { 'aria-label': 'End Value' };
 function App() {
-  const [startValue, setStartValue] = React.useState(10);
-  const [endValue, setEndValue] = React.useState(90);
-  const onRangeChanged = React.useCallback(
+  const [startValue, setStartValue] = useState(10);
+  const [endValue, setEndValue] = useState(90);
+  const onRangeChanged = useCallback(
     (data) => {
       setStartValue(data.start);
       setEndValue(data.end);
     },
     [setStartValue, setEndValue],
   );
-  const onStartChanged = React.useCallback(
+  const onStartChanged = useCallback(
     (data) => {
       setStartValue(data.value);
     },
     [setStartValue],
   );
-  const onEndChanged = React.useCallback(
+  const onEndChanged = useCallback(
     (data) => {
       setEndValue(data.value);
     },

--- a/JSDemos/Demos/Resizable/Overview/React/App.tsx
+++ b/JSDemos/Demos/Resizable/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, { Paging, Scrolling, Column } from 'devextreme-react/data-grid';
 import Resizable from 'devextreme-react/resizable';
 import CheckBox from 'devextreme-react/check-box';
@@ -9,15 +9,15 @@ import { orders, handleLabel } from './data.ts';
 const handleValues = ['left', 'top', 'right', 'bottom'];
 
 const App = () => {
-  const [keepAspectRatio, setKeepAspectRatio] = React.useState(true);
-  const [handles, setHandles] = React.useState(handleValues);
-  const [resizableClasses, setResizableClasses] = React.useState('');
+  const [keepAspectRatio, setKeepAspectRatio] = useState(true);
+  const [handles, setHandles] = useState(handleValues);
+  const [resizableClasses, setResizableClasses] = useState('');
 
-  const keepAspectRatioValueChange = React.useCallback((value) => {
+  const keepAspectRatioValueChange = useCallback((value) => {
     setKeepAspectRatio(value);
   }, [setKeepAspectRatio]);
 
-  const handlesValueChange = React.useCallback((value: string[]) => {
+  const handlesValueChange = useCallback((value: string[]) => {
     const classes = handleValues.reduce((acc, handle) => {
       const newClass = value.includes(handle) ? '' : ` no-${handle}-handle`;
       return acc + newClass;

--- a/JSDemos/Demos/Resizable/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/Resizable/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import DataGrid, { Paging, Scrolling, Column } from 'devextreme-react/data-grid';
 import Resizable from 'devextreme-react/resizable';
 import CheckBox from 'devextreme-react/check-box';
@@ -7,16 +7,16 @@ import { orders, handleLabel } from './data.js';
 
 const handleValues = ['left', 'top', 'right', 'bottom'];
 const App = () => {
-  const [keepAspectRatio, setKeepAspectRatio] = React.useState(true);
-  const [handles, setHandles] = React.useState(handleValues);
-  const [resizableClasses, setResizableClasses] = React.useState('');
-  const keepAspectRatioValueChange = React.useCallback(
+  const [keepAspectRatio, setKeepAspectRatio] = useState(true);
+  const [handles, setHandles] = useState(handleValues);
+  const [resizableClasses, setResizableClasses] = useState('');
+  const keepAspectRatioValueChange = useCallback(
     (value) => {
       setKeepAspectRatio(value);
     },
     [setKeepAspectRatio],
   );
-  const handlesValueChange = React.useCallback(
+  const handlesValueChange = useCallback(
     (value) => {
       const classes = handleValues.reduce((acc, handle) => {
         const newClass = value.includes(handle) ? '' : ` no-${handle}-handle`;

--- a/JSDemos/Demos/Scheduler/Adaptability/React/App.tsx
+++ b/JSDemos/Demos/Scheduler/Adaptability/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import Scheduler, { Resource, SchedulerTypes } from 'devextreme-react/scheduler';
 import SpeedDialAction from 'devextreme-react/speed-dial-action';
 import { data, priorities } from './data.ts';
@@ -9,9 +9,9 @@ const cellDuration = 30;
 const currentDate = new Date(2021, 2, 25);
 
 const App = () => {
-  const schedulerRef = React.useRef<Scheduler>(null);
+  const schedulerRef = useRef<Scheduler>(null);
 
-  const showAppointmentPopup = React.useCallback(() => {
+  const showAppointmentPopup = useCallback(() => {
     schedulerRef.current?.instance.showAppointmentPopup();
   }, []);
 

--- a/JSDemos/Demos/Scheduler/Adaptability/ReactJs/App.js
+++ b/JSDemos/Demos/Scheduler/Adaptability/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import Scheduler, { Resource } from 'devextreme-react/scheduler';
 import SpeedDialAction from 'devextreme-react/speed-dial-action';
 import { data, priorities } from './data.js';
@@ -7,8 +7,8 @@ const views = ['week', 'month'];
 const cellDuration = 30;
 const currentDate = new Date(2021, 2, 25);
 const App = () => {
-  const schedulerRef = React.useRef(null);
-  const showAppointmentPopup = React.useCallback(() => {
+  const schedulerRef = useRef(null);
+  const showAppointmentPopup = useCallback(() => {
     schedulerRef.current?.instance.showAppointmentPopup();
   }, []);
   return (

--- a/JSDemos/Demos/Scheduler/AllDayPanelMode/React/App.tsx
+++ b/JSDemos/Demos/Scheduler/AllDayPanelMode/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Scheduler, { SchedulerTypes } from 'devextreme-react/scheduler';
 import RadioGroup, { RadioGroupTypes } from 'devextreme-react/radio-group';
 import { data } from './data.ts';
@@ -13,9 +13,9 @@ const views: SchedulerTypes.Properties['views'] = [{
 const allDayPanelItems = ['all', 'allDay', 'hidden'];
 
 const App = () => {
-  const [allDayPanelMode, setAllDayPanelMode] = React.useState<SchedulerTypes.AllDayPanelMode>('allDay');
+  const [allDayPanelMode, setAllDayPanelMode] = useState<SchedulerTypes.AllDayPanelMode>('allDay');
 
-  const onChangeAllDayPanelMode = React.useCallback((e: RadioGroupTypes.ValueChangedEvent) => {
+  const onChangeAllDayPanelMode = useCallback((e: RadioGroupTypes.ValueChangedEvent) => {
     setAllDayPanelMode(e.value);
   }, [setAllDayPanelMode]);
 

--- a/JSDemos/Demos/Scheduler/AllDayPanelMode/ReactJs/App.js
+++ b/JSDemos/Demos/Scheduler/AllDayPanelMode/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Scheduler from 'devextreme-react/scheduler';
 import RadioGroup from 'devextreme-react/radio-group';
 import { data } from './data.js';
@@ -14,8 +14,8 @@ const views = [
 ];
 const allDayPanelItems = ['all', 'allDay', 'hidden'];
 const App = () => {
-  const [allDayPanelMode, setAllDayPanelMode] = React.useState('allDay');
-  const onChangeAllDayPanelMode = React.useCallback(
+  const [allDayPanelMode, setAllDayPanelMode] = useState('allDay');
+  const onChangeAllDayPanelMode = useCallback(
     (e) => {
       setAllDayPanelMode(e.value);
     },

--- a/JSDemos/Demos/Scheduler/CellTemplates/React/App.tsx
+++ b/JSDemos/Demos/Scheduler/CellTemplates/React/App.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable func-style */
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import Scheduler, { SchedulerTypes } from 'devextreme-react/scheduler';
 import notify from 'devextreme/ui/notify';
@@ -54,15 +54,15 @@ const onAppointmentUpdating = (e: SchedulerTypes.AppointmentUpdatingEvent) => {
 };
 
 const App = () => {
-  const [currentView, setCurrentView] = React.useState<SchedulerTypes.ViewType>(views[0]);
+  const [currentView, setCurrentView] = useState<SchedulerTypes.ViewType>(views[0]);
 
-  const DataCellComponent = React.useMemo(() => (
+  const DataCellComponent = useMemo(() => (
     currentView === 'month' ? DataCellMonth : DataCell
   ), [currentView]);
 
-  const onCurrentViewChange = React.useCallback((value) => setCurrentView(value), [setCurrentView]);
+  const onCurrentViewChange = useCallback((value) => setCurrentView(value), [setCurrentView]);
 
-  const renderDateCell = React.useCallback((itemData) => (
+  const renderDateCell = useCallback((itemData) => (
     <DateCell itemData={itemData} currentView={currentView} />
   ), []);
 

--- a/JSDemos/Demos/Scheduler/CellTemplates/ReactJs/App.js
+++ b/JSDemos/Demos/Scheduler/CellTemplates/ReactJs/App.js
@@ -1,5 +1,5 @@
 /* eslint-disable func-style */
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import Scheduler from 'devextreme-react/scheduler';
 import notify from 'devextreme/ui/notify';
 import { data, holidays } from './data.js';
@@ -49,13 +49,13 @@ const onAppointmentUpdating = (e) => {
   }
 };
 const App = () => {
-  const [currentView, setCurrentView] = React.useState(views[0]);
-  const DataCellComponent = React.useMemo(
+  const [currentView, setCurrentView] = useState(views[0]);
+  const DataCellComponent = useMemo(
     () => (currentView === 'month' ? DataCellMonth : DataCell),
     [currentView],
   );
-  const onCurrentViewChange = React.useCallback((value) => setCurrentView(value), [setCurrentView]);
-  const renderDateCell = React.useCallback(
+  const onCurrentViewChange = useCallback((value) => setCurrentView(value), [setCurrentView]);
+  const renderDateCell = useCallback(
     (itemData) => (
       <DateCell
         itemData={itemData}

--- a/JSDemos/Demos/Scheduler/ContextMenuIntegration/React/App.tsx
+++ b/JSDemos/Demos/Scheduler/ContextMenuIntegration/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import Scheduler, { Resource, SchedulerTypes } from 'devextreme-react/scheduler';
 import ContextMenu, { ContextMenuTypes } from 'devextreme-react/context-menu';
 import { data, resourcesData, Resource as ResourceItem } from './data.ts';
@@ -17,15 +17,15 @@ const onContextMenuItemClick = (e: ContextMenuTypes.ItemClickEvent) => {
 };
 
 const App = () => {
-  const schedulerRef = React.useRef<Scheduler>(null);
-  const [currentDate, setCurrentDate] = React.useState(new Date(2020, 10, 25));
-  const [contextMenuItems, setContextMenuItems] = React.useState<ContextMenuItem[]>([]);
-  const [target, setTarget] = React.useState(appointmentClassName);
-  const [disabled, setDisabled] = React.useState(true);
-  const [groups, setGroups] = React.useState<string[] | undefined>(undefined);
-  const [crossScrollingEnabled, setCrossScrollingEnabled] = React.useState(false);
+  const schedulerRef = useRef<Scheduler>(null);
+  const [currentDate, setCurrentDate] = useState(new Date(2020, 10, 25));
+  const [contextMenuItems, setContextMenuItems] = useState<ContextMenuItem[]>([]);
+  const [target, setTarget] = useState(appointmentClassName);
+  const [disabled, setDisabled] = useState(true);
+  const [groups, setGroups] = useState<string[] | undefined>(undefined);
+  const [crossScrollingEnabled, setCrossScrollingEnabled] = useState(false);
 
-  const onAppointmentContextMenu = React.useCallback((event: SchedulerTypes.AppointmentContextMenuEvent) => {
+  const onAppointmentContextMenu = useCallback((event: SchedulerTypes.AppointmentContextMenuEvent) => {
     const { appointmentData, targetedAppointmentData } = event;
     const scheduler = schedulerRef.current?.instance;
 
@@ -66,7 +66,7 @@ const App = () => {
   }
   , []);
 
-  const onCellContextMenu = React.useCallback((e: SchedulerTypes.CellContextMenuEvent) => {
+  const onCellContextMenu = useCallback((e: SchedulerTypes.CellContextMenuEvent) => {
     const scheduler = schedulerRef.current?.instance;
 
     setTarget(cellClassName);

--- a/JSDemos/Demos/Scheduler/ContextMenuIntegration/ReactJs/App.js
+++ b/JSDemos/Demos/Scheduler/ContextMenuIntegration/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import Scheduler, { Resource } from 'devextreme-react/scheduler';
 import ContextMenu from 'devextreme-react/context-menu';
 import { data, resourcesData } from './data.js';
@@ -11,14 +11,14 @@ const onContextMenuItemClick = (e) => {
   e.itemData.onItemClick?.(e);
 };
 const App = () => {
-  const schedulerRef = React.useRef(null);
-  const [currentDate, setCurrentDate] = React.useState(new Date(2020, 10, 25));
-  const [contextMenuItems, setContextMenuItems] = React.useState([]);
-  const [target, setTarget] = React.useState(appointmentClassName);
-  const [disabled, setDisabled] = React.useState(true);
-  const [groups, setGroups] = React.useState(undefined);
-  const [crossScrollingEnabled, setCrossScrollingEnabled] = React.useState(false);
-  const onAppointmentContextMenu = React.useCallback((event) => {
+  const schedulerRef = useRef(null);
+  const [currentDate, setCurrentDate] = useState(new Date(2020, 10, 25));
+  const [contextMenuItems, setContextMenuItems] = useState([]);
+  const [target, setTarget] = useState(appointmentClassName);
+  const [disabled, setDisabled] = useState(true);
+  const [groups, setGroups] = useState(undefined);
+  const [crossScrollingEnabled, setCrossScrollingEnabled] = useState(false);
+  const onAppointmentContextMenu = useCallback((event) => {
     const { appointmentData, targetedAppointmentData } = event;
     const scheduler = schedulerRef.current?.instance;
     const resourceItems = resourcesData.map((item) => ({
@@ -57,7 +57,7 @@ const App = () => {
       ...resourceItems,
     ]);
   }, []);
-  const onCellContextMenu = React.useCallback(
+  const onCellContextMenu = useCallback(
     (e) => {
       const scheduler = schedulerRef.current?.instance;
       setTarget(cellClassName);

--- a/JSDemos/Demos/Scheduler/CurrentTimeIndicator/React/App.tsx
+++ b/JSDemos/Demos/Scheduler/CurrentTimeIndicator/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Scheduler, { Resource, SchedulerTypes } from 'devextreme-react/scheduler';
 import { Switch, SwitchTypes } from 'devextreme-react/switch';
 import { NumberBox, NumberBoxTypes } from 'devextreme-react/number-box';
@@ -24,19 +24,19 @@ const onAppointmentDblClick = (e: SchedulerTypes.AppointmentDblClickEvent) => {
 };
 
 const App = () => {
-  const [showCurrentTimeIndicator, setShowCurrentTimeIndicator] = React.useState(true);
-  const [shadeUntilCurrentTime, setShadeUntilCurrentTime] = React.useState(true);
-  const [updateInterval, setUpdateInterval] = React.useState(10);
+  const [showCurrentTimeIndicator, setShowCurrentTimeIndicator] = useState(true);
+  const [shadeUntilCurrentTime, setShadeUntilCurrentTime] = useState(true);
+  const [updateInterval, setUpdateInterval] = useState(10);
 
-  const onShowCurrentTimeIndicatorChanged = React.useCallback((e: SwitchTypes.ValueChangedEvent) => {
+  const onShowCurrentTimeIndicatorChanged = useCallback((e: SwitchTypes.ValueChangedEvent) => {
     setShowCurrentTimeIndicator(e.value);
   }, []);
 
-  const onShadeUntilCurrentTimeChanged = React.useCallback((e: SwitchTypes.ValueChangedEvent) => {
+  const onShadeUntilCurrentTimeChanged = useCallback((e: SwitchTypes.ValueChangedEvent) => {
     setShadeUntilCurrentTime(e.value);
   }, []);
 
-  const onUpdateIntervalChanged = React.useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
+  const onUpdateIntervalChanged = useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
     setUpdateInterval(e.value);
   }, []);
 

--- a/JSDemos/Demos/Scheduler/CurrentTimeIndicator/ReactJs/App.js
+++ b/JSDemos/Demos/Scheduler/CurrentTimeIndicator/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Scheduler, { Resource } from 'devextreme-react/scheduler';
 import { Switch } from 'devextreme-react/switch';
 import { NumberBox } from 'devextreme-react/number-box';
@@ -18,16 +18,16 @@ const onAppointmentDblClick = (e) => {
   e.cancel = true;
 };
 const App = () => {
-  const [showCurrentTimeIndicator, setShowCurrentTimeIndicator] = React.useState(true);
-  const [shadeUntilCurrentTime, setShadeUntilCurrentTime] = React.useState(true);
-  const [updateInterval, setUpdateInterval] = React.useState(10);
-  const onShowCurrentTimeIndicatorChanged = React.useCallback((e) => {
+  const [showCurrentTimeIndicator, setShowCurrentTimeIndicator] = useState(true);
+  const [shadeUntilCurrentTime, setShadeUntilCurrentTime] = useState(true);
+  const [updateInterval, setUpdateInterval] = useState(10);
+  const onShowCurrentTimeIndicatorChanged = useCallback((e) => {
     setShowCurrentTimeIndicator(e.value);
   }, []);
-  const onShadeUntilCurrentTimeChanged = React.useCallback((e) => {
+  const onShadeUntilCurrentTimeChanged = useCallback((e) => {
     setShadeUntilCurrentTime(e.value);
   }, []);
-  const onUpdateIntervalChanged = React.useCallback((e) => {
+  const onUpdateIntervalChanged = useCallback((e) => {
     setUpdateInterval(e.value);
   }, []);
   return (

--- a/JSDemos/Demos/Scheduler/CustomDragAndDrop/React/App.tsx
+++ b/JSDemos/Demos/Scheduler/CustomDragAndDrop/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import Scheduler, { AppointmentDragging, SchedulerTypes } from 'devextreme-react/scheduler';
 import Draggable, { DraggableTypes } from 'devextreme-react/draggable';
@@ -25,11 +25,11 @@ const onItemDragEnd = (e: DraggableTypes.DragEndEvent) => {
 };
 
 const App = () => {
-  const [state, setState] = React.useState({
+  const [state, setState] = useState({
     tasks: defaultTasks, appointments: defaultAppointments,
   });
 
-  const onAppointmentRemove = React.useCallback((e: SchedulerTypes.AppointmentDraggingRemoveEvent) => {
+  const onAppointmentRemove = useCallback((e: SchedulerTypes.AppointmentDraggingRemoveEvent) => {
     setState((currentState: { appointments: SchedulerTypes.Appointment[]; tasks: Task[]; }) => {
       const { appointments, tasks } = currentState;
 
@@ -44,7 +44,7 @@ const App = () => {
     });
   }, []);
 
-  const onAppointmentAdd = React.useCallback((e: SchedulerTypes.AppointmentDraggingAddEvent) => {
+  const onAppointmentAdd = useCallback((e: SchedulerTypes.AppointmentDraggingAddEvent) => {
     setState((currentState: { appointments: SchedulerTypes.Appointment[]; tasks: Task[]; }) => {
       const { appointments, tasks } = currentState;
 

--- a/JSDemos/Demos/Scheduler/CustomDragAndDrop/ReactJs/App.js
+++ b/JSDemos/Demos/Scheduler/CustomDragAndDrop/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Scheduler, { AppointmentDragging } from 'devextreme-react/scheduler';
 import Draggable from 'devextreme-react/draggable';
 import ScrollView from 'devextreme-react/scroll-view';
@@ -19,11 +19,11 @@ const onItemDragEnd = (e) => {
   }
 };
 const App = () => {
-  const [state, setState] = React.useState({
+  const [state, setState] = useState({
     tasks: defaultTasks,
     appointments: defaultAppointments,
   });
-  const onAppointmentRemove = React.useCallback((e) => {
+  const onAppointmentRemove = useCallback((e) => {
     setState((currentState) => {
       const { appointments, tasks } = currentState;
       const index = appointments.indexOf(e.itemData);
@@ -34,7 +34,7 @@ const App = () => {
       return { appointments: [...appointments], tasks: [...tasks] };
     });
   }, []);
-  const onAppointmentAdd = React.useCallback((e) => {
+  const onAppointmentAdd = useCallback((e) => {
     setState((currentState) => {
       const { appointments, tasks } = currentState;
       const index = tasks.indexOf(e.fromData);

--- a/JSDemos/Demos/Scheduler/CustomTemplates/React/Appointment.tsx
+++ b/JSDemos/Demos/Scheduler/CustomTemplates/React/Appointment.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Query from 'devextreme/data/query';
 import localization from 'devextreme/localization';
 import { SchedulerTypes } from 'devextreme-react/scheduler';
@@ -14,7 +14,7 @@ const Appointment = (props: AppointmentProps) => {
   const { targetedAppointmentData } = props.data;
   const { movieId } = targetedAppointmentData;
 
-  const movieData = React.useMemo(() => getMovieById(movieId), [movieId]);
+  const movieData = useMemo(() => getMovieById(movieId), [movieId]);
 
   return (
     <div className="showtime-preview">

--- a/JSDemos/Demos/Scheduler/CustomTemplates/React/AppointmentTooltip.tsx
+++ b/JSDemos/Demos/Scheduler/CustomTemplates/React/AppointmentTooltip.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Query from 'devextreme/data/query';
 import { SchedulerTypes } from 'devextreme-react/scheduler';
 
@@ -13,7 +13,7 @@ type AppointmentProps = {
 const AppointmentTooltip = (props: AppointmentProps) => {
   const { movieId } = props.data.appointmentData;
 
-  const movieData = React.useMemo(() => getMovieById(movieId), [movieId]);
+  const movieData = useMemo(() => getMovieById(movieId), [movieId]);
 
   return (
     <div className="movie-tooltip">

--- a/JSDemos/Demos/Scheduler/CustomTemplates/ReactJs/Appointment.js
+++ b/JSDemos/Demos/Scheduler/CustomTemplates/ReactJs/Appointment.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Query from 'devextreme/data/query';
 import localization from 'devextreme/localization';
 import { moviesData } from './data.js';
@@ -7,7 +7,7 @@ const getMovieById = (id) => Query(moviesData).filter(['id', id]).toArray()[0];
 const Appointment = (props) => {
   const { targetedAppointmentData } = props.data;
   const { movieId } = targetedAppointmentData;
-  const movieData = React.useMemo(() => getMovieById(movieId), [movieId]);
+  const movieData = useMemo(() => getMovieById(movieId), [movieId]);
   return (
     <div className="showtime-preview">
       <div> {movieData.text}</div>

--- a/JSDemos/Demos/Scheduler/CustomTemplates/ReactJs/AppointmentTooltip.js
+++ b/JSDemos/Demos/Scheduler/CustomTemplates/ReactJs/AppointmentTooltip.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Query from 'devextreme/data/query';
 import { moviesData } from './data.js';
 
 const getMovieById = (id) => Query(moviesData).filter(['id', id]).toArray()[0];
 const AppointmentTooltip = (props) => {
   const { movieId } = props.data.appointmentData;
-  const movieData = React.useMemo(() => getMovieById(movieId), [movieId]);
+  const movieData = useMemo(() => getMovieById(movieId), [movieId]);
   return (
     <div className="movie-tooltip">
       <img src={movieData.image} />

--- a/JSDemos/Demos/Scheduler/Editing/React/App.tsx
+++ b/JSDemos/Demos/Scheduler/Editing/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Scheduler, { Editing, SchedulerTypes } from 'devextreme-react/scheduler';
 import { CheckBox, CheckBoxTypes } from 'devextreme-react/check-box';
 import notify from 'devextreme/ui/notify';
@@ -25,21 +25,21 @@ const showDeletedToast = (e: SchedulerTypes.AppointmentDeletedEvent) => {
 };
 
 const App = () => {
-  const [allowAdding, setAllowAdding] = React.useState(true);
-  const [allowDeleting, setAllowDeleting] = React.useState(true);
-  const [allowResizing, setAllowResizing] = React.useState(true);
-  const [allowDragging, setAllowDragging] = React.useState(true);
-  const [allowUpdating, setAllowUpdating] = React.useState(true);
+  const [allowAdding, setAllowAdding] = useState(true);
+  const [allowDeleting, setAllowDeleting] = useState(true);
+  const [allowResizing, setAllowResizing] = useState(true);
+  const [allowDragging, setAllowDragging] = useState(true);
+  const [allowUpdating, setAllowUpdating] = useState(true);
 
-  const onAllowAddingChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => setAllowAdding(e.value), []);
+  const onAllowAddingChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => setAllowAdding(e.value), []);
 
-  const onAllowDeletingChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => setAllowDeleting(e.value), []);
+  const onAllowDeletingChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => setAllowDeleting(e.value), []);
 
-  const onAllowResizingChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => setAllowResizing(e.value), []);
+  const onAllowResizingChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => setAllowResizing(e.value), []);
 
-  const onAllowDraggingChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => setAllowDragging(e.value), []);
+  const onAllowDraggingChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => setAllowDragging(e.value), []);
 
-  const onAllowUpdatingChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => setAllowUpdating(e.value), []);
+  const onAllowUpdatingChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => setAllowUpdating(e.value), []);
 
   return (
     <React.Fragment>

--- a/JSDemos/Demos/Scheduler/Editing/ReactJs/App.js
+++ b/JSDemos/Demos/Scheduler/Editing/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Scheduler, { Editing } from 'devextreme-react/scheduler';
 import { CheckBox } from 'devextreme-react/check-box';
 import notify from 'devextreme/ui/notify';
@@ -19,16 +19,16 @@ const showDeletedToast = (e) => {
   showToast('Deleted', e.appointmentData.text, 'warning');
 };
 const App = () => {
-  const [allowAdding, setAllowAdding] = React.useState(true);
-  const [allowDeleting, setAllowDeleting] = React.useState(true);
-  const [allowResizing, setAllowResizing] = React.useState(true);
-  const [allowDragging, setAllowDragging] = React.useState(true);
-  const [allowUpdating, setAllowUpdating] = React.useState(true);
-  const onAllowAddingChanged = React.useCallback((e) => setAllowAdding(e.value), []);
-  const onAllowDeletingChanged = React.useCallback((e) => setAllowDeleting(e.value), []);
-  const onAllowResizingChanged = React.useCallback((e) => setAllowResizing(e.value), []);
-  const onAllowDraggingChanged = React.useCallback((e) => setAllowDragging(e.value), []);
-  const onAllowUpdatingChanged = React.useCallback((e) => setAllowUpdating(e.value), []);
+  const [allowAdding, setAllowAdding] = useState(true);
+  const [allowDeleting, setAllowDeleting] = useState(true);
+  const [allowResizing, setAllowResizing] = useState(true);
+  const [allowDragging, setAllowDragging] = useState(true);
+  const [allowUpdating, setAllowUpdating] = useState(true);
+  const onAllowAddingChanged = useCallback((e) => setAllowAdding(e.value), []);
+  const onAllowDeletingChanged = useCallback((e) => setAllowDeleting(e.value), []);
+  const onAllowResizingChanged = useCallback((e) => setAllowResizing(e.value), []);
+  const onAllowDraggingChanged = useCallback((e) => setAllowDragging(e.value), []);
+  const onAllowUpdatingChanged = useCallback((e) => setAllowUpdating(e.value), []);
   return (
     <React.Fragment>
       <Scheduler

--- a/JSDemos/Demos/Scheduler/GroupByDate/React/App.tsx
+++ b/JSDemos/Demos/Scheduler/GroupByDate/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import Switch, { SwitchTypes } from 'devextreme-react/switch';
 import Scheduler, { Resource, View } from 'devextreme-react/scheduler';
@@ -9,9 +9,9 @@ const currentDate = new Date(2021, 3, 21);
 const groups = ['priorityId'];
 
 const App = () => {
-  const [groupByDate, setGroupByDate] = React.useState(true);
+  const [groupByDate, setGroupByDate] = useState(true);
 
-  const onGroupByDateChanged = React.useCallback((args: SwitchTypes.ValueChangedEvent) => {
+  const onGroupByDateChanged = useCallback((args: SwitchTypes.ValueChangedEvent) => {
     setGroupByDate(args.value);
   }, []);
 

--- a/JSDemos/Demos/Scheduler/GroupByDate/ReactJs/App.js
+++ b/JSDemos/Demos/Scheduler/GroupByDate/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Switch from 'devextreme-react/switch';
 import Scheduler, { Resource, View } from 'devextreme-react/scheduler';
 import { data, priorityData } from './data.js';
@@ -6,8 +6,8 @@ import { data, priorityData } from './data.js';
 const currentDate = new Date(2021, 3, 21);
 const groups = ['priorityId'];
 const App = () => {
-  const [groupByDate, setGroupByDate] = React.useState(true);
-  const onGroupByDateChanged = React.useCallback((args) => {
+  const [groupByDate, setGroupByDate] = useState(true);
+  const onGroupByDateChanged = useCallback((args) => {
     setGroupByDate(args.value);
   }, []);
   return (

--- a/JSDemos/Demos/Scheduler/Resources/React/App.tsx
+++ b/JSDemos/Demos/Scheduler/Resources/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import Scheduler, { Resource, SchedulerTypes } from 'devextreme-react/scheduler';
 
@@ -12,9 +12,9 @@ const currentDate = new Date(2021, 3, 27);
 const views: SchedulerTypes.ViewType[] = ['workWeek'];
 
 const App = () => {
-  const [currentResource, setCurrentResource] = React.useState(resourcesList[0]);
+  const [currentResource, setCurrentResource] = useState(resourcesList[0]);
 
-  const onRadioGroupValueChanged = React.useCallback((e: RadioGroupTypes.ValueChangedEvent) => {
+  const onRadioGroupValueChanged = useCallback((e: RadioGroupTypes.ValueChangedEvent) => {
     setCurrentResource(e.value);
   }, []);
 

--- a/JSDemos/Demos/Scheduler/Resources/ReactJs/App.js
+++ b/JSDemos/Demos/Scheduler/Resources/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Scheduler, { Resource } from 'devextreme-react/scheduler';
 import RadioGroup from 'devextreme-react/radio-group';
 import {
@@ -8,8 +8,8 @@ import {
 const currentDate = new Date(2021, 3, 27);
 const views = ['workWeek'];
 const App = () => {
-  const [currentResource, setCurrentResource] = React.useState(resourcesList[0]);
-  const onRadioGroupValueChanged = React.useCallback((e) => {
+  const [currentResource, setCurrentResource] = useState(resourcesList[0]);
+  const onRadioGroupValueChanged = useCallback((e) => {
     setCurrentResource(e.value);
   }, []);
   return (

--- a/JSDemos/Demos/Scheduler/TimeZonesSupport/React/App.tsx
+++ b/JSDemos/Demos/Scheduler/TimeZonesSupport/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Scheduler, { Editing, SchedulerTypes } from 'devextreme-react/scheduler';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 
@@ -35,14 +35,14 @@ const onAppointmentFormOpening = (e: SchedulerTypes.AppointmentFormOpeningEvent)
 };
 
 const App = () => {
-  const [currentTimeZone, setCurrentTimeZone] = React.useState(defaultTimeZones[0].id);
-  const [timeZones, setTimeZones] = React.useState(defaultTimeZones);
+  const [currentTimeZone, setCurrentTimeZone] = useState(defaultTimeZones[0].id);
+  const [timeZones, setTimeZones] = useState(defaultTimeZones);
 
-  const onValueChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const onValueChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setCurrentTimeZone(e.value);
   }, []);
 
-  const onOptionChanged = React.useCallback((e: SchedulerTypes.OptionChangedEvent) => {
+  const onOptionChanged = useCallback((e: SchedulerTypes.OptionChangedEvent) => {
     if (e.name === 'currentDate') {
       setTimeZones(getTimeZones(e.value));
     }

--- a/JSDemos/Demos/Scheduler/TimeZonesSupport/ReactJs/App.js
+++ b/JSDemos/Demos/Scheduler/TimeZonesSupport/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Scheduler, { Editing } from 'devextreme-react/scheduler';
 import SelectBox from 'devextreme-react/select-box';
 import timeZoneUtils from 'devextreme/time_zone_utils';
@@ -24,12 +24,12 @@ const onAppointmentFormOpening = (e) => {
   endDateDataSource.load();
 };
 const App = () => {
-  const [currentTimeZone, setCurrentTimeZone] = React.useState(defaultTimeZones[0].id);
-  const [timeZones, setTimeZones] = React.useState(defaultTimeZones);
-  const onValueChanged = React.useCallback((e) => {
+  const [currentTimeZone, setCurrentTimeZone] = useState(defaultTimeZones[0].id);
+  const [timeZones, setTimeZones] = useState(defaultTimeZones);
+  const onValueChanged = useCallback((e) => {
     setCurrentTimeZone(e.value);
   }, []);
-  const onOptionChanged = React.useCallback((e) => {
+  const onOptionChanged = useCallback((e) => {
     if (e.name === 'currentDate') {
       setTimeZones(getTimeZones(e.value));
     }

--- a/JSDemos/Demos/Scheduler/WorkShifts/React/App.tsx
+++ b/JSDemos/Demos/Scheduler/WorkShifts/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import Scheduler, { SchedulerTypes } from 'devextreme-react/scheduler';
 import RadioGroup from 'devextreme-react/radio-group';
@@ -9,7 +9,7 @@ const currentDate = new Date(2021, 2, 30);
 const views: SchedulerTypes.ViewType[] = ['day', 'workWeek'];
 
 const App = () => {
-  const [currentShift, setCurrentShift] = React.useState(shifts[0]);
+  const [currentShift, setCurrentShift] = useState(shifts[0]);
 
   return <React.Fragment>
     <div className="options">

--- a/JSDemos/Demos/Scheduler/WorkShifts/ReactJs/App.js
+++ b/JSDemos/Demos/Scheduler/WorkShifts/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Scheduler from 'devextreme-react/scheduler';
 import RadioGroup from 'devextreme-react/radio-group';
 import { data, shifts } from './data.js';
@@ -6,7 +6,7 @@ import { data, shifts } from './data.js';
 const currentDate = new Date(2021, 2, 30);
 const views = ['day', 'workWeek'];
 const App = () => {
-  const [currentShift, setCurrentShift] = React.useState(shifts[0]);
+  const [currentShift, setCurrentShift] = useState(shifts[0]);
   return (
     <React.Fragment>
       <div className="options">

--- a/JSDemos/Demos/ScrollView/Overview/React/App.tsx
+++ b/JSDemos/Demos/ScrollView/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import ScrollView, { ScrollViewTypes } from 'devextreme-react/scroll-view';
 import SelectBox from 'devextreme-react/select-box';
 import CheckBox, { CheckBoxTypes } from 'devextreme-react/check-box';
@@ -9,15 +9,15 @@ const showScrollBarModeLabel = { 'aria-label': 'Show Scrollbar Mode' };
 let updateContentTimer;
 
 const App = () => {
-  const [showScrollBarMode, setShowScrollBarMode] = React.useState<ScrollViewTypes.Properties['showScrollbar']>('onScroll');
-  const [pullDown, setPullDown] = React.useState(false);
-  const [scrollByContent, setScrollByContent] = React.useState(true);
-  const [scrollByThumb, setScrollByThumb] = React.useState(true);
-  const [content, setContent] = React.useState(service.getContent());
+  const [showScrollBarMode, setShowScrollBarMode] = useState<ScrollViewTypes.Properties['showScrollbar']>('onScroll');
+  const [pullDown, setPullDown] = useState(false);
+  const [scrollByContent, setScrollByContent] = useState(true);
+  const [scrollByThumb, setScrollByThumb] = useState(true);
+  const [content, setContent] = useState(service.getContent());
 
-  const scrollViewRef = React.useRef(null);
+  const scrollViewRef = useRef(null);
 
-  const updateContent = React.useCallback((args: UpdateContentArgs, eventName: string) => {
+  const updateContent = useCallback((args: UpdateContentArgs, eventName: string) => {
     const updateContentText = `\n Content has been updated on the ${eventName} event.\n\n`;
     if (updateContentTimer) {
       clearTimeout(updateContentTimer);
@@ -28,19 +28,19 @@ const App = () => {
     }, 500);
   }, [content, setContent]);
 
-  const updateTopContent = React.useCallback((args: ScrollViewTypes.PullDownEvent) => {
+  const updateTopContent = useCallback((args: ScrollViewTypes.PullDownEvent) => {
     updateContent(args, 'PullDown');
   }, [updateContent]);
 
-  const updateBottomContent = React.useCallback((args: ScrollViewTypes.ReachBottomEvent) => {
+  const updateBottomContent = useCallback((args: ScrollViewTypes.ReachBottomEvent) => {
     updateContent(args, 'ReachBottom');
   }, [updateContent]);
 
-  const pullDownValueChanged = React.useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
+  const pullDownValueChanged = useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
     setPullDown(args.value);
   }, [setPullDown]);
 
-  const reachBottomValueChanged = React.useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
+  const reachBottomValueChanged = useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
     scrollViewRef.current.instance.option('onReachBottom', args.value ? updateBottomContent : null);
   }, [updateBottomContent]);
 

--- a/JSDemos/Demos/ScrollView/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/ScrollView/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import ScrollView from 'devextreme-react/scroll-view';
 import SelectBox from 'devextreme-react/select-box';
 import CheckBox from 'devextreme-react/check-box';
@@ -7,13 +7,13 @@ import service from './data.js';
 const showScrollBarModeLabel = { 'aria-label': 'Show Scrollbar Mode' };
 let updateContentTimer;
 const App = () => {
-  const [showScrollBarMode, setShowScrollBarMode] = React.useState('onScroll');
-  const [pullDown, setPullDown] = React.useState(false);
-  const [scrollByContent, setScrollByContent] = React.useState(true);
-  const [scrollByThumb, setScrollByThumb] = React.useState(true);
-  const [content, setContent] = React.useState(service.getContent());
-  const scrollViewRef = React.useRef(null);
-  const updateContent = React.useCallback(
+  const [showScrollBarMode, setShowScrollBarMode] = useState('onScroll');
+  const [pullDown, setPullDown] = useState(false);
+  const [scrollByContent, setScrollByContent] = useState(true);
+  const [scrollByThumb, setScrollByThumb] = useState(true);
+  const [content, setContent] = useState(service.getContent());
+  const scrollViewRef = useRef(null);
+  const updateContent = useCallback(
     (args, eventName) => {
       const updateContentText = `\n Content has been updated on the ${eventName} event.\n\n`;
       if (updateContentTimer) {
@@ -28,25 +28,25 @@ const App = () => {
     },
     [content, setContent],
   );
-  const updateTopContent = React.useCallback(
+  const updateTopContent = useCallback(
     (args) => {
       updateContent(args, 'PullDown');
     },
     [updateContent],
   );
-  const updateBottomContent = React.useCallback(
+  const updateBottomContent = useCallback(
     (args) => {
       updateContent(args, 'ReachBottom');
     },
     [updateContent],
   );
-  const pullDownValueChanged = React.useCallback(
+  const pullDownValueChanged = useCallback(
     (args) => {
       setPullDown(args.value);
     },
     [setPullDown],
   );
-  const reachBottomValueChanged = React.useCallback(
+  const reachBottomValueChanged = useCallback(
     (args) => {
       scrollViewRef.current.instance.option(
         'onReachBottom',

--- a/JSDemos/Demos/SelectBox/CustomizeDropDownButton/React/App.tsx
+++ b/JSDemos/Demos/SelectBox/CustomizeDropDownButton/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 
 import { Template } from 'devextreme-react/core/template';
@@ -15,10 +15,10 @@ import ConditionalIcon from './conditionalIcon.tsx';
 import Item from './item.tsx';
 
 function App() {
-  const [selectedItem, setSelectedItem] = React.useState(products[0]);
-  const [isLoaded, setIsLoaded] = React.useState(true);
+  const [selectedItem, setSelectedItem] = useState(products[0]);
+  const [isLoaded, setIsLoaded] = useState(true);
 
-  const deferredProducts = React.useMemo<any>(
+  const deferredProducts = useMemo<any>(
     () => ({
       loadMode: 'raw',
       load: () => {
@@ -36,17 +36,17 @@ function App() {
     [setIsLoaded],
   );
 
-  const renderLoadIndicator = React.useCallback(
+  const renderLoadIndicator = useCallback(
     () => <IndicatorIcon isLoaded={isLoaded} />,
     [isLoaded],
   );
 
-  const renderConditionalIcon = React.useCallback(
+  const renderConditionalIcon = useCallback(
     () => <ConditionalIcon value={selectedItem} />,
     [selectedItem],
   );
 
-  const selectionChanged = React.useCallback((event: { selectedItem: any }) => {
+  const selectionChanged = useCallback((event: { selectedItem: any }) => {
     setSelectedItem(event.selectedItem);
   }, []);
 

--- a/JSDemos/Demos/SelectBox/CustomizeDropDownButton/ReactJs/App.js
+++ b/JSDemos/Demos/SelectBox/CustomizeDropDownButton/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import { Template } from 'devextreme-react/core/template';
 import {
@@ -14,9 +14,9 @@ import ConditionalIcon from './conditionalIcon.js';
 import Item from './item.js';
 
 function App() {
-  const [selectedItem, setSelectedItem] = React.useState(products[0]);
-  const [isLoaded, setIsLoaded] = React.useState(true);
-  const deferredProducts = React.useMemo(
+  const [selectedItem, setSelectedItem] = useState(products[0]);
+  const [isLoaded, setIsLoaded] = useState(true);
+  const deferredProducts = useMemo(
     () => ({
       loadMode: 'raw',
       load: () => {
@@ -32,15 +32,15 @@ function App() {
     }),
     [setIsLoaded],
   );
-  const renderLoadIndicator = React.useCallback(
+  const renderLoadIndicator = useCallback(
     () => <IndicatorIcon isLoaded={isLoaded} />,
     [isLoaded],
   );
-  const renderConditionalIcon = React.useCallback(
+  const renderConditionalIcon = useCallback(
     () => <ConditionalIcon value={selectedItem} />,
     [selectedItem],
   );
-  const selectionChanged = React.useCallback((event) => {
+  const selectionChanged = useCallback((event) => {
     setSelectedItem(event.selectedItem);
   }, []);
   return (

--- a/JSDemos/Demos/SelectBox/CustomizeDropDownButton/ReactJs/App.js
+++ b/JSDemos/Demos/SelectBox/CustomizeDropDownButton/ReactJs/App.js
@@ -32,10 +32,7 @@ function App() {
     }),
     [setIsLoaded],
   );
-  const renderLoadIndicator = useCallback(
-    () => <IndicatorIcon isLoaded={isLoaded} />,
-    [isLoaded],
-  );
+  const renderLoadIndicator = useCallback(() => <IndicatorIcon isLoaded={isLoaded} />, [isLoaded]);
   const renderConditionalIcon = useCallback(
     () => <ConditionalIcon value={selectedItem} />,
     [selectedItem],

--- a/JSDemos/Demos/SelectBox/Overview/React/App.tsx
+++ b/JSDemos/Demos/SelectBox/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 import ArrayStore from 'devextreme/data/array_store';
 import notify from 'devextreme/ui/notify';
@@ -23,9 +23,9 @@ const data = new ArrayStore({
 });
 
 function App() {
-  const [value, setValue] = React.useState(service.getSimpleProducts()[0]);
+  const [value, setValue] = useState(service.getSimpleProducts()[0]);
 
-  const onValueChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const onValueChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setValue(e.value);
     notify(`The value is changed to: "${e.value}"`);
   }, []);

--- a/JSDemos/Demos/SelectBox/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/SelectBox/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import ArrayStore from 'devextreme/data/array_store';
 import notify from 'devextreme/ui/notify';
@@ -20,8 +20,8 @@ const data = new ArrayStore({
   key: 'ID',
 });
 function App() {
-  const [value, setValue] = React.useState(service.getSimpleProducts()[0]);
-  const onValueChanged = React.useCallback((e) => {
+  const [value, setValue] = useState(service.getSimpleProducts()[0]);
+  const onValueChanged = useCallback((e) => {
     setValue(e.value);
     notify(`The value is changed to: "${e.value}"`);
   }, []);

--- a/JSDemos/Demos/SelectBox/SearchAndEditing/React/App.tsx
+++ b/JSDemos/Demos/SelectBox/SearchAndEditing/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { SelectBox, SelectBoxTypes } from 'devextreme-react/select-box';
 import { NumberBox } from 'devextreme-react/number-box';
 import { CheckBox } from 'devextreme-react/check-box';
@@ -59,34 +59,34 @@ const customItemCreating = (args: SelectBoxTypes.CustomItemCreatingEvent) => {
 };
 
 function App() {
-  const [editBoxValue, setEditBoxValue] = React.useState(simpleProducts[0]);
-  const [searchModeOption, setSearchModeOption] = React.useState<SimplifiedSearchMode>('contains');
-  const [searchExprOption, setSearchExprOption] = React.useState('Name');
-  const [searchTimeoutOption, setSearchTimeoutOption] = React.useState(200);
-  const [minSearchLengthOption, setMinSearchLengthOption] = React.useState(0);
-  const [showDataBeforeSearchOption, setShowDataBeforeSearchOption] = React.useState(false);
+  const [editBoxValue, setEditBoxValue] = useState(simpleProducts[0]);
+  const [searchModeOption, setSearchModeOption] = useState<SimplifiedSearchMode>('contains');
+  const [searchExprOption, setSearchExprOption] = useState('Name');
+  const [searchTimeoutOption, setSearchTimeoutOption] = useState(200);
+  const [minSearchLengthOption, setMinSearchLengthOption] = useState(0);
+  const [showDataBeforeSearchOption, setShowDataBeforeSearchOption] = useState(false);
 
-  const editBoxValueChanged = React.useCallback(({ component }) => {
+  const editBoxValueChanged = useCallback(({ component }) => {
     setEditBoxValue(component.option('selectedItem'));
   }, []);
 
-  const searchModeOptionChanged = React.useCallback(({ value }) => {
+  const searchModeOptionChanged = useCallback(({ value }) => {
     setSearchModeOption(value);
   }, []);
 
-  const searchExprOptionChanged = React.useCallback(({ value }) => {
+  const searchExprOptionChanged = useCallback(({ value }) => {
     setSearchExprOption(value);
   }, []);
 
-  const searchTimeoutOptionChanged = React.useCallback(({ value }) => {
+  const searchTimeoutOptionChanged = useCallback(({ value }) => {
     setSearchTimeoutOption(value);
   }, []);
 
-  const minSearchLengthOptionChanged = React.useCallback(({ value }) => {
+  const minSearchLengthOptionChanged = useCallback(({ value }) => {
     setMinSearchLengthOption(value);
   }, []);
 
-  const showDataBeforeSearchOptionChanged = React.useCallback(({ value }) => {
+  const showDataBeforeSearchOptionChanged = useCallback(({ value }) => {
     setShowDataBeforeSearchOption(value);
   }, []);
 

--- a/JSDemos/Demos/SelectBox/SearchAndEditing/ReactJs/App.js
+++ b/JSDemos/Demos/SelectBox/SearchAndEditing/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { SelectBox } from 'devextreme-react/select-box';
 import { NumberBox } from 'devextreme-react/number-box';
 import { CheckBox } from 'devextreme-react/check-box';
@@ -53,28 +53,28 @@ const customItemCreating = (args) => {
     });
 };
 function App() {
-  const [editBoxValue, setEditBoxValue] = React.useState(simpleProducts[0]);
-  const [searchModeOption, setSearchModeOption] = React.useState('contains');
-  const [searchExprOption, setSearchExprOption] = React.useState('Name');
-  const [searchTimeoutOption, setSearchTimeoutOption] = React.useState(200);
-  const [minSearchLengthOption, setMinSearchLengthOption] = React.useState(0);
-  const [showDataBeforeSearchOption, setShowDataBeforeSearchOption] = React.useState(false);
-  const editBoxValueChanged = React.useCallback(({ component }) => {
+  const [editBoxValue, setEditBoxValue] = useState(simpleProducts[0]);
+  const [searchModeOption, setSearchModeOption] = useState('contains');
+  const [searchExprOption, setSearchExprOption] = useState('Name');
+  const [searchTimeoutOption, setSearchTimeoutOption] = useState(200);
+  const [minSearchLengthOption, setMinSearchLengthOption] = useState(0);
+  const [showDataBeforeSearchOption, setShowDataBeforeSearchOption] = useState(false);
+  const editBoxValueChanged = useCallback(({ component }) => {
     setEditBoxValue(component.option('selectedItem'));
   }, []);
-  const searchModeOptionChanged = React.useCallback(({ value }) => {
+  const searchModeOptionChanged = useCallback(({ value }) => {
     setSearchModeOption(value);
   }, []);
-  const searchExprOptionChanged = React.useCallback(({ value }) => {
+  const searchExprOptionChanged = useCallback(({ value }) => {
     setSearchExprOption(value);
   }, []);
-  const searchTimeoutOptionChanged = React.useCallback(({ value }) => {
+  const searchTimeoutOptionChanged = useCallback(({ value }) => {
     setSearchTimeoutOption(value);
   }, []);
-  const minSearchLengthOptionChanged = React.useCallback(({ value }) => {
+  const minSearchLengthOptionChanged = useCallback(({ value }) => {
     setMinSearchLengthOption(value);
   }, []);
-  const showDataBeforeSearchOptionChanged = React.useCallback(({ value }) => {
+  const showDataBeforeSearchOptionChanged = useCallback(({ value }) => {
     setShowDataBeforeSearchOption(value);
   }, []);
   return (

--- a/JSDemos/Demos/Slider/Overview/React/App.tsx
+++ b/JSDemos/Demos/Slider/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { Slider, Label, Tooltip } from 'devextreme-react/slider';
 import { NumberBox } from 'devextreme-react/number-box';
 
@@ -7,9 +7,9 @@ const sliderValueLabel = { 'aria-label': 'Slider Value' };
 const format = (value) => `${value}%`;
 
 function App() {
-  const [sliderValue, setSliderValue] = React.useState(10);
+  const [sliderValue, setSliderValue] = useState(10);
 
-  const onValueChanged = React.useCallback((e: { value?: any; }) => {
+  const onValueChanged = useCallback((e: { value?: any; }) => {
     setSliderValue(e.value);
   }, [setSliderValue]);
 

--- a/JSDemos/Demos/Slider/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/Slider/Overview/ReactJs/App.js
@@ -1,12 +1,12 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { Slider, Label, Tooltip } from 'devextreme-react/slider';
 import { NumberBox } from 'devextreme-react/number-box';
 
 const sliderValueLabel = { 'aria-label': 'Slider Value' };
 const format = (value) => `${value}%`;
 function App() {
-  const [sliderValue, setSliderValue] = React.useState(10);
-  const onValueChanged = React.useCallback(
+  const [sliderValue, setSliderValue] = useState(10);
+  const onValueChanged = useCallback(
     (e) => {
       setSliderValue(e.value);
     },

--- a/JSDemos/Demos/Sortable/Customization/React/App.tsx
+++ b/JSDemos/Demos/Sortable/Customization/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import ScrollView from 'devextreme-react/scroll-view';
 import Sortable, { SortableTypes } from 'devextreme-react/sortable';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
@@ -22,21 +22,21 @@ const verticalDragDirections: DragDirection[] = ['both', 'vertical'];
 const horizontalDragDirections: DragDirection[] = ['both', 'horizontal'];
 
 const App = () => {
-  const [items, setItems] = React.useState(tasks);
-  const [dropFeedbackMode, setDropFeedbackMode] = React.useState<DragHighlight>('push');
-  const [itemOrientation, setItemOrientation] = React.useState<Orientation>('vertical');
-  const [dragDirection, setDragDirection] = React.useState<DragDirection>('both');
-  const [scrollSpeed, setScrollSpeed] = React.useState(30);
-  const [scrollSensitivity, setScrollSensitivity] = React.useState(60);
-  const [handle, setHandle] = React.useState('');
-  const [dragComponent, setDragComponent] = React.useState(null);
-  const [cursorOffset, setCursorOffset] = React.useState(null);
+  const [items, setItems] = useState(tasks);
+  const [dropFeedbackMode, setDropFeedbackMode] = useState<DragHighlight>('push');
+  const [itemOrientation, setItemOrientation] = useState<Orientation>('vertical');
+  const [dragDirection, setDragDirection] = useState<DragDirection>('both');
+  const [scrollSpeed, setScrollSpeed] = useState(30);
+  const [scrollSensitivity, setScrollSensitivity] = useState(60);
+  const [handle, setHandle] = useState('');
+  const [dragComponent, setDragComponent] = useState(null);
+  const [cursorOffset, setCursorOffset] = useState(null);
 
-  const onDragStart = React.useCallback((e: SortableTypes.DragStartEvent) => {
+  const onDragStart = useCallback((e: SortableTypes.DragStartEvent) => {
     e.itemData = items[e.fromIndex];
   }, [items]);
 
-  const onReorder = React.useCallback((e: SortableTypes.ReorderEvent) => {
+  const onReorder = useCallback((e: SortableTypes.ReorderEvent) => {
     let updatedItems = [...items.slice(0, e.fromIndex), ...items.slice(e.fromIndex + 1)];
     updatedItems = [
       ...updatedItems.slice(0, e.toIndex),
@@ -47,32 +47,32 @@ const App = () => {
     setItems(updatedItems);
   }, [items, setItems]);
 
-  const onDropFeedbackModeChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const onDropFeedbackModeChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setDropFeedbackMode(e.value);
   }, [setDropFeedbackMode]);
 
-  const onItemOrientationChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const onItemOrientationChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setItemOrientation(e.value);
     setDragDirection('both');
   }, [setItemOrientation, setDragDirection]);
 
-  const onDragDirectionChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const onDragDirectionChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setDragDirection(e.value);
   }, [setDragDirection]);
 
-  const onScrollSpeedChanged = React.useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
+  const onScrollSpeedChanged = useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
     setScrollSpeed(e.value);
   }, [setScrollSpeed]);
 
-  const onScrollSensitivityChanged = React.useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
+  const onScrollSensitivityChanged = useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
     setScrollSensitivity(e.value);
   }, [setScrollSensitivity]);
 
-  const onHandleChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onHandleChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setHandle(e.value ? '.handle' : '');
   }, [setHandle]);
 
-  const onDragTemplateChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onDragTemplateChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setDragComponent(e.value ? DragItem : null);
     setCursorOffset(e.value ? { x: 10, y: 20 } : null);
   }, [setDragComponent, setCursorOffset]);

--- a/JSDemos/Demos/Sortable/Customization/ReactJs/App.js
+++ b/JSDemos/Demos/Sortable/Customization/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import ScrollView from 'devextreme-react/scroll-view';
 import Sortable from 'devextreme-react/sortable';
 import SelectBox from 'devextreme-react/select-box';
@@ -20,22 +20,22 @@ const itemOrientations = ['vertical', 'horizontal'];
 const verticalDragDirections = ['both', 'vertical'];
 const horizontalDragDirections = ['both', 'horizontal'];
 const App = () => {
-  const [items, setItems] = React.useState(tasks);
-  const [dropFeedbackMode, setDropFeedbackMode] = React.useState('push');
-  const [itemOrientation, setItemOrientation] = React.useState('vertical');
-  const [dragDirection, setDragDirection] = React.useState('both');
-  const [scrollSpeed, setScrollSpeed] = React.useState(30);
-  const [scrollSensitivity, setScrollSensitivity] = React.useState(60);
-  const [handle, setHandle] = React.useState('');
-  const [dragComponent, setDragComponent] = React.useState(null);
-  const [cursorOffset, setCursorOffset] = React.useState(null);
-  const onDragStart = React.useCallback(
+  const [items, setItems] = useState(tasks);
+  const [dropFeedbackMode, setDropFeedbackMode] = useState('push');
+  const [itemOrientation, setItemOrientation] = useState('vertical');
+  const [dragDirection, setDragDirection] = useState('both');
+  const [scrollSpeed, setScrollSpeed] = useState(30);
+  const [scrollSensitivity, setScrollSensitivity] = useState(60);
+  const [handle, setHandle] = useState('');
+  const [dragComponent, setDragComponent] = useState(null);
+  const [cursorOffset, setCursorOffset] = useState(null);
+  const onDragStart = useCallback(
     (e) => {
       e.itemData = items[e.fromIndex];
     },
     [items],
   );
-  const onReorder = React.useCallback(
+  const onReorder = useCallback(
     (e) => {
       let updatedItems = [...items.slice(0, e.fromIndex), ...items.slice(e.fromIndex + 1)];
       updatedItems = [
@@ -47,44 +47,44 @@ const App = () => {
     },
     [items, setItems],
   );
-  const onDropFeedbackModeChanged = React.useCallback(
+  const onDropFeedbackModeChanged = useCallback(
     (e) => {
       setDropFeedbackMode(e.value);
     },
     [setDropFeedbackMode],
   );
-  const onItemOrientationChanged = React.useCallback(
+  const onItemOrientationChanged = useCallback(
     (e) => {
       setItemOrientation(e.value);
       setDragDirection('both');
     },
     [setItemOrientation, setDragDirection],
   );
-  const onDragDirectionChanged = React.useCallback(
+  const onDragDirectionChanged = useCallback(
     (e) => {
       setDragDirection(e.value);
     },
     [setDragDirection],
   );
-  const onScrollSpeedChanged = React.useCallback(
+  const onScrollSpeedChanged = useCallback(
     (e) => {
       setScrollSpeed(e.value);
     },
     [setScrollSpeed],
   );
-  const onScrollSensitivityChanged = React.useCallback(
+  const onScrollSensitivityChanged = useCallback(
     (e) => {
       setScrollSensitivity(e.value);
     },
     [setScrollSensitivity],
   );
-  const onHandleChanged = React.useCallback(
+  const onHandleChanged = useCallback(
     (e) => {
       setHandle(e.value ? '.handle' : '');
     },
     [setHandle],
   );
-  const onDragTemplateChanged = React.useCallback(
+  const onDragTemplateChanged = useCallback(
     (e) => {
       setDragComponent(e.value ? DragItem : null);
       setCursorOffset(e.value ? { x: 10, y: 20 } : null);

--- a/JSDemos/Demos/Sortable/Kanban/React/App.tsx
+++ b/JSDemos/Demos/Sortable/Kanban/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import ScrollView from 'devextreme-react/scroll-view';
 import Sortable from 'devextreme-react/sortable';
 import {
@@ -76,15 +76,15 @@ const List: React.FC<{ title, index, tasks, employeesMap, onTaskDrop }> = ({
 </div>;
 
 function App() {
-  const [statuses, setStatuses] = React.useState(taskStatuses);
-  const [lists, setLists] = React.useState(getLists(taskStatuses, taskList));
+  const [statuses, setStatuses] = useState(taskStatuses);
+  const [lists, setLists] = useState(getLists(taskStatuses, taskList));
 
-  const onListReorder = React.useCallback(({ fromIndex, toIndex }) => {
+  const onListReorder = useCallback(({ fromIndex, toIndex }) => {
     setLists((state) => reorderItem(state, fromIndex, toIndex));
     setStatuses((state) => reorderItem(state, fromIndex, toIndex));
   }, []);
 
-  const onTaskDrop = React.useCallback(
+  const onTaskDrop = useCallback(
     ({
       fromData, toData, fromIndex, toIndex,
     }) => {

--- a/JSDemos/Demos/Sortable/Kanban/ReactJs/App.js
+++ b/JSDemos/Demos/Sortable/Kanban/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import ScrollView from 'devextreme-react/scroll-view';
 import Sortable from 'devextreme-react/sortable';
 import { tasks as taskList, employees } from './data.js';
@@ -71,13 +71,13 @@ const List = ({
   </div>
 );
 function App() {
-  const [statuses, setStatuses] = React.useState(taskStatuses);
-  const [lists, setLists] = React.useState(getLists(taskStatuses, taskList));
-  const onListReorder = React.useCallback(({ fromIndex, toIndex }) => {
+  const [statuses, setStatuses] = useState(taskStatuses);
+  const [lists, setLists] = useState(getLists(taskStatuses, taskList));
+  const onListReorder = useCallback(({ fromIndex, toIndex }) => {
     setLists((state) => reorderItem(state, fromIndex, toIndex));
     setStatuses((state) => reorderItem(state, fromIndex, toIndex));
   }, []);
-  const onTaskDrop = React.useCallback(
+  const onTaskDrop = useCallback(
     ({
       fromData, toData, fromIndex, toIndex,
     }) => {

--- a/JSDemos/Demos/Switch/Overview/React/App.tsx
+++ b/JSDemos/Demos/Switch/Overview/React/App.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Switch, { SwitchTypes } from 'devextreme-react/switch';
 
 function App() {
-  const [value, setValue] = React.useState(false);
+  const [value, setValue] = useState(false);
 
-  const valueChanged = React.useCallback((e: SwitchTypes.ValueChangedEvent) => {
+  const valueChanged = useCallback((e: SwitchTypes.ValueChangedEvent) => {
     setValue(e.value);
   }, []);
 

--- a/JSDemos/Demos/Switch/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/Switch/Overview/ReactJs/App.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Switch from 'devextreme-react/switch';
 
 function App() {
-  const [value, setValue] = React.useState(false);
-  const valueChanged = React.useCallback((e) => {
+  const [value, setValue] = useState(false);
+  const valueChanged = useCallback((e) => {
     setValue(e.value);
   }, []);
   return (

--- a/JSDemos/Demos/TabPanel/Overview/React/App.tsx
+++ b/JSDemos/Demos/TabPanel/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import TabPanel from 'devextreme-react/tab-panel';
 import TabPanelItem from './TabPanelItem.tsx';
@@ -14,19 +14,19 @@ import {
 } from './data.ts';
 
 const App = () => {
-  const [tabsPosition, setTabsPosition] = React.useState(tabsPositions[0]);
-  const [stylingMode, setStylingMode] = React.useState(stylingModes[0]);
-  const [iconPosition, setIconPosition] = React.useState(iconPositions[0]);
+  const [tabsPosition, setTabsPosition] = useState(tabsPositions[0]);
+  const [stylingMode, setStylingMode] = useState(stylingModes[0]);
+  const [iconPosition, setIconPosition] = useState(iconPositions[0]);
 
-  const onTabsPositionChanged = React.useCallback((args) => {
+  const onTabsPositionChanged = useCallback((args) => {
     setTabsPosition(args.value);
   }, [setTabsPosition]);
 
-  const onStylingModeChanged = React.useCallback((args) => {
+  const onStylingModeChanged = useCallback((args) => {
     setStylingMode(args.value);
   }, [setStylingMode]);
 
-  const onIconPositionChanged = React.useCallback((args) => {
+  const onIconPositionChanged = useCallback((args) => {
     setIconPosition(args.value);
   }, [setIconPosition]);
 

--- a/JSDemos/Demos/TabPanel/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/TabPanel/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import TabPanel from 'devextreme-react/tab-panel';
 import TabPanelItem from './TabPanelItem.js';
@@ -13,22 +13,22 @@ import {
 } from './data.js';
 
 const App = () => {
-  const [tabsPosition, setTabsPosition] = React.useState(tabsPositions[0]);
-  const [stylingMode, setStylingMode] = React.useState(stylingModes[0]);
-  const [iconPosition, setIconPosition] = React.useState(iconPositions[0]);
-  const onTabsPositionChanged = React.useCallback(
+  const [tabsPosition, setTabsPosition] = useState(tabsPositions[0]);
+  const [stylingMode, setStylingMode] = useState(stylingModes[0]);
+  const [iconPosition, setIconPosition] = useState(iconPositions[0]);
+  const onTabsPositionChanged = useCallback(
     (args) => {
       setTabsPosition(args.value);
     },
     [setTabsPosition],
   );
-  const onStylingModeChanged = React.useCallback(
+  const onStylingModeChanged = useCallback(
     (args) => {
       setStylingMode(args.value);
     },
     [setStylingMode],
   );
-  const onIconPositionChanged = React.useCallback(
+  const onIconPositionChanged = useCallback(
     (args) => {
       setIconPosition(args.value);
     },

--- a/JSDemos/Demos/TabPanel/SortableClosableTabs/React/App.tsx
+++ b/JSDemos/Demos/TabPanel/SortableClosableTabs/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Button from 'devextreme-react/button';
 import Sortable, { SortableTypes } from 'devextreme-react/sortable';
 import TabPanel, { TabPanelTypes } from 'devextreme-react/tab-panel';
@@ -10,10 +10,10 @@ import EmployeeTemplate from './EmployeeTemplate.tsx';
 const allEmployees = service.getEmployees();
 
 function App() {
-  const [employees, setEmployees] = React.useState(allEmployees.slice(0, 3));
-  const [selectedItem, setSelectedItem] = React.useState(allEmployees[0]);
+  const [employees, setEmployees] = useState(allEmployees.slice(0, 3));
+  const [selectedItem, setSelectedItem] = useState(allEmployees[0]);
 
-  const addButtonHandler = React.useCallback(() => {
+  const addButtonHandler = useCallback(() => {
     const newItem = allEmployees
       .filter((employee) => employees.indexOf(employee) === -1)[0];
 
@@ -25,7 +25,7 @@ function App() {
     return employees.length === allEmployees.length;
   }
 
-  const closeButtonHandler = React.useCallback((item) => {
+  const closeButtonHandler = useCallback((item) => {
     const newEmployees = [...employees];
     const index = newEmployees.indexOf(item);
 
@@ -37,7 +37,7 @@ function App() {
     }
   }, [employees, setEmployees, setSelectedItem]);
 
-  const renderTitle = React.useCallback((data) => (
+  const renderTitle = useCallback((data) => (
     <React.Fragment>
       <div>
         <span>
@@ -48,15 +48,15 @@ function App() {
     </React.Fragment>
   ), [employees, closeButtonHandler]);
 
-  const onSelectionChanged = React.useCallback((args: TabPanelTypes.SelectionChangedEvent) => {
+  const onSelectionChanged = useCallback((args: TabPanelTypes.SelectionChangedEvent) => {
     setSelectedItem(args.addedItems[0]);
   }, [setSelectedItem]);
 
-  const onTabDragStart = React.useCallback((e: SortableTypes.DragStartEvent) => {
+  const onTabDragStart = useCallback((e: SortableTypes.DragStartEvent) => {
     e.itemData = e.fromData[e.fromIndex];
   }, []);
 
-  const onTabDrop = React.useCallback((e: SortableTypes.ReorderEvent) => {
+  const onTabDrop = useCallback((e: SortableTypes.ReorderEvent) => {
     const newEmployees = [...employees];
 
     newEmployees.splice(e.fromIndex, 1);

--- a/JSDemos/Demos/TabPanel/SortableClosableTabs/ReactJs/App.js
+++ b/JSDemos/Demos/TabPanel/SortableClosableTabs/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Button from 'devextreme-react/button';
 import Sortable from 'devextreme-react/sortable';
 import TabPanel from 'devextreme-react/tab-panel';
@@ -8,9 +8,9 @@ import EmployeeTemplate from './EmployeeTemplate.js';
 
 const allEmployees = service.getEmployees();
 function App() {
-  const [employees, setEmployees] = React.useState(allEmployees.slice(0, 3));
-  const [selectedItem, setSelectedItem] = React.useState(allEmployees[0]);
-  const addButtonHandler = React.useCallback(() => {
+  const [employees, setEmployees] = useState(allEmployees.slice(0, 3));
+  const [selectedItem, setSelectedItem] = useState(allEmployees[0]);
+  const addButtonHandler = useCallback(() => {
     const newItem = allEmployees.filter((employee) => employees.indexOf(employee) === -1)[0];
     setEmployees([...employees, newItem]);
     setSelectedItem(newItem);
@@ -18,7 +18,7 @@ function App() {
   function disableButton() {
     return employees.length === allEmployees.length;
   }
-  const closeButtonHandler = React.useCallback(
+  const closeButtonHandler = useCallback(
     (item) => {
       const newEmployees = [...employees];
       const index = newEmployees.indexOf(item);
@@ -30,7 +30,7 @@ function App() {
     },
     [employees, setEmployees, setSelectedItem],
   );
-  const renderTitle = React.useCallback(
+  const renderTitle = useCallback(
     (data) => (
       <React.Fragment>
         <div>
@@ -50,16 +50,16 @@ function App() {
     ),
     [employees, closeButtonHandler],
   );
-  const onSelectionChanged = React.useCallback(
+  const onSelectionChanged = useCallback(
     (args) => {
       setSelectedItem(args.addedItems[0]);
     },
     [setSelectedItem],
   );
-  const onTabDragStart = React.useCallback((e) => {
+  const onTabDragStart = useCallback((e) => {
     e.itemData = e.fromData[e.fromIndex];
   }, []);
-  const onTabDrop = React.useCallback(
+  const onTabDrop = useCallback(
     (e) => {
       const newEmployees = [...employees];
       newEmployees.splice(e.fromIndex, 1);

--- a/JSDemos/Demos/TabPanel/Templates/React/App.tsx
+++ b/JSDemos/Demos/TabPanel/Templates/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import CheckBox, { CheckBoxTypes } from 'devextreme-react/check-box';
 import TabPanel, { TabPanelTypes } from 'devextreme-react/tab-panel';
 import { multiViewItems as companies } from './data.ts';
@@ -7,26 +7,26 @@ import CompanyItem from './CompanyItem.tsx';
 const itemTitleRender = (company) => <span>{company.CompanyName}</span>;
 
 const App = () => {
-  const [animationEnabled, setAnimationEnabled] = React.useState(true);
-  const [swipeEnabled, setSwipeEnabled] = React.useState(true);
-  const [loop, setLoop] = React.useState(false);
-  const [selectedIndex, setSelectedIndex] = React.useState(0);
+  const [animationEnabled, setAnimationEnabled] = useState(true);
+  const [swipeEnabled, setSwipeEnabled] = useState(true);
+  const [loop, setLoop] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
 
-  const onSelectionChanged = React.useCallback((args: TabPanelTypes.OptionChangedEvent) => {
+  const onSelectionChanged = useCallback((args: TabPanelTypes.OptionChangedEvent) => {
     if (args.name === 'selectedIndex') {
       setSelectedIndex(args.value);
     }
   }, [setSelectedIndex]);
 
-  const onLoopChanged = React.useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
+  const onLoopChanged = useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
     setLoop(args.value);
   }, [setLoop]);
 
-  const onAnimationEnabledChanged = React.useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
+  const onAnimationEnabledChanged = useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
     setAnimationEnabled(args.value);
   }, [setAnimationEnabled]);
 
-  const onSwipeEnabledChanged = React.useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
+  const onSwipeEnabledChanged = useCallback((args: CheckBoxTypes.ValueChangedEvent) => {
     setSwipeEnabled(args.value);
   }, [setSwipeEnabled]);
 

--- a/JSDemos/Demos/TabPanel/Templates/ReactJs/App.js
+++ b/JSDemos/Demos/TabPanel/Templates/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import CheckBox from 'devextreme-react/check-box';
 import TabPanel from 'devextreme-react/tab-panel';
 import { multiViewItems as companies } from './data.js';
@@ -6,11 +6,11 @@ import CompanyItem from './CompanyItem.js';
 
 const itemTitleRender = (company) => <span>{company.CompanyName}</span>;
 const App = () => {
-  const [animationEnabled, setAnimationEnabled] = React.useState(true);
-  const [swipeEnabled, setSwipeEnabled] = React.useState(true);
-  const [loop, setLoop] = React.useState(false);
-  const [selectedIndex, setSelectedIndex] = React.useState(0);
-  const onSelectionChanged = React.useCallback(
+  const [animationEnabled, setAnimationEnabled] = useState(true);
+  const [swipeEnabled, setSwipeEnabled] = useState(true);
+  const [loop, setLoop] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const onSelectionChanged = useCallback(
     (args) => {
       if (args.name === 'selectedIndex') {
         setSelectedIndex(args.value);
@@ -18,19 +18,19 @@ const App = () => {
     },
     [setSelectedIndex],
   );
-  const onLoopChanged = React.useCallback(
+  const onLoopChanged = useCallback(
     (args) => {
       setLoop(args.value);
     },
     [setLoop],
   );
-  const onAnimationEnabledChanged = React.useCallback(
+  const onAnimationEnabledChanged = useCallback(
     (args) => {
       setAnimationEnabled(args.value);
     },
     [setAnimationEnabled],
   );
-  const onSwipeEnabledChanged = React.useCallback(
+  const onSwipeEnabledChanged = useCallback(
     (args) => {
       setSwipeEnabled(args.value);
     },

--- a/JSDemos/Demos/Tabs/Overview/React/App.tsx
+++ b/JSDemos/Demos/Tabs/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Tabs from 'devextreme-react/tabs';
 import SelectBox from 'devextreme-react/select-box';
 import CheckBox from 'devextreme-react/check-box';
@@ -27,17 +27,17 @@ function OptionWrapper(props) {
 }
 
 const App = () => {
-  const [orientation, setOrientation] = React.useState(orientations[0]);
-  const [stylingMode, setStylingMode] = React.useState(stylingModes[1]);
-  const [iconPosition, setIconPosition] = React.useState(iconPositions[0]);
-  const [showNavigation, setShowNavigation] = React.useState(false);
-  const [scrollContent, setScrollContent] = React.useState(false);
-  const [fullWidth, setFullWidth] = React.useState(false);
-  const [width, setWidth] = React.useState('auto');
-  const [rtlEnabled, setRtlEnabled] = React.useState(false);
-  const [widgetWrapperClasses, setWidgetWrapperClasses] = React.useState('widget-wrapper widget-wrapper-horizontal');
+  const [orientation, setOrientation] = useState(orientations[0]);
+  const [stylingMode, setStylingMode] = useState(stylingModes[1]);
+  const [iconPosition, setIconPosition] = useState(iconPositions[0]);
+  const [showNavigation, setShowNavigation] = useState(false);
+  const [scrollContent, setScrollContent] = useState(false);
+  const [fullWidth, setFullWidth] = useState(false);
+  const [width, setWidth] = useState('auto');
+  const [rtlEnabled, setRtlEnabled] = useState(false);
+  const [widgetWrapperClasses, setWidgetWrapperClasses] = useState('widget-wrapper widget-wrapper-horizontal');
 
-  const enforceWidthConstraint = React.useCallback(
+  const enforceWidthConstraint = useCallback(
     (shouldRestrictWidth) => {
       const callback = (prevClasses: string) => {
         const restClasses = prevClasses.split(' ').filter((className) => className !== STRICT_WIDTH_CLASS).join(' ');
@@ -50,15 +50,15 @@ const App = () => {
     }, [setWidgetWrapperClasses],
   );
 
-  const stylingModeChanged = React.useCallback((e) => {
+  const stylingModeChanged = useCallback((e) => {
     setStylingMode(e.value);
   }, [setStylingMode]);
 
-  const iconPositionChanged = React.useCallback((e) => {
+  const iconPositionChanged = useCallback((e) => {
     setIconPosition(e.value);
   }, [setIconPosition]);
 
-  const orientationChanged = React.useCallback((e) => {
+  const orientationChanged = useCallback((e) => {
     const isVertical = e.value === 'vertical';
 
     const callback = (prevClasses: string) => {
@@ -75,26 +75,26 @@ const App = () => {
     setOrientation(e.value);
   }, [setOrientation, setWidgetWrapperClasses]);
 
-  const showNavigationChanged = React.useCallback((e) => {
+  const showNavigationChanged = useCallback((e) => {
     const shouldRestrictWidth = e.value || scrollContent;
 
     enforceWidthConstraint(shouldRestrictWidth);
     setShowNavigation(e.value);
   }, [scrollContent, setShowNavigation, enforceWidthConstraint]);
 
-  const scrollContentChanged = React.useCallback((e) => {
+  const scrollContentChanged = useCallback((e) => {
     const shouldRestrictWidth = e.value || showNavigation;
 
     enforceWidthConstraint(shouldRestrictWidth);
     setScrollContent(e.value);
   }, [showNavigation, setScrollContent, enforceWidthConstraint]);
 
-  const fullWidthChanged = React.useCallback((e) => {
+  const fullWidthChanged = useCallback((e) => {
     setFullWidth(e.value);
     setWidth(e.value ? '100%' : 'auto');
   }, [setFullWidth, setWidth]);
 
-  const rtlEnabledChanged = React.useCallback((e) => {
+  const rtlEnabledChanged = useCallback((e) => {
     setRtlEnabled(e.value);
   }, [setRtlEnabled]);
 

--- a/JSDemos/Demos/Tabs/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/Tabs/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Tabs from 'devextreme-react/tabs';
 import SelectBox from 'devextreme-react/select-box';
 import CheckBox from 'devextreme-react/check-box';
@@ -24,18 +24,18 @@ function OptionWrapper(props) {
   );
 }
 const App = () => {
-  const [orientation, setOrientation] = React.useState(orientations[0]);
-  const [stylingMode, setStylingMode] = React.useState(stylingModes[1]);
-  const [iconPosition, setIconPosition] = React.useState(iconPositions[0]);
-  const [showNavigation, setShowNavigation] = React.useState(false);
-  const [scrollContent, setScrollContent] = React.useState(false);
-  const [fullWidth, setFullWidth] = React.useState(false);
-  const [width, setWidth] = React.useState('auto');
-  const [rtlEnabled, setRtlEnabled] = React.useState(false);
-  const [widgetWrapperClasses, setWidgetWrapperClasses] = React.useState(
+  const [orientation, setOrientation] = useState(orientations[0]);
+  const [stylingMode, setStylingMode] = useState(stylingModes[1]);
+  const [iconPosition, setIconPosition] = useState(iconPositions[0]);
+  const [showNavigation, setShowNavigation] = useState(false);
+  const [scrollContent, setScrollContent] = useState(false);
+  const [fullWidth, setFullWidth] = useState(false);
+  const [width, setWidth] = useState('auto');
+  const [rtlEnabled, setRtlEnabled] = useState(false);
+  const [widgetWrapperClasses, setWidgetWrapperClasses] = useState(
     'widget-wrapper widget-wrapper-horizontal',
   );
-  const enforceWidthConstraint = React.useCallback(
+  const enforceWidthConstraint = useCallback(
     (shouldRestrictWidth) => {
       const callback = (prevClasses) => {
         const restClasses = prevClasses
@@ -49,19 +49,19 @@ const App = () => {
     },
     [setWidgetWrapperClasses],
   );
-  const stylingModeChanged = React.useCallback(
+  const stylingModeChanged = useCallback(
     (e) => {
       setStylingMode(e.value);
     },
     [setStylingMode],
   );
-  const iconPositionChanged = React.useCallback(
+  const iconPositionChanged = useCallback(
     (e) => {
       setIconPosition(e.value);
     },
     [setIconPosition],
   );
-  const orientationChanged = React.useCallback(
+  const orientationChanged = useCallback(
     (e) => {
       const isVertical = e.value === 'vertical';
       const callback = (prevClasses) => {
@@ -79,7 +79,7 @@ const App = () => {
     },
     [setOrientation, setWidgetWrapperClasses],
   );
-  const showNavigationChanged = React.useCallback(
+  const showNavigationChanged = useCallback(
     (e) => {
       const shouldRestrictWidth = e.value || scrollContent;
       enforceWidthConstraint(shouldRestrictWidth);
@@ -87,7 +87,7 @@ const App = () => {
     },
     [scrollContent, setShowNavigation, enforceWidthConstraint],
   );
-  const scrollContentChanged = React.useCallback(
+  const scrollContentChanged = useCallback(
     (e) => {
       const shouldRestrictWidth = e.value || showNavigation;
       enforceWidthConstraint(shouldRestrictWidth);
@@ -95,14 +95,14 @@ const App = () => {
     },
     [showNavigation, setScrollContent, enforceWidthConstraint],
   );
-  const fullWidthChanged = React.useCallback(
+  const fullWidthChanged = useCallback(
     (e) => {
       setFullWidth(e.value);
       setWidth(e.value ? '100%' : 'auto');
     },
     [setFullWidth, setWidth],
   );
-  const rtlEnabledChanged = React.useCallback(
+  const rtlEnabledChanged = useCallback(
     (e) => {
       setRtlEnabled(e.value);
     },

--- a/JSDemos/Demos/Tabs/Selection/React/App.tsx
+++ b/JSDemos/Demos/Tabs/Selection/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import Tabs from 'devextreme-react/tabs';
 import SelectBox from 'devextreme-react/select-box';
@@ -32,9 +32,9 @@ class EmployeeInfo extends React.Component<{
 }
 
 const App = () => {
-  const [selectedItem, setSelectedItem] = React.useState(employees[0]);
+  const [selectedItem, setSelectedItem] = useState(employees[0]);
 
-  const onSelectionChanged = React.useCallback((args) => {
+  const onSelectionChanged = useCallback((args) => {
     setSelectedItem(args.selectedItem || args.addedItems[0]);
   }, [setSelectedItem]);
 

--- a/JSDemos/Demos/Tabs/Selection/ReactJs/App.js
+++ b/JSDemos/Demos/Tabs/Selection/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Tabs from 'devextreme-react/tabs';
 import SelectBox from 'devextreme-react/select-box';
 import MultiView from 'devextreme-react/multi-view';
@@ -26,8 +26,8 @@ class EmployeeInfo extends React.Component {
   }
 }
 const App = () => {
-  const [selectedItem, setSelectedItem] = React.useState(employees[0]);
-  const onSelectionChanged = React.useCallback(
+  const [selectedItem, setSelectedItem] = useState(employees[0]);
+  const onSelectionChanged = useCallback(
     (args) => {
       setSelectedItem(args.selectedItem || args.addedItems[0]);
     },

--- a/JSDemos/Demos/TagBox/GroupedItems/React/App.tsx
+++ b/JSDemos/Demos/TagBox/GroupedItems/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { TagBox } from 'devextreme-react/tag-box';
 import DataSource from 'devextreme/data/data_source';
 import Group from './Group.tsx';
@@ -14,7 +14,7 @@ const defaultValues = {
 const productLabel = { 'aria-label': 'Product' };
 
 function App() {
-  const [products] = React.useState(
+  const [products] = useState(
     new DataSource({
       store: productsData,
       key: 'ID',

--- a/JSDemos/Demos/TagBox/GroupedItems/ReactJs/App.js
+++ b/JSDemos/Demos/TagBox/GroupedItems/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { TagBox } from 'devextreme-react/tag-box';
 import DataSource from 'devextreme/data/data_source';
 import Group from './Group.js';
@@ -11,7 +11,7 @@ const defaultValues = {
 };
 const productLabel = { 'aria-label': 'Product' };
 function App() {
-  const [products] = React.useState(
+  const [products] = useState(
     new DataSource({
       store: productsData,
       key: 'ID',

--- a/JSDemos/Demos/TagBox/Overview/React/App.tsx
+++ b/JSDemos/Demos/TagBox/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import TagBox, { TagBoxTypes } from 'devextreme-react/tag-box';
 import Popover from 'devextreme-react/popover';
@@ -18,11 +18,11 @@ const dataSource = new ArrayStore({
 });
 
 function App() {
-  const [editableProducts, setEditableProducts] = React.useState([...simpleProducts]);
-  const [target, setTarget] = React.useState(null);
-  const [product, setProduct] = React.useState<Product>({});
+  const [editableProducts, setEditableProducts] = useState([...simpleProducts]);
+  const [target, setTarget] = useState(null);
+  const [product, setProduct] = useState<Product>({});
 
-  const onCustomItemCreating = React.useCallback(
+  const onCustomItemCreating = useCallback(
     (args: TagBoxTypes.CustomItemCreatingEvent) => {
       const newValue = args.text;
       const isItemInDataSource = editableProducts.some((item) => item === newValue);
@@ -34,7 +34,7 @@ function App() {
     [editableProducts],
   );
 
-  const onMouseEnter = React.useCallback((e: { currentTarget: any }, newProduct) => {
+  const onMouseEnter = useCallback((e: { currentTarget: any }, newProduct) => {
     setTarget(e.currentTarget);
     setProduct(newProduct);
   }, []);

--- a/JSDemos/Demos/TagBox/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/TagBox/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TagBox from 'devextreme-react/tag-box';
 import Popover from 'devextreme-react/popover';
 import ArrayStore from 'devextreme/data/array_store';
@@ -13,10 +13,10 @@ const dataSource = new ArrayStore({
   key: 'Id',
 });
 function App() {
-  const [editableProducts, setEditableProducts] = React.useState([...simpleProducts]);
-  const [target, setTarget] = React.useState(null);
-  const [product, setProduct] = React.useState({});
-  const onCustomItemCreating = React.useCallback(
+  const [editableProducts, setEditableProducts] = useState([...simpleProducts]);
+  const [target, setTarget] = useState(null);
+  const [product, setProduct] = useState({});
+  const onCustomItemCreating = useCallback(
     (args) => {
       const newValue = args.text;
       const isItemInDataSource = editableProducts.some((item) => item === newValue);
@@ -27,7 +27,7 @@ function App() {
     },
     [editableProducts],
   );
-  const onMouseEnter = React.useCallback((e, newProduct) => {
+  const onMouseEnter = useCallback((e, newProduct) => {
     setTarget(e.currentTarget);
     setProduct(newProduct);
   }, []);

--- a/JSDemos/Demos/TextArea/Overview/React/App.tsx
+++ b/JSDemos/Demos/TextArea/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import CheckBox, { CheckBoxTypes } from 'devextreme-react/check-box';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 import TextArea, { TextAreaTypes } from 'devextreme-react/text-area';
@@ -11,29 +11,29 @@ const notesLabel = { 'aria-label': 'Notes' };
 const eventLabel = { 'aria-label': 'Event' };
 
 function App() {
-  const [value, setValue] = React.useState(content);
-  const [valueForEditableTestArea, setValueForEditableTestArea] = React.useState(content);
-  const [maxLength, setMaxLength] = React.useState(null);
-  const [eventValue, setEventValue] = React.useState(valueChangeEvents[0].name);
-  const [autoResizeEnabled, setAutoResizeEnabled] = React.useState(false);
-  const [height, setHeight] = React.useState(90);
+  const [value, setValue] = useState(content);
+  const [valueForEditableTestArea, setValueForEditableTestArea] = useState(content);
+  const [maxLength, setMaxLength] = useState(null);
+  const [eventValue, setEventValue] = useState(valueChangeEvents[0].name);
+  const [autoResizeEnabled, setAutoResizeEnabled] = useState(false);
+  const [height, setHeight] = useState(90);
 
-  const onCheckboxValueChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onCheckboxValueChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     const str = content;
     setValue(e.value ? str.substring(0, 100) : str);
     setMaxLength(e.value ? 100 : null);
   }, []);
 
-  const onAutoResizeChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onAutoResizeChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setAutoResizeEnabled(e.value);
     setHeight(e.value ? undefined : 90);
   }, []);
 
-  const onSelectBoxValueChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const onSelectBoxValueChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setEventValue(e.value);
   }, []);
 
-  const onTextAreaValueChanged = React.useCallback((e: TextAreaTypes.ValueChangedEvent) => {
+  const onTextAreaValueChanged = useCallback((e: TextAreaTypes.ValueChangedEvent) => {
     setValueForEditableTestArea(e.value);
   }, []);
 

--- a/JSDemos/Demos/TextArea/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/TextArea/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import CheckBox from 'devextreme-react/check-box';
 import SelectBox from 'devextreme-react/select-box';
 import TextArea from 'devextreme-react/text-area';
@@ -9,25 +9,25 @@ const { valueChangeEvents } = service;
 const notesLabel = { 'aria-label': 'Notes' };
 const eventLabel = { 'aria-label': 'Event' };
 function App() {
-  const [value, setValue] = React.useState(content);
-  const [valueForEditableTestArea, setValueForEditableTestArea] = React.useState(content);
-  const [maxLength, setMaxLength] = React.useState(null);
-  const [eventValue, setEventValue] = React.useState(valueChangeEvents[0].name);
-  const [autoResizeEnabled, setAutoResizeEnabled] = React.useState(false);
-  const [height, setHeight] = React.useState(90);
-  const onCheckboxValueChanged = React.useCallback((e) => {
+  const [value, setValue] = useState(content);
+  const [valueForEditableTestArea, setValueForEditableTestArea] = useState(content);
+  const [maxLength, setMaxLength] = useState(null);
+  const [eventValue, setEventValue] = useState(valueChangeEvents[0].name);
+  const [autoResizeEnabled, setAutoResizeEnabled] = useState(false);
+  const [height, setHeight] = useState(90);
+  const onCheckboxValueChanged = useCallback((e) => {
     const str = content;
     setValue(e.value ? str.substring(0, 100) : str);
     setMaxLength(e.value ? 100 : null);
   }, []);
-  const onAutoResizeChanged = React.useCallback((e) => {
+  const onAutoResizeChanged = useCallback((e) => {
     setAutoResizeEnabled(e.value);
     setHeight(e.value ? undefined : 90);
   }, []);
-  const onSelectBoxValueChanged = React.useCallback((e) => {
+  const onSelectBoxValueChanged = useCallback((e) => {
     setEventValue(e.value);
   }, []);
-  const onTextAreaValueChanged = React.useCallback((e) => {
+  const onTextAreaValueChanged = useCallback((e) => {
     setValueForEditableTestArea(e.value);
   }, []);
   return (

--- a/JSDemos/Demos/TextBox/Overview/React/App.tsx
+++ b/JSDemos/Demos/TextBox/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TextBox, { TextBoxTypes } from 'devextreme-react/text-box';
 
 const nameLabel = { 'aria-label': 'Name' };
@@ -9,9 +9,9 @@ const emailLabel = { 'aria-label': 'Email' };
 const rules = { X: /[02-9]/ };
 
 function App() {
-  const [emailValue, setEmailValue] = React.useState('smith@corp.com');
+  const [emailValue, setEmailValue] = useState('smith@corp.com');
 
-  const valueChanged = React.useCallback((data: TextBoxTypes.ValueChangedEvent) => {
+  const valueChanged = useCallback((data: TextBoxTypes.ValueChangedEvent) => {
     setEmailValue(`${data.value.replace(/\s/g, '').toLowerCase()}@corp.com`);
   }, []);
 

--- a/JSDemos/Demos/TextBox/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/TextBox/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TextBox from 'devextreme-react/text-box';
 
 const nameLabel = { 'aria-label': 'Name' };
@@ -8,8 +8,8 @@ const maskLabel = { 'aria-label': 'Mask' };
 const emailLabel = { 'aria-label': 'Email' };
 const rules = { X: /[02-9]/ };
 function App() {
-  const [emailValue, setEmailValue] = React.useState('smith@corp.com');
-  const valueChanged = React.useCallback((data) => {
+  const [emailValue, setEmailValue] = useState('smith@corp.com');
+  const valueChanged = useCallback((data) => {
     setEmailValue(`${data.value.replace(/\s/g, '').toLowerCase()}@corp.com`);
   }, []);
   return (

--- a/JSDemos/Demos/TileView/Directions/React/App.tsx
+++ b/JSDemos/Demos/TileView/Directions/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TileView, { TileViewTypes } from 'devextreme-react/tile-view';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
 import RenderHomeItem from './HomeItem.tsx';
@@ -7,9 +7,9 @@ import { homes, directionLabel } from './data.ts';
 const directions = ['horizontal', 'vertical'];
 
 const App = () => {
-  const [direction, setDirection] = React.useState<TileViewTypes.Properties['direction']>('horizontal');
+  const [direction, setDirection] = useState<TileViewTypes.Properties['direction']>('horizontal');
 
-  const directionChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const directionChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setDirection(e.value);
   }, [setDirection]);
 

--- a/JSDemos/Demos/TileView/Directions/ReactJs/App.js
+++ b/JSDemos/Demos/TileView/Directions/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TileView from 'devextreme-react/tile-view';
 import SelectBox from 'devextreme-react/select-box';
 import RenderHomeItem from './HomeItem.js';
@@ -6,8 +6,8 @@ import { homes, directionLabel } from './data.js';
 
 const directions = ['horizontal', 'vertical'];
 const App = () => {
-  const [direction, setDirection] = React.useState('horizontal');
-  const directionChanged = React.useCallback(
+  const [direction, setDirection] = useState('horizontal');
+  const directionChanged = useCallback(
     (e) => {
       setDirection(e.value);
     },

--- a/JSDemos/Demos/Toast/Overview/React/App.tsx
+++ b/JSDemos/Demos/Toast/Overview/React/App.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { Toast } from 'devextreme-react/toast';
 
 import { ProductItem } from './ProductItem.tsx';
 import { products } from './data.ts';
 
 function App() {
-  const [toastConfig, setToastConfig] = React.useState({
+  const [toastConfig, setToastConfig] = useState({
     isVisible: false,
     type: 'info',
     message: '',
@@ -15,7 +15,7 @@ function App() {
     message: string,
   });
 
-  const checkAvailability = React.useCallback((e: { value: any; }, product: { Name: string | number; }) => {
+  const checkAvailability = useCallback((e: { value: any; }, product: { Name: string | number; }) => {
     const type = e.value ? 'success' : 'error';
     const message = product.Name + (e.value ? ' is available' : ' is not available');
 
@@ -27,7 +27,7 @@ function App() {
     });
   }, [toastConfig, setToastConfig]);
 
-  const onHiding = React.useCallback(() => {
+  const onHiding = useCallback(() => {
     setToastConfig({
       ...toastConfig,
       isVisible: false,

--- a/JSDemos/Demos/Toast/Overview/React/ProductItem.tsx
+++ b/JSDemos/Demos/Toast/Overview/React/ProductItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { CheckBox } from 'devextreme-react/check-box';
 
@@ -8,7 +8,7 @@ interface ProductItemProps {
 }
 
 export function ProductItem(props: ProductItemProps) {
-  const onValueChanged = React.useCallback((e) => {
+  const onValueChanged = useCallback((e) => {
     props.checkAvailability(e, props.product);
   }, [props]);
 

--- a/JSDemos/Demos/Toast/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/Toast/Overview/ReactJs/App.js
@@ -1,15 +1,15 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { Toast } from 'devextreme-react/toast';
 import { ProductItem } from './ProductItem.js';
 import { products } from './data.js';
 
 function App() {
-  const [toastConfig, setToastConfig] = React.useState({
+  const [toastConfig, setToastConfig] = useState({
     isVisible: false,
     type: 'info',
     message: '',
   });
-  const checkAvailability = React.useCallback(
+  const checkAvailability = useCallback(
     (e, product) => {
       const type = e.value ? 'success' : 'error';
       const message = product.Name + (e.value ? ' is available' : ' is not available');
@@ -22,7 +22,7 @@ function App() {
     },
     [toastConfig, setToastConfig],
   );
-  const onHiding = React.useCallback(() => {
+  const onHiding = useCallback(() => {
     setToastConfig({
       ...toastConfig,
       isVisible: false,

--- a/JSDemos/Demos/Toast/Overview/ReactJs/ProductItem.js
+++ b/JSDemos/Demos/Toast/Overview/ReactJs/ProductItem.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { CheckBox } from 'devextreme-react/check-box';
 
 export function ProductItem(props) {
-  const onValueChanged = React.useCallback(
+  const onValueChanged = useCallback(
     (e) => {
       props.checkAvailability(e, props.product);
     },

--- a/JSDemos/Demos/Toast/Stack/React/App.tsx
+++ b/JSDemos/Demos/Toast/Stack/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Button from 'devextreme-react/button';
 import RadioGroup from 'devextreme-react/radio-group';
 import SelectBox from 'devextreme-react/select-box';
@@ -14,38 +14,38 @@ import {
 type NotifyStack = (typeof Notify)['arguments'][1];
 
 function App() {
-  const [id, setId] = React.useState(1);
-  const [isPredefined, setIsPredefined] = React.useState(true);
-  const [predefinedPosition, setPredefinedPosition] = React.useState('bottom center');
-  const [coordinatePosition, setCoordinatePosition] = React.useState({
+  const [id, setId] = useState(1);
+  const [isPredefined, setIsPredefined] = useState(true);
+  const [predefinedPosition, setPredefinedPosition] = useState('bottom center');
+  const [coordinatePosition, setCoordinatePosition] = useState({
     top: undefined,
     left: undefined,
     bottom: undefined,
     right: undefined,
   });
-  const [direction, setDirection] = React.useState('up-push' as NotifyStack['direction']);
+  const [direction, setDirection] = useState('up-push' as NotifyStack['direction']);
 
-  const topNumberBoxValueChanged = React.useCallback(
+  const topNumberBoxValueChanged = useCallback(
     (top) => setCoordinatePosition({ ...coordinatePosition, top }),
     [coordinatePosition, setCoordinatePosition],
   );
 
-  const bottomNumberBoxValueChanged = React.useCallback(
+  const bottomNumberBoxValueChanged = useCallback(
     (bottom) => setCoordinatePosition({ ...coordinatePosition, bottom }),
     [coordinatePosition, setCoordinatePosition],
   );
 
-  const leftNumberBoxValueChanged = React.useCallback(
+  const leftNumberBoxValueChanged = useCallback(
     (left) => setCoordinatePosition({ ...coordinatePosition, left }),
     [coordinatePosition, setCoordinatePosition],
   );
 
-  const rightNumberBoxValueChanged = React.useCallback(
+  const rightNumberBoxValueChanged = useCallback(
     (right) => setCoordinatePosition({ ...coordinatePosition, right }),
     [coordinatePosition, setCoordinatePosition],
   );
 
-  const show = React.useCallback(() => {
+  const show = useCallback(() => {
     const position: NotifyStack['position'] = isPredefined ? predefinedPosition : coordinatePosition;
 
     Notify({

--- a/JSDemos/Demos/Toast/Stack/ReactJs/App.js
+++ b/JSDemos/Demos/Toast/Stack/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Button from 'devextreme-react/button';
 import RadioGroup from 'devextreme-react/radio-group';
 import SelectBox from 'devextreme-react/select-box';
@@ -19,33 +19,33 @@ import {
 } from './data.js';
 
 function App() {
-  const [id, setId] = React.useState(1);
-  const [isPredefined, setIsPredefined] = React.useState(true);
-  const [predefinedPosition, setPredefinedPosition] = React.useState('bottom center');
-  const [coordinatePosition, setCoordinatePosition] = React.useState({
+  const [id, setId] = useState(1);
+  const [isPredefined, setIsPredefined] = useState(true);
+  const [predefinedPosition, setPredefinedPosition] = useState('bottom center');
+  const [coordinatePosition, setCoordinatePosition] = useState({
     top: undefined,
     left: undefined,
     bottom: undefined,
     right: undefined,
   });
-  const [direction, setDirection] = React.useState('up-push');
-  const topNumberBoxValueChanged = React.useCallback(
+  const [direction, setDirection] = useState('up-push');
+  const topNumberBoxValueChanged = useCallback(
     (top) => setCoordinatePosition({ ...coordinatePosition, top }),
     [coordinatePosition, setCoordinatePosition],
   );
-  const bottomNumberBoxValueChanged = React.useCallback(
+  const bottomNumberBoxValueChanged = useCallback(
     (bottom) => setCoordinatePosition({ ...coordinatePosition, bottom }),
     [coordinatePosition, setCoordinatePosition],
   );
-  const leftNumberBoxValueChanged = React.useCallback(
+  const leftNumberBoxValueChanged = useCallback(
     (left) => setCoordinatePosition({ ...coordinatePosition, left }),
     [coordinatePosition, setCoordinatePosition],
   );
-  const rightNumberBoxValueChanged = React.useCallback(
+  const rightNumberBoxValueChanged = useCallback(
     (right) => setCoordinatePosition({ ...coordinatePosition, right }),
     [coordinatePosition, setCoordinatePosition],
   );
-  const show = React.useCallback(() => {
+  const show = useCallback(() => {
     const position = isPredefined ? predefinedPosition : coordinatePosition;
     Notify(
       {

--- a/JSDemos/Demos/Toolbar/Adaptability/React/App.tsx
+++ b/JSDemos/Demos/Toolbar/Adaptability/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Toolbar, { Item } from 'devextreme-react/toolbar';
 import Button from 'devextreme-react/button';
 import ButtonGroup, { ButtonGroupTypes } from 'devextreme-react/button-group';
@@ -35,57 +35,57 @@ function onSelectionChanged(name: string) {
 }
 
 function App() {
-  const [lineHeight, setLineHeight] = React.useState(lineHeightDefault);
-  const [textAlign, setTextAlign] = React.useState(textAlignDefault);
-  const [fontSize, setFontSize] = React.useState(fontSizeDefault);
-  const [heading, setHeading] = React.useState(headingDefault);
-  const [multiline, setMultiline] = React.useState(true);
+  const [lineHeight, setLineHeight] = useState(lineHeightDefault);
+  const [textAlign, setTextAlign] = useState(textAlignDefault);
+  const [fontSize, setFontSize] = useState(fontSizeDefault);
+  const [heading, setHeading] = useState(headingDefault);
+  const [multiline, setMultiline] = useState(true);
 
-  const onFontFamilyClick = React.useCallback(() => {
+  const onFontFamilyClick = useCallback(() => {
     notify('The "Font Family" value has been changed');
   }, []);
 
-  const onUndoButtonClick = React.useCallback(() => {
+  const onUndoButtonClick = useCallback(() => {
     onButtonClick('Undo');
   }, []);
 
-  const onButtonGroupClick = React.useCallback((e: ButtonGroupTypes.ItemClickEvent) => {
+  const onButtonGroupClick = useCallback((e: ButtonGroupTypes.ItemClickEvent) => {
     onButtonClick(e.itemData.hint);
   }, []);
 
-  const onRedoButtonClick = React.useCallback(() => {
+  const onRedoButtonClick = useCallback(() => {
     onButtonClick('Redo');
   }, []);
 
-  const onLinkButtonClick = React.useCallback(() => {
+  const onLinkButtonClick = useCallback(() => {
     onButtonClick('Link');
   }, []);
 
-  const onAddImageButtonClick = React.useCallback(() => {
+  const onAddImageButtonClick = useCallback(() => {
     onButtonClick('Add Image');
   }, []);
 
-  const onClearButtonClick = React.useCallback(() => {
+  const onClearButtonClick = useCallback(() => {
     onButtonClick('Clear Formating');
   }, []);
 
-  const onCodeBlockButtonClick = React.useCallback(() => {
+  const onCodeBlockButtonClick = useCallback(() => {
     onButtonClick('Code Block');
   }, []);
 
-  const onQuoteButtonClick = React.useCallback(() => {
+  const onQuoteButtonClick = useCallback(() => {
     onButtonClick('Blockquote');
   }, []);
 
-  const onAttachButtonClick = React.useCallback(() => {
+  const onAttachButtonClick = useCallback(() => {
     onButtonClick('Attach');
   }, []);
 
-  const onAboutButtonClick = React.useCallback(() => {
+  const onAboutButtonClick = useCallback(() => {
     onButtonClick('Attach');
   }, []);
 
-  const onHeadingClick = React.useCallback(
+  const onHeadingClick = useCallback(
     (e: SelectBoxTypes.ItemClickEvent) => {
       setHeading(e.itemData.text);
       notify('The "Heading" value has been changed');
@@ -93,7 +93,7 @@ function App() {
     [setHeading],
   );
 
-  const onLineHeightChanged = React.useCallback(
+  const onLineHeightChanged = useCallback(
     (e: DropDownButtonTypes.SelectionChangedEvent) => {
       setLineHeight(e.item.lineHeight);
       onSelectionChanged('Line Height');
@@ -101,7 +101,7 @@ function App() {
     [setLineHeight],
   );
 
-  const onFontSizeChange = React.useCallback(
+  const onFontSizeChange = useCallback(
     (e: DropDownButtonTypes.SelectionChangedEvent) => {
       setFontSize(e.item.size);
       onSelectionChanged('Font Size');
@@ -109,7 +109,7 @@ function App() {
     [setFontSize],
   );
 
-  const onTextAlignChanged = React.useCallback(
+  const onTextAlignChanged = useCallback(
     (e: ButtonGroupTypes.ItemClickEvent) => {
       const { alignment, hint } = e.itemData;
 
@@ -119,21 +119,21 @@ function App() {
     [setTextAlign],
   );
 
-  const onToolbarLineModeChanged = React.useCallback(
+  const onToolbarLineModeChanged = useCallback(
     ({ value }) => {
       setMultiline(value);
     },
     [setMultiline],
   );
 
-  const renderFontSize = React.useCallback(
+  const renderFontSize = useCallback(
     (itemData) => (
       <div style={{ fontSize: `${itemData.size}px` }}>{itemData.text}</div>
     ),
     [],
   );
 
-  const renderTextAlign = React.useCallback(
+  const renderTextAlign = useCallback(
     () => (
       <ButtonGroup
         keyExpr="alignment"
@@ -146,7 +146,7 @@ function App() {
     [textAlign, onTextAlignChanged],
   );
 
-  const renderTextAlignMenu = React.useCallback(
+  const renderTextAlignMenu = useCallback(
     () => (
       <ButtonGroup
         keyExpr="alignment"
@@ -159,7 +159,7 @@ function App() {
     [textAlign, onTextAlignChanged],
   );
 
-  const renderMenuSeparator = React.useCallback(
+  const renderMenuSeparator = useCallback(
     () => <div className="toolbar-menu-separator"></div>,
     [],
   );

--- a/JSDemos/Demos/Toolbar/Adaptability/ReactJs/App.js
+++ b/JSDemos/Demos/Toolbar/Adaptability/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import Toolbar, { Item } from 'devextreme-react/toolbar';
 import Button from 'devextreme-react/button';
 import ButtonGroup from 'devextreme-react/button-group';
@@ -32,66 +32,66 @@ function onSelectionChanged(name) {
   notify(`The "${name}" value has been changed`);
 }
 function App() {
-  const [lineHeight, setLineHeight] = React.useState(lineHeightDefault);
-  const [textAlign, setTextAlign] = React.useState(textAlignDefault);
-  const [fontSize, setFontSize] = React.useState(fontSizeDefault);
-  const [heading, setHeading] = React.useState(headingDefault);
-  const [multiline, setMultiline] = React.useState(true);
-  const onFontFamilyClick = React.useCallback(() => {
+  const [lineHeight, setLineHeight] = useState(lineHeightDefault);
+  const [textAlign, setTextAlign] = useState(textAlignDefault);
+  const [fontSize, setFontSize] = useState(fontSizeDefault);
+  const [heading, setHeading] = useState(headingDefault);
+  const [multiline, setMultiline] = useState(true);
+  const onFontFamilyClick = useCallback(() => {
     notify('The "Font Family" value has been changed');
   }, []);
-  const onUndoButtonClick = React.useCallback(() => {
+  const onUndoButtonClick = useCallback(() => {
     onButtonClick('Undo');
   }, []);
-  const onButtonGroupClick = React.useCallback((e) => {
+  const onButtonGroupClick = useCallback((e) => {
     onButtonClick(e.itemData.hint);
   }, []);
-  const onRedoButtonClick = React.useCallback(() => {
+  const onRedoButtonClick = useCallback(() => {
     onButtonClick('Redo');
   }, []);
-  const onLinkButtonClick = React.useCallback(() => {
+  const onLinkButtonClick = useCallback(() => {
     onButtonClick('Link');
   }, []);
-  const onAddImageButtonClick = React.useCallback(() => {
+  const onAddImageButtonClick = useCallback(() => {
     onButtonClick('Add Image');
   }, []);
-  const onClearButtonClick = React.useCallback(() => {
+  const onClearButtonClick = useCallback(() => {
     onButtonClick('Clear Formating');
   }, []);
-  const onCodeBlockButtonClick = React.useCallback(() => {
+  const onCodeBlockButtonClick = useCallback(() => {
     onButtonClick('Code Block');
   }, []);
-  const onQuoteButtonClick = React.useCallback(() => {
+  const onQuoteButtonClick = useCallback(() => {
     onButtonClick('Blockquote');
   }, []);
-  const onAttachButtonClick = React.useCallback(() => {
+  const onAttachButtonClick = useCallback(() => {
     onButtonClick('Attach');
   }, []);
-  const onAboutButtonClick = React.useCallback(() => {
+  const onAboutButtonClick = useCallback(() => {
     onButtonClick('Attach');
   }, []);
-  const onHeadingClick = React.useCallback(
+  const onHeadingClick = useCallback(
     (e) => {
       setHeading(e.itemData.text);
       notify('The "Heading" value has been changed');
     },
     [setHeading],
   );
-  const onLineHeightChanged = React.useCallback(
+  const onLineHeightChanged = useCallback(
     (e) => {
       setLineHeight(e.item.lineHeight);
       onSelectionChanged('Line Height');
     },
     [setLineHeight],
   );
-  const onFontSizeChange = React.useCallback(
+  const onFontSizeChange = useCallback(
     (e) => {
       setFontSize(e.item.size);
       onSelectionChanged('Font Size');
     },
     [setFontSize],
   );
-  const onTextAlignChanged = React.useCallback(
+  const onTextAlignChanged = useCallback(
     (e) => {
       const { alignment, hint } = e.itemData;
       setTextAlign([alignment]);
@@ -99,17 +99,17 @@ function App() {
     },
     [setTextAlign],
   );
-  const onToolbarLineModeChanged = React.useCallback(
+  const onToolbarLineModeChanged = useCallback(
     ({ value }) => {
       setMultiline(value);
     },
     [setMultiline],
   );
-  const renderFontSize = React.useCallback(
+  const renderFontSize = useCallback(
     (itemData) => <div style={{ fontSize: `${itemData.size}px` }}>{itemData.text}</div>,
     [],
   );
-  const renderTextAlign = React.useCallback(
+  const renderTextAlign = useCallback(
     () => (
       <ButtonGroup
         keyExpr="alignment"
@@ -121,7 +121,7 @@ function App() {
     ),
     [textAlign, onTextAlignChanged],
   );
-  const renderTextAlignMenu = React.useCallback(
+  const renderTextAlignMenu = useCallback(
     () => (
       <ButtonGroup
         keyExpr="alignment"
@@ -133,7 +133,7 @@ function App() {
     ),
     [textAlign, onTextAlignChanged],
   );
-  const renderMenuSeparator = React.useCallback(
+  const renderMenuSeparator = useCallback(
     () => <div className="toolbar-menu-separator"></div>,
     [],
   );

--- a/JSDemos/Demos/Toolbar/Adaptability/ReactJs/App.js
+++ b/JSDemos/Demos/Toolbar/Adaptability/ReactJs/App.js
@@ -133,10 +133,7 @@ function App() {
     ),
     [textAlign, onTextAlignChanged],
   );
-  const renderMenuSeparator = useCallback(
-    () => <div className="toolbar-menu-separator"></div>,
-    [],
-  );
+  const renderMenuSeparator = useCallback(() => <div className="toolbar-menu-separator"></div>, []);
   return (
     <React.Fragment>
       <div className="widget-container">

--- a/JSDemos/Demos/TreeList/ColumnChooser/React/App.tsx
+++ b/JSDemos/Demos/TreeList/ColumnChooser/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   TreeList, Column, ColumnChooser, ColumnChooserSearch, ColumnChooserSelection, Position, TreeListTypes,
 } from 'devextreme-react/tree-list';
@@ -19,11 +19,11 @@ const expandedRowKeys = [1, 5];
 const searchEditorOptions = { placeholder: 'Search column' };
 
 const App = () => {
-  const [mode, setMode] = React.useState<TreeListTypes.ColumnChooserMode>(columnChooserModes[1].key);
-  const [searchEnabled, setSearchEnabled] = React.useState(true);
-  const [allowSelectAll, setAllowSelectAll] = React.useState(true);
-  const [selectByClick, setSelectByClick] = React.useState(true);
-  const [recursive, setRecursive] = React.useState(true);
+  const [mode, setMode] = useState<TreeListTypes.ColumnChooserMode>(columnChooserModes[1].key);
+  const [searchEnabled, setSearchEnabled] = useState(true);
+  const [allowSelectAll, setAllowSelectAll] = useState(true);
+  const [selectByClick, setSelectByClick] = useState(true);
+  const [recursive, setRecursive] = useState(true);
 
   const isDragMode = mode === columnChooserModes[0].key;
 

--- a/JSDemos/Demos/TreeList/ColumnChooser/ReactJs/App.js
+++ b/JSDemos/Demos/TreeList/ColumnChooser/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   TreeList,
   Column,
@@ -24,11 +24,11 @@ const columnChooserModes = [
 const expandedRowKeys = [1, 5];
 const searchEditorOptions = { placeholder: 'Search column' };
 const App = () => {
-  const [mode, setMode] = React.useState(columnChooserModes[1].key);
-  const [searchEnabled, setSearchEnabled] = React.useState(true);
-  const [allowSelectAll, setAllowSelectAll] = React.useState(true);
-  const [selectByClick, setSelectByClick] = React.useState(true);
-  const [recursive, setRecursive] = React.useState(true);
+  const [mode, setMode] = useState(columnChooserModes[1].key);
+  const [searchEnabled, setSearchEnabled] = useState(true);
+  const [allowSelectAll, setAllowSelectAll] = useState(true);
+  const [selectByClick, setSelectByClick] = useState(true);
+  const [recursive, setRecursive] = useState(true);
   const isDragMode = mode === columnChooserModes[0].key;
   return (
     <div>

--- a/JSDemos/Demos/TreeList/CustomizeKeyboardNavigation/React/App.tsx
+++ b/JSDemos/Demos/TreeList/CustomizeKeyboardNavigation/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import TreeList, {
   Column,
@@ -19,9 +19,9 @@ const onFocusedCellChanging = (e: TreeListTypes.FocusedCellChangingEvent) => {
 };
 
 const App = () => {
-  const [editOnKeyPress, setEditOnKeyPress] = React.useState(true);
-  const [enterKeyAction, setEnterKeyAction] = React.useState<TreeListTypes.EnterKeyAction>('moveFocus');
-  const [enterKeyDirection, setEnterKeyDirection] = React.useState<TreeListTypes.EnterKeyDirection>('column');
+  const [editOnKeyPress, setEditOnKeyPress] = useState(true);
+  const [enterKeyAction, setEnterKeyAction] = useState<TreeListTypes.EnterKeyAction>('moveFocus');
+  const [enterKeyDirection, setEnterKeyDirection] = useState<TreeListTypes.EnterKeyDirection>('column');
 
   return (
     <div id="tree-list-demo">

--- a/JSDemos/Demos/TreeList/CustomizeKeyboardNavigation/ReactJs/App.js
+++ b/JSDemos/Demos/TreeList/CustomizeKeyboardNavigation/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import TreeList, { Column, Editing, KeyboardNavigation } from 'devextreme-react/tree-list';
 import SelectBox from 'devextreme-react/select-box';
 import CheckBox from 'devextreme-react/check-box';
@@ -11,9 +11,9 @@ const onFocusedCellChanging = (e) => {
   e.isHighlighted = true;
 };
 const App = () => {
-  const [editOnKeyPress, setEditOnKeyPress] = React.useState(true);
-  const [enterKeyAction, setEnterKeyAction] = React.useState('moveFocus');
-  const [enterKeyDirection, setEnterKeyDirection] = React.useState('column');
+  const [editOnKeyPress, setEditOnKeyPress] = useState(true);
+  const [enterKeyAction, setEnterKeyAction] = useState('moveFocus');
+  const [enterKeyDirection, setEnterKeyDirection] = useState('column');
   return (
     <div id="tree-list-demo">
       <TreeList

--- a/JSDemos/Demos/TreeList/FilterModes/React/App.tsx
+++ b/JSDemos/Demos/TreeList/FilterModes/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   TreeList, Column, SearchPanel, TreeListTypes,
 } from 'devextreme-react/tree-list';
@@ -8,7 +8,7 @@ import { employees, filterLabel } from './data.ts';
 const filterModes = ['matchOnly', 'withAncestors', 'fullBranch'];
 
 const App = () => {
-  const [filterMode, setFilterMode] = React.useState<TreeListTypes.TreeListFilterMode>('matchOnly');
+  const [filterMode, setFilterMode] = useState<TreeListTypes.TreeListFilterMode>('matchOnly');
 
   return (
     <React.Fragment>

--- a/JSDemos/Demos/TreeList/FilterModes/ReactJs/App.js
+++ b/JSDemos/Demos/TreeList/FilterModes/ReactJs/App.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { TreeList, Column, SearchPanel } from 'devextreme-react/tree-list';
 import SelectBox from 'devextreme-react/select-box';
 import { employees, filterLabel } from './data.js';
 
 const filterModes = ['matchOnly', 'withAncestors', 'fullBranch'];
 const App = () => {
-  const [filterMode, setFilterMode] = React.useState('matchOnly');
+  const [filterMode, setFilterMode] = useState('matchOnly');
   return (
     <React.Fragment>
       <TreeList

--- a/JSDemos/Demos/TreeList/FocusedRow/React/App.tsx
+++ b/JSDemos/Demos/TreeList/FocusedRow/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import TreeList, { Column, Lookup, TreeListTypes } from 'devextreme-react/tree-list';
 import { NumberBox, NumberBoxTypes } from 'devextreme-react/number-box';
@@ -21,21 +21,21 @@ const taskEmployees = AspNetData.createStore({
 const focusedRowKeyLabel = { 'aria-label': 'Focused Row Key' };
 
 const App = () => {
-  const [taskSubject, setTaskSubject] = React.useState('');
-  const [taskAssigned, setTaskAssigned] = React.useState('');
-  const [startDate, setStartDate] = React.useState('');
-  const [taskStatus, setTaskStatus] = React.useState('');
-  const [taskProgress, setTaskProgress] = React.useState('');
-  const [focusedRowKey, setFocusedRowKey] = React.useState(45);
+  const [taskSubject, setTaskSubject] = useState('');
+  const [taskAssigned, setTaskAssigned] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [taskStatus, setTaskStatus] = useState('');
+  const [taskProgress, setTaskProgress] = useState('');
+  const [focusedRowKey, setFocusedRowKey] = useState(45);
 
-  const onTaskIdChanged = React.useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
+  const onTaskIdChanged = useCallback((e: NumberBoxTypes.ValueChangedEvent) => {
     if (e.event && e.value > 0) {
       setFocusedRowKey(e.value);
     }
   }, []);
 
   // eslint-disable-next-line @typescript-eslint/space-before-function-paren
-  const onFocusedRowChanged = React.useCallback(async(e: TreeListTypes.FocusedRowChangedEvent) => {
+  const onFocusedRowChanged = useCallback(async(e: TreeListTypes.FocusedRowChangedEvent) => {
     const rowData = e.row && e.row.data;
 
     if (rowData) {

--- a/JSDemos/Demos/TreeList/FocusedRow/ReactJs/App.js
+++ b/JSDemos/Demos/TreeList/FocusedRow/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TreeList, { Column, Lookup } from 'devextreme-react/tree-list';
 import { NumberBox } from 'devextreme-react/number-box';
 import * as AspNetData from 'devextreme-aspnet-data-nojquery';
@@ -18,19 +18,19 @@ const taskEmployees = AspNetData.createStore({
 });
 const focusedRowKeyLabel = { 'aria-label': 'Focused Row Key' };
 const App = () => {
-  const [taskSubject, setTaskSubject] = React.useState('');
-  const [taskAssigned, setTaskAssigned] = React.useState('');
-  const [startDate, setStartDate] = React.useState('');
-  const [taskStatus, setTaskStatus] = React.useState('');
-  const [taskProgress, setTaskProgress] = React.useState('');
-  const [focusedRowKey, setFocusedRowKey] = React.useState(45);
-  const onTaskIdChanged = React.useCallback((e) => {
+  const [taskSubject, setTaskSubject] = useState('');
+  const [taskAssigned, setTaskAssigned] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [taskStatus, setTaskStatus] = useState('');
+  const [taskProgress, setTaskProgress] = useState('');
+  const [focusedRowKey, setFocusedRowKey] = useState(45);
+  const onTaskIdChanged = useCallback((e) => {
     if (e.event && e.value > 0) {
       setFocusedRowKey(e.value);
     }
   }, []);
   // eslint-disable-next-line @typescript-eslint/space-before-function-paren
-  const onFocusedRowChanged = React.useCallback(async(e) => {
+  const onFocusedRowChanged = useCallback(async(e) => {
     const rowData = e.row && e.row.data;
     if (rowData) {
       const progress = rowData.Task_Completion ? `${rowData.Task_Completion}%` : '';

--- a/JSDemos/Demos/TreeList/LocalReordering/React/App.tsx
+++ b/JSDemos/Demos/TreeList/LocalReordering/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TreeList, { Column, RowDragging } from 'devextreme-react/tree-list';
 import CheckBox from 'devextreme-react/check-box';
 import { employees as employeeList } from './data.ts';
@@ -20,12 +20,12 @@ const onDragChange = (e) => {
 };
 
 const App = () => {
-  const [employees, setEmployees] = React.useState(employeeList);
-  const [allowDropInsideItem, setAllowDropInsideItem] = React.useState(true);
-  const [allowReordering, setAllowReordering] = React.useState(true);
-  const [showDragIcons, setShowDragIcons] = React.useState(true);
+  const [employees, setEmployees] = useState(employeeList);
+  const [allowDropInsideItem, setAllowDropInsideItem] = useState(true);
+  const [allowReordering, setAllowReordering] = useState(true);
+  const [showDragIcons, setShowDragIcons] = useState(true);
 
-  const onReorder = React.useCallback((e) => {
+  const onReorder = useCallback((e) => {
     const visibleRows = e.component.getVisibleRows();
     let sourceData = e.itemData;
     const updatedEmployees = [...employees];

--- a/JSDemos/Demos/TreeList/LocalReordering/ReactJs/App.js
+++ b/JSDemos/Demos/TreeList/LocalReordering/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TreeList, { Column, RowDragging } from 'devextreme-react/tree-list';
 import CheckBox from 'devextreme-react/check-box';
 import { employees as employeeList } from './data.js';
@@ -17,11 +17,11 @@ const onDragChange = (e) => {
   }
 };
 const App = () => {
-  const [employees, setEmployees] = React.useState(employeeList);
-  const [allowDropInsideItem, setAllowDropInsideItem] = React.useState(true);
-  const [allowReordering, setAllowReordering] = React.useState(true);
-  const [showDragIcons, setShowDragIcons] = React.useState(true);
-  const onReorder = React.useCallback(
+  const [employees, setEmployees] = useState(employeeList);
+  const [allowDropInsideItem, setAllowDropInsideItem] = useState(true);
+  const [allowReordering, setAllowReordering] = useState(true);
+  const [showDragIcons, setShowDragIcons] = useState(true);
+  const onReorder = useCallback(
     (e) => {
       const visibleRows = e.component.getVisibleRows();
       let sourceData = e.itemData;

--- a/JSDemos/Demos/TreeList/MultipleRowSelection/React/App.tsx
+++ b/JSDemos/Demos/TreeList/MultipleRowSelection/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   TreeList, Selection, Column, TreeListTypes,
 } from 'devextreme-react/tree-list';
@@ -11,31 +11,31 @@ const emptySelectedText = 'Nobody has been selected';
 const selectionModes = ['all', 'excludeRecursive', 'leavesOnly'];
 
 const App = () => {
-  const [selectedRowKeys, setSelectedRowKeys] = React.useState([]);
-  const [recursive, setRecursive] = React.useState(false);
-  const [selectionMode, setSelectionMode] = React.useState('all');
-  const [selectedEmployeeNames, setSelectedEmployeeNames] = React.useState(emptySelectedText);
+  const [selectedRowKeys, setSelectedRowKeys] = useState([]);
+  const [recursive, setRecursive] = useState(false);
+  const [selectionMode, setSelectionMode] = useState('all');
+  const [selectedEmployeeNames, setSelectedEmployeeNames] = useState(emptySelectedText);
 
-  const getEmployeeNames = React.useCallback((employeeList) => {
+  const getEmployeeNames = useCallback((employeeList) => {
     if (employeeList.length > 0) {
       return employeeList.map((employee) => employee.Full_Name).join(', ');
     }
     return emptySelectedText;
   }, []);
 
-  const onSelectionChanged = React.useCallback((e: TreeListTypes.SelectionChangedEvent) => {
+  const onSelectionChanged = useCallback((e: TreeListTypes.SelectionChangedEvent) => {
     const selectedData = e.component.getSelectedRowsData(selectionMode);
     setSelectedRowKeys(e.selectedRowKeys);
     setSelectedEmployeeNames(getEmployeeNames(selectedData));
   }, [selectionMode, getEmployeeNames]);
 
-  const onRecursiveChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const onRecursiveChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setRecursive(e.value);
     setSelectedRowKeys([]);
     setSelectedEmployeeNames(emptySelectedText);
   }, []);
 
-  const onSelectionModeChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const onSelectionModeChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setSelectionMode(e.value);
     setSelectedRowKeys([]);
     setSelectedEmployeeNames(emptySelectedText);

--- a/JSDemos/Demos/TreeList/MultipleRowSelection/ReactJs/App.js
+++ b/JSDemos/Demos/TreeList/MultipleRowSelection/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { TreeList, Selection, Column } from 'devextreme-react/tree-list';
 import { CheckBox } from 'devextreme-react/check-box';
 import { SelectBox } from 'devextreme-react/select-box';
@@ -8,17 +8,17 @@ const expandedRowKeys = [1, 2, 10];
 const emptySelectedText = 'Nobody has been selected';
 const selectionModes = ['all', 'excludeRecursive', 'leavesOnly'];
 const App = () => {
-  const [selectedRowKeys, setSelectedRowKeys] = React.useState([]);
-  const [recursive, setRecursive] = React.useState(false);
-  const [selectionMode, setSelectionMode] = React.useState('all');
-  const [selectedEmployeeNames, setSelectedEmployeeNames] = React.useState(emptySelectedText);
-  const getEmployeeNames = React.useCallback((employeeList) => {
+  const [selectedRowKeys, setSelectedRowKeys] = useState([]);
+  const [recursive, setRecursive] = useState(false);
+  const [selectionMode, setSelectionMode] = useState('all');
+  const [selectedEmployeeNames, setSelectedEmployeeNames] = useState(emptySelectedText);
+  const getEmployeeNames = useCallback((employeeList) => {
     if (employeeList.length > 0) {
       return employeeList.map((employee) => employee.Full_Name).join(', ');
     }
     return emptySelectedText;
   }, []);
-  const onSelectionChanged = React.useCallback(
+  const onSelectionChanged = useCallback(
     (e) => {
       const selectedData = e.component.getSelectedRowsData(selectionMode);
       setSelectedRowKeys(e.selectedRowKeys);
@@ -26,12 +26,12 @@ const App = () => {
     },
     [selectionMode, getEmployeeNames],
   );
-  const onRecursiveChanged = React.useCallback((e) => {
+  const onRecursiveChanged = useCallback((e) => {
     setRecursive(e.value);
     setSelectedRowKeys([]);
     setSelectedEmployeeNames(emptySelectedText);
   }, []);
-  const onSelectionModeChanged = React.useCallback((e) => {
+  const onSelectionModeChanged = useCallback((e) => {
     setSelectionMode(e.value);
     setSelectedRowKeys([]);
     setSelectedEmployeeNames(emptySelectedText);

--- a/JSDemos/Demos/TreeList/Resizing/React/App.tsx
+++ b/JSDemos/Demos/TreeList/Resizing/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { TreeList, Column, TreeListTypes } from 'devextreme-react/tree-list';
 import { SelectBox } from 'devextreme-react/select-box';
 import { employees, columnResizingModeLabel } from './data.ts';
@@ -7,7 +7,7 @@ const resizingModes = ['nextColumn', 'widget'];
 const expandedRowKeys = [1, 3, 6];
 
 const App = () => {
-  const [columnResizingMode, setColumnResizingMode] = React.useState<TreeListTypes.ColumnResizeMode>('nextColumn');
+  const [columnResizingMode, setColumnResizingMode] = useState<TreeListTypes.ColumnResizeMode>('nextColumn');
 
   return (
     <div>

--- a/JSDemos/Demos/TreeList/Resizing/ReactJs/App.js
+++ b/JSDemos/Demos/TreeList/Resizing/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { TreeList, Column } from 'devextreme-react/tree-list';
 import { SelectBox } from 'devextreme-react/select-box';
 import { employees, columnResizingModeLabel } from './data.js';
@@ -6,7 +6,7 @@ import { employees, columnResizingModeLabel } from './data.js';
 const resizingModes = ['nextColumn', 'widget'];
 const expandedRowKeys = [1, 3, 6];
 const App = () => {
-  const [columnResizingMode, setColumnResizingMode] = React.useState('nextColumn');
+  const [columnResizingMode, setColumnResizingMode] = useState('nextColumn');
   return (
     <div>
       <TreeList

--- a/JSDemos/Demos/TreeList/StatePersistence/React/App.tsx
+++ b/JSDemos/Demos/TreeList/StatePersistence/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import {
   TreeList, Selection, FilterRow, StateStoring, Column,
 } from 'devextreme-react/tree-list';
@@ -11,9 +11,9 @@ const reloadPage = () => {
 };
 
 const App = () => {
-  const treeList = React.useRef<TreeList>(null);
+  const treeList = useRef<TreeList>(null);
 
-  const onStateResetClick = React.useCallback(() => {
+  const onStateResetClick = useCallback(() => {
     treeList.current.instance.state(null);
   }, []);
 

--- a/JSDemos/Demos/TreeList/StatePersistence/ReactJs/App.js
+++ b/JSDemos/Demos/TreeList/StatePersistence/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import {
   TreeList, Selection, FilterRow, StateStoring, Column,
 } from 'devextreme-react/tree-list';
@@ -9,8 +9,8 @@ const reloadPage = () => {
   window.location.reload();
 };
 const App = () => {
-  const treeList = React.useRef(null);
-  const onStateResetClick = React.useCallback(() => {
+  const treeList = useRef(null);
+  const onStateResetClick = useCallback(() => {
     treeList.current.instance.state(null);
   }, []);
   return (

--- a/JSDemos/Demos/TreeView/ContextMenuIntegration/React/App.tsx
+++ b/JSDemos/Demos/TreeView/ContextMenuIntegration/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import TreeView, { TreeViewTypes } from 'devextreme-react/tree-view';
 import ContextMenu, { ContextMenuTypes } from 'devextreme-react/context-menu';
 import List from 'devextreme-react/list';
@@ -8,12 +8,12 @@ const products = service.getProducts();
 const menuItems = service.getMenuItems();
 
 const App = () => {
-  const contextMenuRef = React.useRef(null);
-  const treeViewRef = React.useRef(null);
-  const [logItems, setLogItems] = React.useState([]);
-  const [selectedTreeItem, setSelectedTreeItem] = React.useState(undefined);
+  const contextMenuRef = useRef(null);
+  const treeViewRef = useRef(null);
+  const [logItems, setLogItems] = useState([]);
+  const [selectedTreeItem, setSelectedTreeItem] = useState(undefined);
 
-  const treeViewItemContextMenu = React.useCallback((
+  const treeViewItemContextMenu = useCallback((
     e: TreeViewTypes.ItemContextMenuEvent & { itemData: { price?: any; }; },
   ) => {
     setSelectedTreeItem(e.itemData);
@@ -28,7 +28,7 @@ const App = () => {
     contextMenuRef.current.instance.option('items[1].disabled', !e.node.expanded);
   }, []);
 
-  const contextMenuItemClick = React.useCallback((
+  const contextMenuItemClick = useCallback((
     e: ContextMenuTypes.ItemClickEvent & { itemData: { id?: any; }; },
   ) => {
     let logEntry = '';

--- a/JSDemos/Demos/TreeView/ContextMenuIntegration/ReactJs/App.js
+++ b/JSDemos/Demos/TreeView/ContextMenuIntegration/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import TreeView from 'devextreme-react/tree-view';
 import ContextMenu from 'devextreme-react/context-menu';
 import List from 'devextreme-react/list';
@@ -7,11 +7,11 @@ import service from './data.js';
 const products = service.getProducts();
 const menuItems = service.getMenuItems();
 const App = () => {
-  const contextMenuRef = React.useRef(null);
-  const treeViewRef = React.useRef(null);
-  const [logItems, setLogItems] = React.useState([]);
-  const [selectedTreeItem, setSelectedTreeItem] = React.useState(undefined);
-  const treeViewItemContextMenu = React.useCallback((e) => {
+  const contextMenuRef = useRef(null);
+  const treeViewRef = useRef(null);
+  const [logItems, setLogItems] = useState([]);
+  const [selectedTreeItem, setSelectedTreeItem] = useState(undefined);
+  const treeViewItemContextMenu = useCallback((e) => {
     setSelectedTreeItem(e.itemData);
     const isProduct = e.itemData.price !== undefined;
     contextMenuRef.current.instance.option('items[0].visible', !isProduct);
@@ -21,7 +21,7 @@ const App = () => {
     contextMenuRef.current.instance.option('items[0].disabled', e.node.expanded);
     contextMenuRef.current.instance.option('items[1].disabled', !e.node.expanded);
   }, []);
-  const contextMenuItemClick = React.useCallback(
+  const contextMenuItemClick = useCallback(
     (e) => {
       let logEntry = '';
       switch (e.itemData.id) {

--- a/JSDemos/Demos/TreeView/DragAndDropHierarchicalDataStructure/React/App.tsx
+++ b/JSDemos/Demos/TreeView/DragAndDropHierarchicalDataStructure/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import TreeView, { TreeViewTypes } from 'devextreme-react/tree-view';
 import Sortable, { SortableTypes } from 'devextreme-react/sortable';
 
@@ -83,17 +83,17 @@ const getTopVisibleNode = (component) => {
 };
 
 const App = () => {
-  const treeViewDriveCRef = React.useRef<TreeView>(null);
-  const treeViewDriveDRef = React.useRef<TreeView>(null);
+  const treeViewDriveCRef = useRef<TreeView>(null);
+  const treeViewDriveDRef = useRef<TreeView>(null);
 
-  const [itemsDriveC, setItemsDriveC] = React.useState(service.getItemsDriveC());
-  const [itemsDriveD, setItemsDriveD] = React.useState(service.getItemsDriveD());
+  const [itemsDriveC, setItemsDriveC] = useState(service.getItemsDriveC());
+  const [itemsDriveD, setItemsDriveD] = useState(service.getItemsDriveD());
 
-  const getTreeView = React.useCallback((driveName: string) => (driveName === 'driveC'
+  const getTreeView = useCallback((driveName: string) => (driveName === 'driveC'
     ? treeViewDriveCRef.current.instance
     : treeViewDriveDRef.current.instance), []);
 
-  const onDragChange = React.useCallback((e: SortableTypes.DragChangeEvent) => {
+  const onDragChange = useCallback((e: SortableTypes.DragChangeEvent) => {
     if (e.fromComponent === e.toComponent) {
       const fromNode = findNode(getTreeView(e.fromData), e.fromIndex);
       const toNode = findNode(getTreeView(e.toData), calculateToIndex(e));
@@ -103,11 +103,11 @@ const App = () => {
     }
   }, [getTreeView]);
 
-  const getStateFieldItems = React.useCallback((driveName: string) => (driveName === 'driveC'
+  const getStateFieldItems = useCallback((driveName: string) => (driveName === 'driveC'
     ? itemsDriveC
     : itemsDriveD), [itemsDriveC, itemsDriveD]);
 
-  const onDragEnd = React.useCallback((e: SortableTypes.DragEndEvent) => {
+  const onDragEnd = useCallback((e: SortableTypes.DragEndEvent) => {
     if (e.fromComponent === e.toComponent && e.fromIndex === e.toIndex) {
       return;
     }

--- a/JSDemos/Demos/TreeView/DragAndDropHierarchicalDataStructure/ReactJs/App.js
+++ b/JSDemos/Demos/TreeView/DragAndDropHierarchicalDataStructure/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import TreeView from 'devextreme-react/tree-view';
 import Sortable from 'devextreme-react/sortable';
 import service from './data.js';
@@ -69,18 +69,18 @@ const getTopVisibleNode = (component) => {
   return null;
 };
 const App = () => {
-  const treeViewDriveCRef = React.useRef(null);
-  const treeViewDriveDRef = React.useRef(null);
-  const [itemsDriveC, setItemsDriveC] = React.useState(service.getItemsDriveC());
-  const [itemsDriveD, setItemsDriveD] = React.useState(service.getItemsDriveD());
-  const getTreeView = React.useCallback(
+  const treeViewDriveCRef = useRef(null);
+  const treeViewDriveDRef = useRef(null);
+  const [itemsDriveC, setItemsDriveC] = useState(service.getItemsDriveC());
+  const [itemsDriveD, setItemsDriveD] = useState(service.getItemsDriveD());
+  const getTreeView = useCallback(
     (driveName) =>
       (driveName === 'driveC'
         ? treeViewDriveCRef.current.instance
         : treeViewDriveDRef.current.instance),
     [],
   );
-  const onDragChange = React.useCallback(
+  const onDragChange = useCallback(
     (e) => {
       if (e.fromComponent === e.toComponent) {
         const fromNode = findNode(getTreeView(e.fromData), e.fromIndex);
@@ -92,11 +92,11 @@ const App = () => {
     },
     [getTreeView],
   );
-  const getStateFieldItems = React.useCallback(
+  const getStateFieldItems = useCallback(
     (driveName) => (driveName === 'driveC' ? itemsDriveC : itemsDriveD),
     [itemsDriveC, itemsDriveD],
   );
-  const onDragEnd = React.useCallback(
+  const onDragEnd = useCallback(
     (e) => {
       if (e.fromComponent === e.toComponent && e.fromIndex === e.toIndex) {
         return;

--- a/JSDemos/Demos/TreeView/DragAndDropPlainDataStructure/React/App.tsx
+++ b/JSDemos/Demos/TreeView/DragAndDropPlainDataStructure/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import TreeView from 'devextreme-react/tree-view';
 import Sortable, { SortableTypes } from 'devextreme-react/sortable';
 
@@ -102,17 +102,17 @@ const getTopVisibleNode = (component) => {
 };
 
 const App = () => {
-  const treeViewDriveCRef = React.useRef<TreeView>(null);
-  const treeViewDriveDRef = React.useRef<TreeView>(null);
+  const treeViewDriveCRef = useRef<TreeView>(null);
+  const treeViewDriveDRef = useRef<TreeView>(null);
 
-  const [itemsDriveC, setItemsDriveC] = React.useState(service.getItemsDriveC());
-  const [itemsDriveD, setItemsDriveD] = React.useState(service.getItemsDriveD());
+  const [itemsDriveC, setItemsDriveC] = useState(service.getItemsDriveC());
+  const [itemsDriveD, setItemsDriveD] = useState(service.getItemsDriveD());
 
-  const getTreeView = React.useCallback((driveName: string) => (driveName === 'driveC'
+  const getTreeView = useCallback((driveName: string) => (driveName === 'driveC'
     ? treeViewDriveCRef.current.instance
     : treeViewDriveDRef.current.instance), []);
 
-  const onDragChange = React.useCallback((e: SortableTypes.DragChangeEvent) => {
+  const onDragChange = useCallback((e: SortableTypes.DragChangeEvent) => {
     if (e.fromComponent === e.toComponent) {
       const fromNode = findNode(getTreeView(e.fromData), e.fromIndex);
       const toNode = findNode(getTreeView(e.toData), calculateToIndex(e));
@@ -122,7 +122,7 @@ const App = () => {
     }
   }, [getTreeView]);
 
-  const onDragEnd = React.useCallback((e: SortableTypes.DragEndEvent) => {
+  const onDragEnd = useCallback((e: SortableTypes.DragEndEvent) => {
     if (e.fromComponent === e.toComponent && e.fromIndex === e.toIndex) {
       return;
     }

--- a/JSDemos/Demos/TreeView/DragAndDropPlainDataStructure/ReactJs/App.js
+++ b/JSDemos/Demos/TreeView/DragAndDropPlainDataStructure/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import TreeView from 'devextreme-react/tree-view';
 import Sortable from 'devextreme-react/sortable';
 import service from './data.js';
@@ -81,18 +81,18 @@ const getTopVisibleNode = (component) => {
   return null;
 };
 const App = () => {
-  const treeViewDriveCRef = React.useRef(null);
-  const treeViewDriveDRef = React.useRef(null);
-  const [itemsDriveC, setItemsDriveC] = React.useState(service.getItemsDriveC());
-  const [itemsDriveD, setItemsDriveD] = React.useState(service.getItemsDriveD());
-  const getTreeView = React.useCallback(
+  const treeViewDriveCRef = useRef(null);
+  const treeViewDriveDRef = useRef(null);
+  const [itemsDriveC, setItemsDriveC] = useState(service.getItemsDriveC());
+  const [itemsDriveD, setItemsDriveD] = useState(service.getItemsDriveD());
+  const getTreeView = useCallback(
     (driveName) =>
       (driveName === 'driveC'
         ? treeViewDriveCRef.current.instance
         : treeViewDriveDRef.current.instance),
     [],
   );
-  const onDragChange = React.useCallback(
+  const onDragChange = useCallback(
     (e) => {
       if (e.fromComponent === e.toComponent) {
         const fromNode = findNode(getTreeView(e.fromData), e.fromIndex);
@@ -104,7 +104,7 @@ const App = () => {
     },
     [getTreeView],
   );
-  const onDragEnd = React.useCallback(
+  const onDragEnd = useCallback(
     (e) => {
       if (e.fromComponent === e.toComponent && e.fromIndex === e.toIndex) {
         return;

--- a/JSDemos/Demos/TreeView/FlatDataStructure/React/App.tsx
+++ b/JSDemos/Demos/TreeView/FlatDataStructure/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TreeView, { TreeViewTypes } from 'devextreme-react/tree-view';
 
 import service, { ProductType } from './data.ts';
@@ -6,9 +6,9 @@ import service, { ProductType } from './data.ts';
 const products = service.getProducts();
 
 const App = () => {
-  const [currentItem, setCurrentItem] = React.useState(products[0]);
+  const [currentItem, setCurrentItem] = useState(products[0]);
 
-  const selectItem = React.useCallback((e: TreeViewTypes.ItemClickEvent & { itemData: ProductType }) => {
+  const selectItem = useCallback((e: TreeViewTypes.ItemClickEvent & { itemData: ProductType }) => {
     setCurrentItem({ ...e.itemData });
   }, [setCurrentItem]);
 

--- a/JSDemos/Demos/TreeView/FlatDataStructure/ReactJs/App.js
+++ b/JSDemos/Demos/TreeView/FlatDataStructure/ReactJs/App.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TreeView from 'devextreme-react/tree-view';
 import service from './data.js';
 
 const products = service.getProducts();
 const App = () => {
-  const [currentItem, setCurrentItem] = React.useState(products[0]);
-  const selectItem = React.useCallback(
+  const [currentItem, setCurrentItem] = useState(products[0]);
+  const selectItem = useCallback(
     (e) => {
       setCurrentItem({ ...e.itemData });
     },

--- a/JSDemos/Demos/TreeView/HierarchicalDataStructure/React/App.tsx
+++ b/JSDemos/Demos/TreeView/HierarchicalDataStructure/React/App.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TreeView, { TreeViewTypes } from 'devextreme-react/tree-view';
 import service, { ProductType } from './data.ts';
 
 const products = service.getProducts();
 
 const App = () => {
-  const [currentItem, setCurrentItem] = React.useState({ ...products[0] });
+  const [currentItem, setCurrentItem] = useState({ ...products[0] });
 
-  const selectItem = React.useCallback((e: TreeViewTypes.ItemClickEvent & { itemData?: ProductType; }) => {
+  const selectItem = useCallback((e: TreeViewTypes.ItemClickEvent & { itemData?: ProductType; }) => {
     setCurrentItem({ ...e.itemData });
   }, [setCurrentItem]);
 

--- a/JSDemos/Demos/TreeView/HierarchicalDataStructure/ReactJs/App.js
+++ b/JSDemos/Demos/TreeView/HierarchicalDataStructure/ReactJs/App.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TreeView from 'devextreme-react/tree-view';
 import service from './data.js';
 
 const products = service.getProducts();
 const App = () => {
-  const [currentItem, setCurrentItem] = React.useState({ ...products[0] });
-  const selectItem = React.useCallback(
+  const [currentItem, setCurrentItem] = useState({ ...products[0] });
+  const selectItem = useCallback(
     (e) => {
       setCurrentItem({ ...e.itemData });
     },

--- a/JSDemos/Demos/TreeView/ItemSelectionAndCustomization/React/App.tsx
+++ b/JSDemos/Demos/TreeView/ItemSelectionAndCustomization/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import TreeView, { TreeViewTypes } from 'devextreme-react/tree-view';
 import List from 'devextreme-react/list';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
@@ -14,31 +14,31 @@ const renderTreeViewItem = (item: { fullName: any; position: any; }) => `${item.
 const renderListItem = (item: { prefix: any; fullName: any; position: any; }) => `${item.prefix} ${item.fullName} (${item.position})`;
 
 const App = () => {
-  const treeViewRef = React.useRef(null);
-  const [selectedEmployees, setSelectedEmployees] = React.useState([]);
-  const [selectNodesRecursive, setSelectNodesRecursive] = React.useState(true);
-  const [selectByClick, setSelectByClick] = React.useState(false);
-  const [showCheckBoxesMode, setShowCheckBoxesMode] = React.useState(showCheckBoxesModes[0]);
-  const [selectionMode, setSelectionMode] = React.useState(selectionModes[0]);
-  const [isSelectionModeDisabled, setIsSelectionModeDisabled] = React.useState(false);
-  const [isRecursiveDisabled, setIsRecursiveDisabled] = React.useState(false);
+  const treeViewRef = useRef(null);
+  const [selectedEmployees, setSelectedEmployees] = useState([]);
+  const [selectNodesRecursive, setSelectNodesRecursive] = useState(true);
+  const [selectByClick, setSelectByClick] = useState(false);
+  const [showCheckBoxesMode, setShowCheckBoxesMode] = useState(showCheckBoxesModes[0]);
+  const [selectionMode, setSelectionMode] = useState(selectionModes[0]);
+  const [isSelectionModeDisabled, setIsSelectionModeDisabled] = useState(false);
+  const [isRecursiveDisabled, setIsRecursiveDisabled] = useState(false);
 
-  const syncSelection = React.useCallback((treeView) => {
+  const syncSelection = useCallback((treeView) => {
     const syncSelectedEmployees = treeView.getSelectedNodes()
       .map((node) => node.itemData);
 
     setSelectedEmployees(syncSelectedEmployees);
   }, [setSelectedEmployees]);
 
-  const treeViewSelectionChanged = React.useCallback((e: TreeViewTypes.SelectionChangedEvent) => {
+  const treeViewSelectionChanged = useCallback((e: TreeViewTypes.SelectionChangedEvent) => {
     syncSelection(e.component);
   }, [syncSelection]);
 
-  const treeViewContentReady = React.useCallback((e: TreeViewTypes.ContentReadyEvent) => {
+  const treeViewContentReady = useCallback((e: TreeViewTypes.ContentReadyEvent) => {
     syncSelection(e.component);
   }, [syncSelection]);
 
-  const showCheckBoxesModeValueChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const showCheckBoxesModeValueChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     const value = e.value;
     setShowCheckBoxesMode(value);
 
@@ -49,7 +49,7 @@ const App = () => {
     setIsSelectionModeDisabled(value === 'selectAll');
   }, [setShowCheckBoxesMode, setSelectionMode, setIsRecursiveDisabled, setIsSelectionModeDisabled]);
 
-  const selectionModeValueChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const selectionModeValueChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     const value = e.value;
     setSelectionMode(value);
 
@@ -60,11 +60,11 @@ const App = () => {
     setIsRecursiveDisabled(value === 'single');
   }, [setSelectionMode, setSelectNodesRecursive, setIsRecursiveDisabled]);
 
-  const selectNodesRecursiveValueChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const selectNodesRecursiveValueChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setSelectNodesRecursive(e.value);
   }, [setSelectNodesRecursive]);
 
-  const selectByClickValueChanged = React.useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
+  const selectByClickValueChanged = useCallback((e: CheckBoxTypes.ValueChangedEvent) => {
     setSelectByClick(e.value);
   }, [setSelectByClick]);
 

--- a/JSDemos/Demos/TreeView/ItemSelectionAndCustomization/ReactJs/App.js
+++ b/JSDemos/Demos/TreeView/ItemSelectionAndCustomization/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import TreeView from 'devextreme-react/tree-view';
 import List from 'devextreme-react/list';
 import SelectBox from 'devextreme-react/select-box';
@@ -10,34 +10,34 @@ const selectionModes = ['multiple', 'single'];
 const renderTreeViewItem = (item) => `${item.fullName} (${item.position})`;
 const renderListItem = (item) => `${item.prefix} ${item.fullName} (${item.position})`;
 const App = () => {
-  const treeViewRef = React.useRef(null);
-  const [selectedEmployees, setSelectedEmployees] = React.useState([]);
-  const [selectNodesRecursive, setSelectNodesRecursive] = React.useState(true);
-  const [selectByClick, setSelectByClick] = React.useState(false);
-  const [showCheckBoxesMode, setShowCheckBoxesMode] = React.useState(showCheckBoxesModes[0]);
-  const [selectionMode, setSelectionMode] = React.useState(selectionModes[0]);
-  const [isSelectionModeDisabled, setIsSelectionModeDisabled] = React.useState(false);
-  const [isRecursiveDisabled, setIsRecursiveDisabled] = React.useState(false);
-  const syncSelection = React.useCallback(
+  const treeViewRef = useRef(null);
+  const [selectedEmployees, setSelectedEmployees] = useState([]);
+  const [selectNodesRecursive, setSelectNodesRecursive] = useState(true);
+  const [selectByClick, setSelectByClick] = useState(false);
+  const [showCheckBoxesMode, setShowCheckBoxesMode] = useState(showCheckBoxesModes[0]);
+  const [selectionMode, setSelectionMode] = useState(selectionModes[0]);
+  const [isSelectionModeDisabled, setIsSelectionModeDisabled] = useState(false);
+  const [isRecursiveDisabled, setIsRecursiveDisabled] = useState(false);
+  const syncSelection = useCallback(
     (treeView) => {
       const syncSelectedEmployees = treeView.getSelectedNodes().map((node) => node.itemData);
       setSelectedEmployees(syncSelectedEmployees);
     },
     [setSelectedEmployees],
   );
-  const treeViewSelectionChanged = React.useCallback(
+  const treeViewSelectionChanged = useCallback(
     (e) => {
       syncSelection(e.component);
     },
     [syncSelection],
   );
-  const treeViewContentReady = React.useCallback(
+  const treeViewContentReady = useCallback(
     (e) => {
       syncSelection(e.component);
     },
     [syncSelection],
   );
-  const showCheckBoxesModeValueChanged = React.useCallback(
+  const showCheckBoxesModeValueChanged = useCallback(
     (e) => {
       const value = e.value;
       setShowCheckBoxesMode(value);
@@ -49,7 +49,7 @@ const App = () => {
     },
     [setShowCheckBoxesMode, setSelectionMode, setIsRecursiveDisabled, setIsSelectionModeDisabled],
   );
-  const selectionModeValueChanged = React.useCallback(
+  const selectionModeValueChanged = useCallback(
     (e) => {
       const value = e.value;
       setSelectionMode(value);
@@ -61,13 +61,13 @@ const App = () => {
     },
     [setSelectionMode, setSelectNodesRecursive, setIsRecursiveDisabled],
   );
-  const selectNodesRecursiveValueChanged = React.useCallback(
+  const selectNodesRecursiveValueChanged = useCallback(
     (e) => {
       setSelectNodesRecursive(e.value);
     },
     [setSelectNodesRecursive],
   );
-  const selectByClickValueChanged = React.useCallback(
+  const selectByClickValueChanged = useCallback(
     (e) => {
       setSelectByClick(e.value);
     },

--- a/JSDemos/Demos/TreeView/TreeViewWithSearchBar/React/App.tsx
+++ b/JSDemos/Demos/TreeView/TreeViewWithSearchBar/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import TreeView from 'devextreme-react/tree-view';
 import SelectBox, { SelectBoxTypes } from 'devextreme-react/select-box';
@@ -9,9 +9,9 @@ import { products, searchModeLabel } from './data.ts';
 const options: SearchMode[] = ['contains', 'startswith', 'equals'];
 
 const App = () => {
-  const [value, setValue] = React.useState<SearchMode>('contains');
+  const [value, setValue] = useState<SearchMode>('contains');
 
-  const valueChanged = React.useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
+  const valueChanged = useCallback((e: SelectBoxTypes.ValueChangedEvent) => {
     setValue(e.value);
   }, [setValue]);
 

--- a/JSDemos/Demos/TreeView/TreeViewWithSearchBar/ReactJs/App.js
+++ b/JSDemos/Demos/TreeView/TreeViewWithSearchBar/ReactJs/App.js
@@ -1,12 +1,12 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import TreeView from 'devextreme-react/tree-view';
 import SelectBox from 'devextreme-react/select-box';
 import { products, searchModeLabel } from './data.js';
 
 const options = ['contains', 'startswith', 'equals'];
 const App = () => {
-  const [value, setValue] = React.useState('contains');
-  const valueChanged = React.useCallback(
+  const [value, setValue] = useState('contains');
+  const valueChanged = useCallback(
     (e) => {
       setValue(e.value);
     },

--- a/JSDemos/Demos/Validation/Overview/React/App.tsx
+++ b/JSDemos/Demos/Validation/Overview/React/App.tsx
@@ -1,4 +1,6 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback, useMemo, useRef, useState,
+} from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import CheckBox from 'devextreme-react/check-box';
 import { TextBox, Button as TextBoxButton, TextBoxTypes } from 'devextreme-react/text-box';

--- a/JSDemos/Demos/Validation/Overview/React/App.tsx
+++ b/JSDemos/Demos/Validation/Overview/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import CheckBox from 'devextreme-react/check-box';
 import { TextBox, Button as TextBoxButton, TextBoxTypes } from 'devextreme-react/text-box';
@@ -59,13 +59,13 @@ function App() {
   const currentDate = new Date();
   const maxDate = new Date(currentDate.setFullYear(currentDate.getFullYear() - 21));
 
-  const [password, setPassword] = React.useState('');
-  const [confirmPassword, setConfirmPassword] = React.useState('');
-  const [passwordMode, setPasswordMode] = React.useState<TextBoxTypes.TextBoxType>('password');
-  const [confirmPasswordMode, setConfirmPasswordMode] = React.useState<TextBoxTypes.TextBoxType>('password');
-  const validatorRef = React.useRef(null);
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordMode, setPasswordMode] = useState<TextBoxTypes.TextBoxType>('password');
+  const [confirmPasswordMode, setConfirmPasswordMode] = useState<TextBoxTypes.TextBoxType>('password');
+  const validatorRef = useRef(null);
 
-  const passwordButton = React.useMemo<ButtonTypes.Properties>(
+  const passwordButton = useMemo<ButtonTypes.Properties>(
     () => ({
       icon: 'eyeopen',
       stylingMode: 'text',
@@ -76,7 +76,7 @@ function App() {
     [passwordMode, setPasswordMode],
   );
 
-  const confirmPasswordButton = React.useMemo<ButtonTypes.Properties>(
+  const confirmPasswordButton = useMemo<ButtonTypes.Properties>(
     () => ({
       icon: 'eyeopen',
       stylingMode: 'text',
@@ -87,9 +87,9 @@ function App() {
     [confirmPasswordMode, setConfirmPasswordMode],
   );
 
-  const passwordComparison = React.useCallback<any>(() => password, [password]);
+  const passwordComparison = useCallback<any>(() => password, [password]);
 
-  const onPasswordChanged = React.useCallback(
+  const onPasswordChanged = useCallback(
     (e: TextBoxTypes.ValueChangedEvent) => {
       setPassword(e.value);
       if (confirmPassword) {
@@ -99,7 +99,7 @@ function App() {
     [confirmPassword, setPassword],
   );
 
-  const onConfirmPasswordChanged = React.useCallback((e: TextBoxTypes.ValueChangedEvent) => {
+  const onConfirmPasswordChanged = useCallback((e: TextBoxTypes.ValueChangedEvent) => {
     setConfirmPassword(e.value);
   }, []);
 

--- a/JSDemos/Demos/Validation/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/Validation/Overview/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import CheckBox from 'devextreme-react/check-box';
 import { TextBox, Button as TextBoxButton } from 'devextreme-react/text-box';
@@ -54,12 +54,12 @@ const onFormSubmit = (e) => {
 function App() {
   const currentDate = new Date();
   const maxDate = new Date(currentDate.setFullYear(currentDate.getFullYear() - 21));
-  const [password, setPassword] = React.useState('');
-  const [confirmPassword, setConfirmPassword] = React.useState('');
-  const [passwordMode, setPasswordMode] = React.useState('password');
-  const [confirmPasswordMode, setConfirmPasswordMode] = React.useState('password');
-  const validatorRef = React.useRef(null);
-  const passwordButton = React.useMemo(
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordMode, setPasswordMode] = useState('password');
+  const [confirmPasswordMode, setConfirmPasswordMode] = useState('password');
+  const validatorRef = useRef(null);
+  const passwordButton = useMemo(
     () => ({
       icon: 'eyeopen',
       stylingMode: 'text',
@@ -69,7 +69,7 @@ function App() {
     }),
     [passwordMode, setPasswordMode],
   );
-  const confirmPasswordButton = React.useMemo(
+  const confirmPasswordButton = useMemo(
     () => ({
       icon: 'eyeopen',
       stylingMode: 'text',
@@ -79,8 +79,8 @@ function App() {
     }),
     [confirmPasswordMode, setConfirmPasswordMode],
   );
-  const passwordComparison = React.useCallback(() => password, [password]);
-  const onPasswordChanged = React.useCallback(
+  const passwordComparison = useCallback(() => password, [password]);
+  const onPasswordChanged = useCallback(
     (e) => {
       setPassword(e.value);
       if (confirmPassword) {
@@ -89,7 +89,7 @@ function App() {
     },
     [confirmPassword, setPassword],
   );
-  const onConfirmPasswordChanged = React.useCallback((e) => {
+  const onConfirmPasswordChanged = useCallback((e) => {
     setConfirmPassword(e.value);
   }, []);
   return (

--- a/JSDemos/Demos/Validation/Overview/ReactJs/App.js
+++ b/JSDemos/Demos/Validation/Overview/ReactJs/App.js
@@ -1,4 +1,6 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback, useMemo, useRef, useState,
+} from 'react';
 import SelectBox from 'devextreme-react/select-box';
 import CheckBox from 'devextreme-react/check-box';
 import { TextBox, Button as TextBoxButton } from 'devextreme-react/text-box';

--- a/JSDemos/Demos/VectorMap/DynamicViewport/React/App.tsx
+++ b/JSDemos/Demos/VectorMap/DynamicViewport/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import VectorMap, { Layer, ControlBar, VectorMapTypes } from 'devextreme-react/vector-map';
 import TextBox from 'devextreme-react/text-box';
 import SelectBox from 'devextreme-react/select-box';
@@ -11,32 +11,32 @@ import {
 const bounds = [-180, 85, 180, -60];
 
 const App = () => {
-  const [coordinates, setCoordinates] = React.useState(viewportCoordinates[0].coordinates);
-  const [zoomFactor, setZoomFactor] = React.useState('1.00');
-  const [center, setCenter] = React.useState('0.000, 46.036');
-  const [panVisible, setPanVisible] = React.useState(true);
-  const [zoomVisible, setZoomVisible] = React.useState(true);
-  const mapRef = React.useRef(null);
+  const [coordinates, setCoordinates] = useState(viewportCoordinates[0].coordinates);
+  const [zoomFactor, setZoomFactor] = useState('1.00');
+  const [center, setCenter] = useState('0.000, 46.036');
+  const [panVisible, setPanVisible] = useState(true);
+  const [zoomVisible, setZoomVisible] = useState(true);
+  const mapRef = useRef(null);
 
-  const continentChanged = React.useCallback(({ value }) => {
+  const continentChanged = useCallback(({ value }) => {
     setCoordinates(value);
     mapRef.current.instance.viewport(value);
   }, [setCoordinates]);
 
-  const zoomFactorChanged = React.useCallback((e: VectorMapTypes.ZoomFactorChangedEvent) => {
+  const zoomFactorChanged = useCallback((e: VectorMapTypes.ZoomFactorChangedEvent) => {
     setZoomFactor(e.zoomFactor.toFixed(2));
   }, [setZoomFactor]);
 
-  const centerChanged = React.useCallback((e: VectorMapTypes.CenterChangedEvent) => {
+  const centerChanged = useCallback((e: VectorMapTypes.CenterChangedEvent) => {
     const value = `${e.center[0].toFixed(3)}, ${e.center[1].toFixed(3)}`;
     setCenter(value);
   }, [setCenter]);
 
-  const panVisibleChange = React.useCallback((value) => {
+  const panVisibleChange = useCallback((value) => {
     setPanVisible(value);
   }, [setPanVisible]);
 
-  const zoomVisibleChange = React.useCallback((value) => {
+  const zoomVisibleChange = useCallback((value) => {
     setZoomVisible(value);
   }, [setZoomVisible]);
 

--- a/JSDemos/Demos/VectorMap/DynamicViewport/ReactJs/App.js
+++ b/JSDemos/Demos/VectorMap/DynamicViewport/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import VectorMap, { Layer, ControlBar } from 'devextreme-react/vector-map';
 import TextBox from 'devextreme-react/text-box';
 import SelectBox from 'devextreme-react/select-box';
@@ -10,39 +10,39 @@ import {
 
 const bounds = [-180, 85, 180, -60];
 const App = () => {
-  const [coordinates, setCoordinates] = React.useState(viewportCoordinates[0].coordinates);
-  const [zoomFactor, setZoomFactor] = React.useState('1.00');
-  const [center, setCenter] = React.useState('0.000, 46.036');
-  const [panVisible, setPanVisible] = React.useState(true);
-  const [zoomVisible, setZoomVisible] = React.useState(true);
-  const mapRef = React.useRef(null);
-  const continentChanged = React.useCallback(
+  const [coordinates, setCoordinates] = useState(viewportCoordinates[0].coordinates);
+  const [zoomFactor, setZoomFactor] = useState('1.00');
+  const [center, setCenter] = useState('0.000, 46.036');
+  const [panVisible, setPanVisible] = useState(true);
+  const [zoomVisible, setZoomVisible] = useState(true);
+  const mapRef = useRef(null);
+  const continentChanged = useCallback(
     ({ value }) => {
       setCoordinates(value);
       mapRef.current.instance.viewport(value);
     },
     [setCoordinates],
   );
-  const zoomFactorChanged = React.useCallback(
+  const zoomFactorChanged = useCallback(
     (e) => {
       setZoomFactor(e.zoomFactor.toFixed(2));
     },
     [setZoomFactor],
   );
-  const centerChanged = React.useCallback(
+  const centerChanged = useCallback(
     (e) => {
       const value = `${e.center[0].toFixed(3)}, ${e.center[1].toFixed(3)}`;
       setCenter(value);
     },
     [setCenter],
   );
-  const panVisibleChange = React.useCallback(
+  const panVisibleChange = useCallback(
     (value) => {
       setPanVisible(value);
     },
     [setPanVisible],
   );
-  const zoomVisibleChange = React.useCallback(
+  const zoomVisibleChange = useCallback(
     (value) => {
       setZoomVisible(value);
     },

--- a/JSDemos/Demos/VectorMap/ZoomingAndCentering/React/App.tsx
+++ b/JSDemos/Demos/VectorMap/ZoomingAndCentering/React/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import VectorMap, {
   ITooltipProps,
   Layer,
@@ -26,9 +26,9 @@ const markerClick = ({ target, component }) => {
 };
 
 const App = () => {
-  const vectorMapRef = React.useRef(null);
+  const vectorMapRef = useRef(null);
 
-  const reset = React.useCallback(() => {
+  const reset = useCallback(() => {
     vectorMapRef.current.instance.center(null);
     vectorMapRef.current.instance.zoomFactor(null);
   }, [vectorMapRef]);

--- a/JSDemos/Demos/VectorMap/ZoomingAndCentering/ReactJs/App.js
+++ b/JSDemos/Demos/VectorMap/ZoomingAndCentering/ReactJs/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import VectorMap, { Layer, Tooltip } from 'devextreme-react/vector-map';
 import Button from 'devextreme-react/button';
 import * as mapsData from 'devextreme-dist/js/vectormap-data/world.js';
@@ -17,8 +17,8 @@ const markerClick = ({ target, component }) => {
   }
 };
 const App = () => {
-  const vectorMapRef = React.useRef(null);
-  const reset = React.useCallback(() => {
+  const vectorMapRef = useRef(null);
+  const reset = useCallback(() => {
     vectorMapRef.current.instance.center(null);
     vectorMapRef.current.instance.zoomFactor(null);
   }, [vectorMapRef]);

--- a/utils/bundle/index.js
+++ b/utils/bundle/index.js
@@ -128,6 +128,7 @@ const prepareConfigs = (framework) => {
       name: 'react/*',
       metaValue: {
         build: true,
+        esModule: true,
       },
       pathValue: 'node_modules/react/*',
     }, {

--- a/utils/bundle/index.js
+++ b/utils/bundle/index.js
@@ -3,43 +3,6 @@ const path = require('path');
 const fs = require('fs-extra');
 const Builder = require('systemjs-builder');
 
-// https://stackoverflow.com/questions/42412965/how-to-load-named-exports-with-systemjs/47108328
-const prepareModulesToNamedImport = () => {
-  const modules = [
-    'time_zone_utils.js',
-    'localization.js',
-    'viz/export.js',
-    'viz/core/export.js',
-    'viz/vector_map/projection.js',
-    'viz/palette.js',
-    'excel_exporter.js',
-    'pdf_exporter.js',
-    'time_zone_utils.js',
-    'devextreme/ui/dialog.js',
-    'common/charts.js',
-  ];
-
-  const paths = [
-    '../npm-scripts/npm-devextreme/cjs',
-    'node_modules/devextreme/cjs',
-  ];
-
-  const esModuleExport = 'exports.__esModule = true;';
-
-  paths.forEach((p) => {
-    modules.forEach((name) => {
-      const filePath = `${p}/${name}`;
-
-      if (fs.existsSync(filePath)) {
-        const fileText = fs.readFileSync(filePath, 'utf8');
-        if (fileText.search(esModuleExport) === -1) {
-          fs.appendFileSync(filePath, `\n ${esModuleExport}`);
-        }
-      }
-    });
-  });
-};
-
 const getDefaultBuilderConfig = (framework, additionPaths) => ({
   defaultExtension: false,
   defaultJSExtensions: 'js',
@@ -57,6 +20,7 @@ const getDefaultBuilderConfig = (framework, additionPaths) => ({
     },
     'devextreme/*': {
       build: true,
+      esModule: true,
     },
     'devexpress-gantt': {
       build: true,
@@ -172,8 +136,6 @@ const prepareConfigs = (framework) => {
 
 const build = async (framework) => {
   const builder = new Builder();
-  prepareModulesToNamedImport();
-
   const {
     builderConfig, packages, bundlePath, bundleOpts,
   } = prepareConfigs(framework);

--- a/utils/bundle/index.js
+++ b/utils/bundle/index.js
@@ -87,7 +87,6 @@ const prepareConfigs = (framework) => {
   let additionPaths = {};
 
   let main = `devextreme-${framework}/index.js`;
-  let minify = true;
 
   if (framework === 'angular') {
     additionPackage = [{
@@ -106,7 +105,6 @@ const prepareConfigs = (framework) => {
     // eslint-disable-next-line spellcheck/spell-checker
     if (currentPackage.fesm2015) {
       main = `devextreme-${framework}`;
-      minify = false;
       const bundlesRoot = 'node_modules/devextreme-angular/bundles';
       const componentNames = fs.readdirSync(bundlesRoot)
         .filter((fileName) => fileName.indexOf('umd.js.map') !== -1)
@@ -167,8 +165,6 @@ const prepareConfigs = (framework) => {
     packages: packages.join(' + '),
     bundlePath: `bundles/devextreme.${framework}.systemjs.js`,
     bundleOpts: {
-      minify,
-      uglify: { mangle: true },
     },
   };
 };

--- a/utils/bundle/index.js
+++ b/utils/bundle/index.js
@@ -87,6 +87,7 @@ const prepareConfigs = (framework) => {
   let additionPaths = {};
 
   let main = `devextreme-${framework}/index.js`;
+  let minify = true;
 
   if (framework === 'angular') {
     additionPackage = [{
@@ -105,6 +106,7 @@ const prepareConfigs = (framework) => {
     // eslint-disable-next-line spellcheck/spell-checker
     if (currentPackage.fesm2015) {
       main = `devextreme-${framework}`;
+      minify = false;
       const bundlesRoot = 'node_modules/devextreme-angular/bundles';
       const componentNames = fs.readdirSync(bundlesRoot)
         .filter((fileName) => fileName.indexOf('umd.js.map') !== -1)
@@ -166,6 +168,8 @@ const prepareConfigs = (framework) => {
     packages: packages.join(' + '),
     bundlePath: `bundles/devextreme.${framework}.systemjs.js`,
     bundleOpts: {
+      minify,
+      uglify: { mangle: true },
     },
   };
 };

--- a/utils/bundle/index.js
+++ b/utils/bundle/index.js
@@ -3,6 +3,43 @@ const path = require('path');
 const fs = require('fs-extra');
 const Builder = require('systemjs-builder');
 
+// https://stackoverflow.com/questions/42412965/how-to-load-named-exports-with-systemjs/47108328
+const prepareModulesToNamedImport = () => {
+  const modules = [
+    'time_zone_utils.js',
+    'localization.js',
+    'viz/export.js',
+    'viz/core/export.js',
+    'viz/vector_map/projection.js',
+    'viz/palette.js',
+    'excel_exporter.js',
+    'pdf_exporter.js',
+    'time_zone_utils.js',
+    'devextreme/ui/dialog.js',
+    'common/charts.js',
+  ];
+
+  const paths = [
+    '../npm-scripts/npm-devextreme/cjs',
+    'node_modules/devextreme/cjs',
+  ];
+
+  const esModuleExport = 'exports.__esModule = true;';
+
+  paths.forEach((p) => {
+    modules.forEach((name) => {
+      const filePath = `${p}/${name}`;
+
+      if (fs.existsSync(filePath)) {
+        const fileText = fs.readFileSync(filePath, 'utf8');
+        if (fileText.search(esModuleExport) === -1) {
+          fs.appendFileSync(filePath, `\n ${esModuleExport}`);
+        }
+      }
+    });
+  });
+};
+
 const getDefaultBuilderConfig = (framework, additionPaths) => ({
   defaultExtension: false,
   defaultJSExtensions: 'js',
@@ -20,7 +57,6 @@ const getDefaultBuilderConfig = (framework, additionPaths) => ({
     },
     'devextreme/*': {
       build: true,
-      esModule: true,
     },
     'devexpress-gantt': {
       build: true,
@@ -136,6 +172,8 @@ const prepareConfigs = (framework) => {
 
 const build = async (framework) => {
   const builder = new Builder();
+  prepareModulesToNamedImport();
+
   const {
     builderConfig, packages, bundlePath, bundleOpts,
   } = prepareConfigs(framework);


### PR DESCRIPTION
The main idea is to add the `metaValue: { esModule: true, ... }` hint for the react module for the single-file devextreme.react.systemjs.js bundle (similar to `'react': { 'esModule': true, }` for an individual module):

- according to:
#2656

- actually, already added at:
https://github.com/DevExpress/devextreme-demos/blob/23_2/JSDemos/configs/React/config.js#L12

Affected 459 files:
- 1 /utils/bundle/index.js file;
- 229 * 2 (React / ReactJs) = 458 (*.tsx) files:
  - found the following unique hooks:

`React.useCallback`
`React.useEffect`
`React.useMemo`
`React.useReducer`
`React.useRef`
`React.useState`
  
  - replaced in code "React.use*" -> ""use*";
  - moved to named import, sorted.
