### PR TITLE
dx-diagram.min.css before dx.light.css

### DIFF
--- a/JSDemos/Demos/Diagram/Adaptability/Angular/index.html
+++ b/JSDemos/Demos/Diagram/Adaptability/Angular/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/Adaptability/Angular/index.html
+++ b/JSDemos/Demos/Diagram/Adaptability/Angular/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/Adaptability/React/index.html
+++ b/JSDemos/Demos/Diagram/Adaptability/React/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/Adaptability/React/index.html
+++ b/JSDemos/Demos/Diagram/Adaptability/React/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/Adaptability/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/Adaptability/ReactJs/index.html
@@ -22,7 +22,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/Adaptability/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/Adaptability/ReactJs/index.html
@@ -17,12 +17,12 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
+      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/Adaptability/Vue/index.html
+++ b/JSDemos/Demos/Diagram/Adaptability/Vue/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/Adaptability/Vue/index.html
+++ b/JSDemos/Demos/Diagram/Adaptability/Vue/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/Adaptability/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/Adaptability/jQuery/index.html
@@ -8,7 +8,7 @@
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="index.js"></script>

--- a/JSDemos/Demos/Diagram/Adaptability/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/Adaptability/jQuery/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="index.js"></script>

--- a/JSDemos/Demos/Diagram/AdvancedDataBinding/Angular/index.html
+++ b/JSDemos/Demos/Diagram/AdvancedDataBinding/Angular/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/AdvancedDataBinding/Angular/index.html
+++ b/JSDemos/Demos/Diagram/AdvancedDataBinding/Angular/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/AdvancedDataBinding/React/index.html
+++ b/JSDemos/Demos/Diagram/AdvancedDataBinding/React/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/AdvancedDataBinding/React/index.html
+++ b/JSDemos/Demos/Diagram/AdvancedDataBinding/React/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/AdvancedDataBinding/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/AdvancedDataBinding/ReactJs/index.html
@@ -22,7 +22,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/AdvancedDataBinding/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/AdvancedDataBinding/ReactJs/index.html
@@ -17,12 +17,12 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
+      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/AdvancedDataBinding/Vue/index.html
+++ b/JSDemos/Demos/Diagram/AdvancedDataBinding/Vue/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/AdvancedDataBinding/Vue/index.html
+++ b/JSDemos/Demos/Diagram/AdvancedDataBinding/Vue/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/AdvancedDataBinding/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/AdvancedDataBinding/jQuery/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="data.js"></script>

--- a/JSDemos/Demos/Diagram/AdvancedDataBinding/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/AdvancedDataBinding/jQuery/index.html
@@ -8,7 +8,7 @@
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="data.js"></script>

--- a/JSDemos/Demos/Diagram/Containers/Angular/index.html
+++ b/JSDemos/Demos/Diagram/Containers/Angular/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/Containers/Angular/index.html
+++ b/JSDemos/Demos/Diagram/Containers/Angular/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/Containers/React/index.html
+++ b/JSDemos/Demos/Diagram/Containers/React/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/Containers/React/index.html
+++ b/JSDemos/Demos/Diagram/Containers/React/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/Containers/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/Containers/ReactJs/index.html
@@ -22,7 +22,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/Containers/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/Containers/ReactJs/index.html
@@ -17,12 +17,12 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
+      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/Containers/Vue/index.html
+++ b/JSDemos/Demos/Diagram/Containers/Vue/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/Containers/Vue/index.html
+++ b/JSDemos/Demos/Diagram/Containers/Vue/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/Containers/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/Containers/jQuery/index.html
@@ -8,7 +8,7 @@
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="index.js"></script>

--- a/JSDemos/Demos/Diagram/Containers/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/Containers/jQuery/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="index.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithIcons/Angular/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithIcons/Angular/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithIcons/Angular/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithIcons/Angular/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithIcons/React/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithIcons/React/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithIcons/React/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithIcons/React/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithIcons/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithIcons/ReactJs/index.html
@@ -22,7 +22,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/CustomShapesWithIcons/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithIcons/ReactJs/index.html
@@ -17,12 +17,12 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
+      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/CustomShapesWithIcons/Vue/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithIcons/Vue/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithIcons/Vue/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithIcons/Vue/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithIcons/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithIcons/jQuery/index.html
@@ -8,7 +8,7 @@
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="index.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithIcons/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithIcons/jQuery/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="index.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplates/Angular/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplates/Angular/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplates/Angular/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplates/Angular/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplates/React/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplates/React/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplates/React/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplates/React/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplates/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplates/ReactJs/index.html
@@ -22,7 +22,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplates/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplates/ReactJs/index.html
@@ -17,12 +17,12 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
+      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplates/Vue/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplates/Vue/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplates/Vue/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplates/Vue/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplates/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplates/jQuery/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="data.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplates/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplates/jQuery/index.html
@@ -8,7 +8,7 @@
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="data.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/Angular/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/Angular/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/Angular/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/Angular/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/React/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/React/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/React/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/React/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/ReactJs/index.html
@@ -22,7 +22,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/ReactJs/index.html
@@ -17,12 +17,12 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
+      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/Vue/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/Vue/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/Vue/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/Vue/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/jQuery/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="data.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTemplatesWithEditing/jQuery/index.html
@@ -8,7 +8,7 @@
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="data.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTexts/Angular/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTexts/Angular/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTexts/Angular/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTexts/Angular/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTexts/React/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTexts/React/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTexts/React/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTexts/React/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTexts/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTexts/ReactJs/index.html
@@ -22,7 +22,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/CustomShapesWithTexts/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTexts/ReactJs/index.html
@@ -17,12 +17,12 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
+      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/CustomShapesWithTexts/Vue/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTexts/Vue/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTexts/Vue/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTexts/Vue/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTexts/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTexts/jQuery/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="data.js"></script>

--- a/JSDemos/Demos/Diagram/CustomShapesWithTexts/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/CustomShapesWithTexts/jQuery/index.html
@@ -8,7 +8,7 @@
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="data.js"></script>

--- a/JSDemos/Demos/Diagram/ImagesInShapes/Angular/index.html
+++ b/JSDemos/Demos/Diagram/ImagesInShapes/Angular/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/ImagesInShapes/Angular/index.html
+++ b/JSDemos/Demos/Diagram/ImagesInShapes/Angular/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/ImagesInShapes/React/index.html
+++ b/JSDemos/Demos/Diagram/ImagesInShapes/React/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/ImagesInShapes/React/index.html
+++ b/JSDemos/Demos/Diagram/ImagesInShapes/React/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/ImagesInShapes/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/ImagesInShapes/ReactJs/index.html
@@ -22,7 +22,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/ImagesInShapes/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/ImagesInShapes/ReactJs/index.html
@@ -17,12 +17,12 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
+      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/ImagesInShapes/Vue/index.html
+++ b/JSDemos/Demos/Diagram/ImagesInShapes/Vue/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/ImagesInShapes/Vue/index.html
+++ b/JSDemos/Demos/Diagram/ImagesInShapes/Vue/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/ImagesInShapes/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/ImagesInShapes/jQuery/index.html
@@ -8,7 +8,7 @@
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="index.js"></script>

--- a/JSDemos/Demos/Diagram/ImagesInShapes/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/ImagesInShapes/jQuery/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="index.js"></script>

--- a/JSDemos/Demos/Diagram/ItemSelection/Angular/index.html
+++ b/JSDemos/Demos/Diagram/ItemSelection/Angular/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/ItemSelection/Angular/index.html
+++ b/JSDemos/Demos/Diagram/ItemSelection/Angular/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/ItemSelection/React/index.html
+++ b/JSDemos/Demos/Diagram/ItemSelection/React/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/ItemSelection/React/index.html
+++ b/JSDemos/Demos/Diagram/ItemSelection/React/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/ItemSelection/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/ItemSelection/ReactJs/index.html
@@ -22,7 +22,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/ItemSelection/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/ItemSelection/ReactJs/index.html
@@ -17,12 +17,12 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
+      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/ItemSelection/Vue/index.html
+++ b/JSDemos/Demos/Diagram/ItemSelection/Vue/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/ItemSelection/Vue/index.html
+++ b/JSDemos/Demos/Diagram/ItemSelection/Vue/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/ItemSelection/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/ItemSelection/jQuery/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="data.js"></script>

--- a/JSDemos/Demos/Diagram/ItemSelection/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/ItemSelection/jQuery/index.html
@@ -8,7 +8,7 @@
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="data.js"></script>

--- a/JSDemos/Demos/Diagram/NodesAndEdgesArrays/Angular/index.html
+++ b/JSDemos/Demos/Diagram/NodesAndEdgesArrays/Angular/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/NodesAndEdgesArrays/Angular/index.html
+++ b/JSDemos/Demos/Diagram/NodesAndEdgesArrays/Angular/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/NodesAndEdgesArrays/React/index.html
+++ b/JSDemos/Demos/Diagram/NodesAndEdgesArrays/React/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/NodesAndEdgesArrays/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/NodesAndEdgesArrays/ReactJs/index.html
@@ -17,12 +17,12 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
+      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/NodesAndEdgesArrays/Vue/index.html
+++ b/JSDemos/Demos/Diagram/NodesAndEdgesArrays/Vue/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/NodesAndEdgesArrays/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/NodesAndEdgesArrays/jQuery/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="data.js"></script>

--- a/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/Angular/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/Angular/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/Angular/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/Angular/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/React/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/React/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/ReactJs/index.html
@@ -17,12 +17,12 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
+      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/Vue/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/Vue/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayHierarchicalStructure/jQuery/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="data.js"></script>

--- a/JSDemos/Demos/Diagram/NodesArrayPlainStructure/Angular/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayPlainStructure/Angular/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/NodesArrayPlainStructure/Angular/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayPlainStructure/Angular/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/NodesArrayPlainStructure/React/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayPlainStructure/React/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/NodesArrayPlainStructure/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayPlainStructure/ReactJs/index.html
@@ -17,12 +17,12 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
+      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/NodesArrayPlainStructure/Vue/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayPlainStructure/Vue/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/NodesArrayPlainStructure/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/NodesArrayPlainStructure/jQuery/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="data.js"></script>

--- a/JSDemos/Demos/Diagram/OperationRestrictions/Angular/index.html
+++ b/JSDemos/Demos/Diagram/OperationRestrictions/Angular/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/OperationRestrictions/Angular/index.html
+++ b/JSDemos/Demos/Diagram/OperationRestrictions/Angular/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/OperationRestrictions/React/index.html
+++ b/JSDemos/Demos/Diagram/OperationRestrictions/React/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/OperationRestrictions/React/index.html
+++ b/JSDemos/Demos/Diagram/OperationRestrictions/React/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/OperationRestrictions/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/OperationRestrictions/ReactJs/index.html
@@ -22,7 +22,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/OperationRestrictions/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/OperationRestrictions/ReactJs/index.html
@@ -17,12 +17,12 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
+      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/OperationRestrictions/Vue/index.html
+++ b/JSDemos/Demos/Diagram/OperationRestrictions/Vue/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/OperationRestrictions/Vue/index.html
+++ b/JSDemos/Demos/Diagram/OperationRestrictions/Vue/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/OperationRestrictions/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/OperationRestrictions/jQuery/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="data.js"></script>

--- a/JSDemos/Demos/Diagram/OperationRestrictions/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/OperationRestrictions/jQuery/index.html
@@ -8,7 +8,7 @@
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="data.js"></script>

--- a/JSDemos/Demos/Diagram/Overview/Angular/index.html
+++ b/JSDemos/Demos/Diagram/Overview/Angular/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/Overview/Angular/index.html
+++ b/JSDemos/Demos/Diagram/Overview/Angular/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/Overview/React/index.html
+++ b/JSDemos/Demos/Diagram/Overview/React/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/Overview/React/index.html
+++ b/JSDemos/Demos/Diagram/Overview/React/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/Overview/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/Overview/ReactJs/index.html
@@ -22,7 +22,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/Overview/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/Overview/ReactJs/index.html
@@ -17,12 +17,12 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
+      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/Overview/Vue/index.html
+++ b/JSDemos/Demos/Diagram/Overview/Vue/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/Overview/Vue/index.html
+++ b/JSDemos/Demos/Diagram/Overview/Vue/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/Overview/jQuery/index.html
@@ -8,7 +8,7 @@
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="index.js"></script>

--- a/JSDemos/Demos/Diagram/Overview/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/Overview/jQuery/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="index.js"></script>

--- a/JSDemos/Demos/Diagram/ReadOnly/Angular/index.html
+++ b/JSDemos/Demos/Diagram/ReadOnly/Angular/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/ReadOnly/Angular/index.html
+++ b/JSDemos/Demos/Diagram/ReadOnly/Angular/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/ReadOnly/React/index.html
+++ b/JSDemos/Demos/Diagram/ReadOnly/React/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/ReadOnly/React/index.html
+++ b/JSDemos/Demos/Diagram/ReadOnly/React/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/ReadOnly/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/ReadOnly/ReactJs/index.html
@@ -22,7 +22,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/ReadOnly/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/ReadOnly/ReactJs/index.html
@@ -17,12 +17,12 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
+      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/ReadOnly/Vue/index.html
+++ b/JSDemos/Demos/Diagram/ReadOnly/Vue/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/ReadOnly/Vue/index.html
+++ b/JSDemos/Demos/Diagram/ReadOnly/Vue/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/ReadOnly/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/ReadOnly/jQuery/index.html
@@ -8,7 +8,7 @@
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="index.js"></script>

--- a/JSDemos/Demos/Diagram/ReadOnly/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/ReadOnly/jQuery/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="index.js"></script>

--- a/JSDemos/Demos/Diagram/SimpleView/Angular/index.html
+++ b/JSDemos/Demos/Diagram/SimpleView/Angular/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/SimpleView/Angular/index.html
+++ b/JSDemos/Demos/Diagram/SimpleView/Angular/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/SimpleView/React/index.html
+++ b/JSDemos/Demos/Diagram/SimpleView/React/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/SimpleView/React/index.html
+++ b/JSDemos/Demos/Diagram/SimpleView/React/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/SimpleView/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/SimpleView/ReactJs/index.html
@@ -22,7 +22,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/SimpleView/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/SimpleView/ReactJs/index.html
@@ -17,12 +17,12 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
+      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/SimpleView/Vue/index.html
+++ b/JSDemos/Demos/Diagram/SimpleView/Vue/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/SimpleView/Vue/index.html
+++ b/JSDemos/Demos/Diagram/SimpleView/Vue/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/SimpleView/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/SimpleView/jQuery/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="data.js"></script>

--- a/JSDemos/Demos/Diagram/SimpleView/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/SimpleView/jQuery/index.html
@@ -8,7 +8,7 @@
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="data.js"></script>

--- a/JSDemos/Demos/Diagram/UICustomization/Angular/index.html
+++ b/JSDemos/Demos/Diagram/UICustomization/Angular/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/UICustomization/Angular/index.html
+++ b/JSDemos/Demos/Diagram/UICustomization/Angular/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/UICustomization/React/index.html
+++ b/JSDemos/Demos/Diagram/UICustomization/React/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/UICustomization/React/index.html
+++ b/JSDemos/Demos/Diagram/UICustomization/React/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/UICustomization/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/UICustomization/ReactJs/index.html
@@ -22,7 +22,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/UICustomization/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/UICustomization/ReactJs/index.html
@@ -17,12 +17,12 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
+      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/UICustomization/Vue/index.html
+++ b/JSDemos/Demos/Diagram/UICustomization/Vue/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/UICustomization/Vue/index.html
+++ b/JSDemos/Demos/Diagram/UICustomization/Vue/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/UICustomization/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/UICustomization/jQuery/index.html
@@ -8,7 +8,7 @@
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="index.js"></script>

--- a/JSDemos/Demos/Diagram/UICustomization/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/UICustomization/jQuery/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="index.js"></script>

--- a/JSDemos/Demos/Diagram/WebAPIService/Angular/index.html
+++ b/JSDemos/Demos/Diagram/WebAPIService/Angular/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/WebAPIService/Angular/index.html
+++ b/JSDemos/Demos/Diagram/WebAPIService/Angular/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
 
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>
     <script src="../../../../../node_modules/zone.js/dist/zone.js"></script>

--- a/JSDemos/Demos/Diagram/WebAPIService/React/index.html
+++ b/JSDemos/Demos/Diagram/WebAPIService/React/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/WebAPIService/React/index.html
+++ b/JSDemos/Demos/Diagram/WebAPIService/React/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <script src="../../../../../node_modules/core-js/client/shim.min.js"></script>

--- a/JSDemos/Demos/Diagram/WebAPIService/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/WebAPIService/ReactJs/index.html
@@ -22,7 +22,7 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/WebAPIService/ReactJs/index.html
+++ b/JSDemos/Demos/Diagram/WebAPIService/ReactJs/index.html
@@ -17,12 +17,12 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
+      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css"
+      href="../../../../../node_modules/devextreme-dist/css/dx.light.css"
     />
     <link
       rel="stylesheet"

--- a/JSDemos/Demos/Diagram/WebAPIService/Vue/index.html
+++ b/JSDemos/Demos/Diagram/WebAPIService/Vue/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/WebAPIService/Vue/index.html
+++ b/JSDemos/Demos/Diagram/WebAPIService/Vue/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 
     <script src="../../../../../node_modules/typescript/lib/typescript.js"></script>

--- a/JSDemos/Demos/Diagram/WebAPIService/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/WebAPIService/jQuery/index.html
@@ -8,7 +8,7 @@
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
     <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />

--- a/JSDemos/Demos/Diagram/WebAPIService/jQuery/index.html
+++ b/JSDemos/Demos/Diagram/WebAPIService/jQuery/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <script src="../../../../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
-    <link rel="stylesheet" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../../node_modules/devexpress-diagram/dist/dx-diagram.min.css" />
+    <link rel="stylesheet" href="../../../../../node_modules/devextreme-dist/css/dx.light.css" />
     <script src="../../../../../node_modules/devextreme-dist/js/dx.all.js"></script>
     <script src="../../../../../node_modules/devextreme-aspnet-data/js/dx.aspnet.data.js"></script>
     <link rel="stylesheet" type="text/css" href="styles.css" />


### PR DESCRIPTION
### Cherry-picks
 - #3129

Replace `dx-diagram.css` with `dx-diagram.min.css`:
  - Before:
    - dx-diagram.css - 78 results in 78 files
    - dx-diagram.min.css - 12 results in 12 files
  - After:
    - dx-diagram.min.css - 90 results in 90 files

Swap `devextreme-dist/css/dx.light.css` with `devexpress-diagram/dist/dx-diagram.min.css` to ensure `dx-diagram.min.css` before `dx.light.css`, according to:

https://js.devexpress.com/jQuery/Documentation/Guide/UI_Components/Diagram/Getting_Started_with_Diagram/
