### PR TITLE
Use non-existing component type from integration package

### DIFF
--- a/JSDemos/Demos/DataGrid/BatchUpdateRequest/Angular/app/app.component.ts
+++ b/JSDemos/Demos/DataGrid/BatchUpdateRequest/Angular/app/app.component.ts
@@ -4,7 +4,9 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { lastValueFrom } from 'rxjs';
 import * as AspNetData from 'devextreme-aspnet-data-nojquery';
-import { DxDataGridComponent, DxDataGridModule, DxDataGridTypes } from 'devextreme-angular/ui/data-grid';
+import {
+  DxDataGridComponent, DxDataGridModule, DxDataGridTypes, dxDataGrid,
+} from 'devextreme-angular/ui/data-grid';
 
 if (!/localhost/.test(document.location.host)) {
   enableProdMode();
@@ -41,7 +43,7 @@ export class AppComponent {
   async processBatchRequest(
     url: string,
     changes: Array<DxDataGridTypes.DataChange>,
-    component: DxDataGridComponent['instance'],
+    component: dxDataGrid,
   ): Promise<void> {
     await lastValueFrom(
       this.http.post(url, JSON.stringify(changes), {

--- a/JSDemos/Demos/DataGrid/BatchUpdateRequest/React/App.tsx
+++ b/JSDemos/Demos/DataGrid/BatchUpdateRequest/React/App.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import DataGrid, { Column, DataGridTypes, Editing } from 'devextreme-react/data-grid';
+import DataGrid, {
+  Column, DataGridTypes, Editing, dxDataGrid,
+} from 'devextreme-react/data-grid';
 import { createStore } from 'devextreme-aspnet-data-nojquery';
 import 'whatwg-fetch';
 
@@ -30,7 +32,7 @@ async function sendBatchRequest(url: string, changes: DataGridTypes.DataChange[]
   }
 }
 
-async function processBatchRequest(url: string, changes: DataGridTypes.DataChange[], component: DataGrid['instance']) {
+async function processBatchRequest(url: string, changes: DataGridTypes.DataChange[], component: dxDataGrid) {
   await sendBatchRequest(url, changes);
   await component.refresh(true);
   component.cancelEditData();

--- a/JSDemos/Demos/DataGrid/BatchUpdateRequest/Vue/App.vue
+++ b/JSDemos/Demos/DataGrid/BatchUpdateRequest/Vue/App.vue
@@ -30,7 +30,7 @@
 </template>
 <script setup lang="ts">
 import {
-  DxDataGrid, DxColumn, DxEditing, DxDataGridTypes,
+  DxDataGrid, DxColumn, DxEditing, DxDataGridTypes, dxDataGrid,
 } from 'devextreme-vue/data-grid';
 import { createStore } from 'devextreme-aspnet-data-nojquery';
 import 'whatwg-fetch';
@@ -54,7 +54,7 @@ const onSaving = (e: DxDataGridTypes.SavingEvent) => {
 };
 
 async function processBatchRequest(
-  url: string, changes: DxDataGridTypes.DataChange[], component: DxDataGrid['instance'],
+  url: string, changes: DxDataGridTypes.DataChange[], component: dxDataGrid,
 ) {
   await sendBatchRequest(url, changes);
   await component.refresh(true);


### PR DESCRIPTION
Use non-existing component type from integration package (workaround-ed via `default export['instance']`).
Should fail on build?

Migrated to mono-repo:
https://github.com/DevExpress/DevExtreme/pull/26731