### PR TITLE
MVC Demos: Fix path to demo source files

### DIFF
--- a/MVCDemos/DemoShell/DemoMenuMeta.cs
+++ b/MVCDemos/DemoShell/DemoMenuMeta.cs
@@ -195,7 +195,7 @@ namespace DevExtreme.MVC.Demos.DemoShell {
 
             if(demo.MvcAdditionalFiles != null) {
                 foreach(var f in demo.MvcAdditionalFiles)
-                    demo.Files.Add(new DemoSourceFile(contentRootPath, "." + Regex.Replace(f, "^/(Content|Scripts)/", "/wwwroot/")));
+                    demo.Files.Add(new DemoSourceFile(contentRootPath, "." + f));
             }
 
             Func<string, int> GetPreSortKey = name => {


### PR DESCRIPTION
Do not replace part of a path to static demo source files in MVC DemoShell. This will fix missing code in code tabs in MVC Demos project. 